### PR TITLE
Support nil & bool expand

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -771,6 +771,10 @@ func (o *operator) expand(in interface{}) (interface{}, error) {
 				s = strconv.Itoa(int(v))
 			case int:
 				s = strconv.Itoa(v)
+			case bool:
+				s = strconv.FormatBool(v)
+			case nil:
+				// expand nil. s = nil
 			default:
 				reperr = fmt.Errorf("invalid format: %v\n%s", o, string(b))
 			}

--- a/operator_test.go
+++ b/operator_test.go
@@ -70,6 +70,18 @@ func TestExpand(t *testing.T) {
 			map[string]string{"path?year={{ vars.year }}": "value"},
 			map[string]interface{}{"path?year=2022": "value"},
 		},
+		{
+			[]map[string]interface{}{},
+			map[string]interface{}{"boolean": true},
+			map[string]string{"boolean": "{{ vars.boolean }}"},
+			map[string]interface{}{"boolean": true},
+		},
+		{
+			[]map[string]interface{}{},
+			map[string]interface{}{"nullable": nil},
+			map[string]string{"nullable": "{{ vars.nullable }}"},
+			map[string]interface{}{"nullable": nil},
+		},
 	}
 	for _, tt := range tests {
 		o, err := New()


### PR DESCRIPTION
# Problem

If the value to be expanded into an expression is bool or nil, an error will occur.

* Error example
  * boolean
    ```log
    invalid format: true
    ```
  * nil
    ```log
    invalid format: <nil>
    ```

# Proposal for revision

It would be good to expand appropriately when the value is bool or nil.