### PR TITLE
Fix support string expr

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -697,7 +697,8 @@ func (o *operator) expand(in interface{}) (interface{}, error) {
 			var s string
 			switch v := o.(type) {
 			case string:
-				if numberRe.MatchString(v) {
+				// Stringify only one expression.
+				if strings.TrimSpace(in) == m[0] && numberRe.MatchString(v) {
 					s = fmt.Sprintf("'%s'", v)
 				} else {
 					s = v

--- a/operator_test.go
+++ b/operator_test.go
@@ -57,6 +57,18 @@ func TestExpand(t *testing.T) {
 			map[string]string{"key": "{{ string(vars.one) }}"},
 			map[string]interface{}{"key": "1"},
 		},
+		{
+			[]map[string]interface{}{},
+			map[string]interface{}{"one": "01"},
+			map[string]string{"path/{{ vars.one }}": "value"},
+			map[string]interface{}{"path/01": "value"},
+		},
+		{
+			[]map[string]interface{}{},
+			map[string]interface{}{"year": 2022},
+			map[string]string{"path?year={{ vars.year }}": "value"},
+			map[string]interface{}{"path?year=2022": "value"},
+		},
 	}
 	for _, tt := range tests {
 		o, err := New()


### PR DESCRIPTION
# Problem

The value to be expanded into an expression is determined to be a number, and single quotes are added to the path and GET parameters.

* Example
  ```yaml
  vars:
    year: 2022
  steps:
    -
      req:
        /api/path?year={{ vars.year }}:
          get:
  ```

* Execution logs
  ```
  -----START HTTP REQUEST-----
  GET /api/path?year=%272022%27 HTTP/1.1
  ```

## Proposal for revision

If the expanded content after executing string() is not only that expression, it seems better not to stringify it.


## Related PR

https://github.com/k1LoW/runn/pull/21
