### PR TITLE
Support named ( ordered map ) steps

### DIFF
--- a/book.go
+++ b/book.go
@@ -2,6 +2,7 @@ package runn
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -18,6 +19,7 @@ type book struct {
 	Vars        map[string]interface{}   `yaml:"vars,omitempty"`
 	Steps       []map[string]interface{} `yaml:"steps,omitempty"`
 	Debug       bool                     `yaml:"debug,omitempty"`
+	stepKeys    []string
 	path        string
 	httpRunners map[string]*httpRunner
 	dbRunners   map[string]*dbRunner
@@ -35,22 +37,54 @@ func newBook() *book {
 }
 
 func loadBook(in io.Reader) (*book, error) {
+	bk := newBook()
 	buf := new(bytes.Buffer)
 	if _, err := io.Copy(buf, in); err != nil {
 		return nil, err
 	}
-	bk := newBook()
-	if err := yaml.Unmarshal(expand.ExpandenvYAMLBytes(buf.Bytes()), bk); err != nil {
+	if err := yaml.NewDecoder(bytes.NewBuffer(expand.ExpandenvYAMLBytes(buf.Bytes()))).Decode(bk); err == nil {
+		if bk.Runners == nil {
+			bk.Runners = map[string]string{}
+		}
+		if bk.Vars == nil {
+			bk.Vars = map[string]interface{}{}
+		}
+		if bk.Desc == "" {
+			bk.Desc = noDesc
+		}
+		return bk, nil
+	}
+
+	// orderedmap
+	m := struct {
+		Desc    string                 `yaml:"desc,omitempty"`
+		Runners map[string]string      `yaml:"runners,omitempty"`
+		Vars    map[string]interface{} `yaml:"vars,omitempty"`
+		Steps   yaml.MapSlice          `yaml:"steps,omitempty"`
+		Debug   bool                   `yaml:"debug,omitempty"`
+	}{
+		Runners: map[string]string{},
+		Vars:    map[string]interface{}{},
+		Steps:   yaml.MapSlice{},
+	}
+
+	if err := yaml.NewDecoder(bytes.NewBuffer(expand.ExpandenvYAMLBytes(buf.Bytes()))).Decode(&m); err != nil {
 		return nil, err
 	}
-	if bk.Runners == nil {
-		bk.Runners = map[string]string{}
-	}
-	if bk.Vars == nil {
-		bk.Vars = map[string]interface{}{}
-	}
-	if bk.Desc == "" {
-		bk.Desc = noDesc
+	bk.Desc = m.Desc
+	bk.Runners = m.Runners
+	bk.Vars = m.Vars
+	bk.Debug = m.Debug
+	for _, s := range m.Steps {
+		bk.Steps = append(bk.Steps, s.Value.(map[string]interface{}))
+		switch v := s.Key.(type) {
+		case string:
+			bk.stepKeys = append(bk.stepKeys, v)
+		case uint64:
+			bk.stepKeys = append(bk.stepKeys, fmt.Sprintf("%d", v))
+		default:
+			bk.stepKeys = append(bk.stepKeys, fmt.Sprintf("%v", v))
+		}
 	}
 	return bk, nil
 }

--- a/book_test.go
+++ b/book_test.go
@@ -9,18 +9,25 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	path := "testdata/book/book.yml"
-	o, err := New(Book(path))
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		path string
+	}{
+		{"testdata/book/book.yml"},
+		{"testdata/book/map.yml"},
 	}
-	if want := 1; len(o.httpRunners) != want {
-		t.Errorf("got %v\nwant %v", len(o.httpRunners), want)
-	}
-	if want := 1; len(o.dbRunners) != want {
-		t.Errorf("got %v\nwant %v", len(o.dbRunners), want)
-	}
-	if want := 6; len(o.steps) != want {
-		t.Errorf("got %v\nwant %v", len(o.steps), want)
+	for _, tt := range tests {
+		o, err := New(Book(tt.path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := 1; len(o.httpRunners) != want {
+			t.Errorf("got %v\nwant %v", len(o.httpRunners), want)
+		}
+		if want := 1; len(o.dbRunners) != want {
+			t.Errorf("got %v\nwant %v", len(o.dbRunners), want)
+		}
+		if want := 6; len(o.steps) != want {
+			t.Errorf("got %v\nwant %v", len(o.steps), want)
+		}
 	}
 }

--- a/db.go
+++ b/db.go
@@ -135,7 +135,7 @@ func (rnr *dbRunner) Run(ctx context.Context, q *dbQuery) error {
 			return err
 		}
 	}
-	rnr.operator.store.steps = append(rnr.operator.store.steps, out)
+	rnr.operator.record(out)
 	return nil
 }
 

--- a/dump.go
+++ b/dump.go
@@ -25,10 +25,7 @@ func newDumpRunner(o *operator) (*dumpRunner, error) {
 }
 
 func (rnr *dumpRunner) Run(ctx context.Context, cond string) error {
-	store := map[string]interface{}{
-		"steps": rnr.operator.store.steps,
-		"vars":  rnr.operator.store.vars,
-	}
+	store := rnr.operator.store.toMap()
 	v, err := expr.Eval(cond, store)
 	if err != nil {
 		return err
@@ -39,7 +36,7 @@ func (rnr *dumpRunner) Run(ctx context.Context, cond string) error {
 	}
 	out := string(b)
 	_, _ = fmt.Fprintf(rnr.out, "%s\n", out)
-	rnr.operator.store.steps = append(rnr.operator.store.steps, map[string]interface{}{
+	rnr.operator.record(map[string]interface{}{
 		"out": out,
 	})
 	return nil

--- a/dump_test.go
+++ b/dump_test.go
@@ -59,6 +59,32 @@ func TestDumpRunnerRun(t *testing.T) {
 ]
 `,
 		},
+		{
+			store{
+				stepMaps: map[string]interface{}{
+					"key": "value",
+				},
+				vars:    map[string]interface{}{},
+				useMaps: true,
+			},
+			"steps",
+			`{
+  "key": "value"
+}
+`,
+		},
+		{
+			store{
+				stepMaps: map[string]interface{}{
+					"0": "value",
+				},
+				vars:    map[string]interface{}{},
+				useMaps: true,
+			},
+			"steps['0']",
+			`"value"
+`,
+		},
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
@@ -78,7 +104,7 @@ func TestDumpRunnerRun(t *testing.T) {
 		}
 		got := buf.String()
 		if got != tt.want {
-			t.Errorf("got %v\nwant %v", got, tt.want)
+			t.Errorf("got\n%v\nwant\n%v", got, tt.want)
 		}
 	}
 }

--- a/exec.go
+++ b/exec.go
@@ -52,7 +52,7 @@ func (rnr *execRunner) Run(ctx context.Context, c *execCommand) error {
 		_, _ = fmt.Fprintf(os.Stderr, "-----START STDOUT-----\n%s\n-----END STDOUT-----\n", stdout.String())
 		_, _ = fmt.Fprintf(os.Stderr, "-----START STDERR-----\n%s\n-----END STDERR-----\n", stderr.String())
 	}
-	rnr.operator.store.steps = append(rnr.operator.store.steps, map[string]interface{}{
+	rnr.operator.record(map[string]interface{}{
 		"stdout":    stdout.String(),
 		"stderr":    stderr.String(),
 		"exit_code": cmd.ProcessState.ExitCode(),

--- a/http.go
+++ b/http.go
@@ -165,7 +165,7 @@ func (rnr *httpRunner) Run(ctx context.Context, r *httpRequest) error {
 
 	d["headers"] = res.Header
 
-	rnr.operator.store.steps = append(rnr.operator.store.steps, map[string]interface{}{
+	rnr.operator.record(map[string]interface{}{
 		"res": d,
 	})
 

--- a/include.go
+++ b/include.go
@@ -25,7 +25,7 @@ func (rnr *includeRunner) Run(ctx context.Context, path string) error {
 	if err := oo.Run(ctx); err != nil {
 		return err
 	}
-	rnr.operator.store.steps = append(rnr.operator.store.steps, map[string]interface{}{
+	rnr.operator.record(map[string]interface{}{
 		"steps": oo.store.steps,
 	})
 	return nil

--- a/operator_test.go
+++ b/operator_test.go
@@ -148,13 +148,21 @@ func TestRunUsingGitHubAPI(t *testing.T) {
 	if os.Getenv("GITHUB_TOKEN") == "" {
 		t.Skip("env GITHUB_TOKEN is not set")
 	}
-	ctx := context.Background()
-	f, err := New(Book("testdata/book/github.yml"))
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		path string
+	}{
+		{"testdata/book/github.yml"},
+		{"testdata/book/github_map.yml"},
 	}
-	if err := f.Run(ctx); err != nil {
-		t.Error(err)
+	for _, tt := range tests {
+		ctx := context.Background()
+		f, err := New(Book(tt.path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Run(ctx); err != nil {
+			t.Error(err)
+		}
 	}
 }
 
@@ -163,8 +171,8 @@ func TestLoad(t *testing.T) {
 		path string
 		want int
 	}{
-		{"testdata/book/*", 6},
-		{"testdata/**/*", 6},
+		{"testdata/book/*", 7},
+		{"testdata/**/*", 7},
 	}
 	for _, tt := range tests {
 		ops, err := Load(tt.path, Runner("req", "https://api.github.com"), Runner("db", "sqlite://path/to/test.db"))

--- a/operator_test.go
+++ b/operator_test.go
@@ -163,8 +163,8 @@ func TestLoad(t *testing.T) {
 		path string
 		want int
 	}{
-		{"testdata/book/*", 5},
-		{"testdata/**/*", 5},
+		{"testdata/book/*", 6},
+		{"testdata/**/*", 6},
 	}
 	for _, tt := range tests {
 		ops, err := Load(tt.path, Runner("req", "https://api.github.com"), Runner("db", "sqlite://path/to/test.db"))

--- a/option.go
+++ b/option.go
@@ -28,6 +28,7 @@ func Book(path string) Option {
 			bk.Vars[k] = v
 		}
 		bk.Steps = loaded.Steps
+		bk.stepKeys = loaded.stepKeys
 		bk.Debug = loaded.Debug
 		bk.path = loaded.path
 		return nil

--- a/test.go
+++ b/test.go
@@ -28,10 +28,7 @@ const rep = "-----"
 var opReplacer = strings.NewReplacer("==", rep, "!=", rep, "<", rep, ">", rep, "<=", rep, ">=", rep, " not ", rep, "!", rep, " and ", rep, "&&", rep, " or ", rep, "||", rep)
 
 func (rnr *testRunner) Run(ctx context.Context, cond string) error {
-	store := map[string]interface{}{
-		"steps": rnr.operator.store.steps,
-		"vars":  rnr.operator.store.vars,
-	}
+	store := rnr.operator.store.toMap()
 	t := buildTree(cond, store)
 	if rnr.operator.debug {
 		_, _ = fmt.Fprintln(os.Stderr, "-----START TEST CONDITION-----")
@@ -42,7 +39,7 @@ func (rnr *testRunner) Run(ctx context.Context, cond string) error {
 	if err != nil {
 		return err
 	}
-	rnr.operator.store.steps = append(rnr.operator.store.steps, nil)
+	rnr.operator.record(nil)
 	if !tf.(bool) {
 		return fmt.Errorf("(%s) is not true\n%s", cond, t)
 	}

--- a/testdata/book/github_map.yml
+++ b/testdata/book/github_map.yml
@@ -1,0 +1,37 @@
+desc: Test using GitHub ( named steps )
+vars:
+  user: k1LoW
+  token: ${GITHUB_TOKEN}
+runners:
+  req: https://api.github.com
+steps:
+  req0:
+    req:
+      /users/{{ vars.user }}:
+        get:
+          headers:
+            Authorization: "token {{ vars.token }}"
+          body: null
+  test0:
+    test: 'steps.req0.res.status == 200'
+  req1:
+    req:
+      /orgs/golang/repos?per_page=30&page=1:
+        get:
+          headers:
+            Authorization: "token {{ vars.token }}"
+          body: null
+  test1:
+    test: 'steps.req1.res.status == 200'
+  req2:
+    req:
+      /orgs/golang/repos?per_page=30&page=2:
+        get:
+          headers:
+            Authorization: "token {{ vars.token }}"
+          body: null
+  test2:
+    test: 'steps.req2.res.status == 200'
+  test3:
+    test: 'len(steps.req1.res.body) + len(steps.req2.res.body) == 53'
+   

--- a/testdata/book/map.yml
+++ b/testdata/book/map.yml
@@ -1,0 +1,31 @@
+desc: Login and get projects.
+runners:
+  req: https://example.com/api/v1
+  db: mysql://root:mypass@localhost:3306/testdb
+vars:
+  username: alice
+steps:
+  db0:
+    db:
+      query: SELECT * FROM users WHERE name = '{{ vars.username }}'
+  req0:
+    req:
+      /login:
+        post:
+          body:
+            application/json:
+              email: "{{ steps.db1.rows[0].email }}"
+              password: "{{ steps.db1.rows[0].password }}"
+  test0:
+    test: steps.req0.res.status == 200
+  req1:
+    req:
+      /projects:
+        headers:
+          Authorization: "token {{ steps.req0.res.session_token }}"
+        get:
+          body: nil
+  test1:
+    test: steps.req1.res.status == 200
+  test2:
+    test: len(steps.req1.res.projects) > 0


### PR DESCRIPTION
Support following runbook

```yaml
desc: Login and get projects.
runners:
  req: https://example.com/api/v1
  db: mysql://root:mypass@localhost:3306/testdb
vars:
  username: alice
steps:
  db0:
    db:
      query: SELECT * FROM users WHERE name = '{{ vars.username }}'
  req0:
    req:
      /login:
        post:
          body:
            application/json:
              email: "{{ steps.db1.rows[0].email }}"
              password: "{{ steps.db1.rows[0].password }}"
  test0:
    test: steps.req0.res.status == 200
  req1:
    req:
      /projects:
        headers:
          Authorization: "token {{ steps.req0.res.session_token }}"
        get:
          body: nil
  test1:
    test: steps.req1.res.status == 200
  test2:
    test: len(steps.req1.res.projects) > 0

```