### PR TITLE
Support OpenAPI3 validation at authentication request

### DIFF
--- a/http_validator.go
+++ b/http_validator.go
@@ -150,6 +150,9 @@ func (v *openApi3Validator) requestInput(req *http.Request) (*openapi3filter.Req
 		Request:    req,
 		PathParams: pathParams,
 		Route:      route,
+		Options: &openapi3filter.Options{
+			AuthenticationFunc: openapi3filter.NoopAuthenticationFunc,
+		},
 	}, nil
 }
 

--- a/http_validator_test.go
+++ b/http_validator_test.go
@@ -71,6 +71,19 @@ paths:
                       - email
                 required:
                   - data
+  /private:
+    get:
+      parameters: null
+      responses:
+        '200':
+          description: OK
+      security:
+      - Bearer: []
+components:  
+  securitySchemes:
+    Bearer:
+      type: http
+      scheme: bearer
 `
 
 func TestOpenApi3Validator(t *testing.T) {
@@ -152,6 +165,20 @@ func TestOpenApi3Validator(t *testing.T) {
 				Body:       io.NopCloser(strings.NewReader(`{"invalid_key": "invalid_value"}`)),
 			},
 			true,
+		},
+		{
+			[]RunnerOption{OpenApi3FromData([]byte(validOpenApi3Spec))},
+			&http.Request{
+				Method: http.MethodGet,
+				URL:    pathToURL(t, "/private"),
+				Header: http.Header{"Content-Type": []string{"application/json"}, "Authorization": []string{"Bearer dummy_token"}},
+				Body:   nil,
+			},
+			&http.Response{
+				StatusCode: http.StatusOK,
+				Body:       nil,
+			},
+			false,
 		},
 	}
 	ctx := context.Background()


### PR DESCRIPTION
## Reasons for Proposal

I want to validate HTTP requests with authentication.

Verification currently yields the following error.

```log
openapi3 validation error: Security requirements failed
```

## Proposal for revision

Since checking the response code is sufficient to verify the authentication itself, you may want to set an option not to perform authentication checks when verifying the request.

NoopAuthenticationFunc was used.

see.
https://github.com/getkin/kin-openapi/blob/648d6b9a170b6162c79927aeba39bda2fe37386a/openapi3filter/validation_handler.go#L17-L18