### PR TITLE
Support bool expand

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -773,8 +773,6 @@ func (o *operator) expand(in interface{}) (interface{}, error) {
 				s = strconv.Itoa(v)
 			case bool:
 				s = strconv.FormatBool(v)
-			case nil:
-				// expand nil. s = nil
 			default:
 				reperr = fmt.Errorf("invalid format: %v\n%s", o, string(b))
 			}

--- a/operator_test.go
+++ b/operator_test.go
@@ -76,12 +76,6 @@ func TestExpand(t *testing.T) {
 			map[string]string{"boolean": "{{ vars.boolean }}"},
 			map[string]interface{}{"boolean": true},
 		},
-		{
-			[]map[string]interface{}{},
-			map[string]interface{}{"nullable": nil},
-			map[string]string{"nullable": "{{ vars.nullable }}"},
-			map[string]interface{}{"nullable": nil},
-		},
 	}
 	for _, tt := range tests {
 		o, err := New()


### PR DESCRIPTION
# Problem

If the value to be expanded into an expression is bool, an error will occur.

* Error example
  ```log
  invalid format: true
  ```

# Proposal for revision

It would be good to expand appropriately when the value is bool.