### PR TITLE
Improvement of unstable operation during OAS Spec verification

### DIFF
--- a/http.go
+++ b/http.go
@@ -149,6 +149,17 @@ func (rnr *httpRunner) Run(ctx context.Context, r *httpRequest) error {
 		if err := rnr.validator.ValidateRequest(ctx, req); err != nil {
 			return err
 		}
+		// reset Request.Body
+		reqBody, err := r.encodeBody()
+		if err != nil {
+			return err
+		}
+		rc, ok := reqBody.(io.ReadCloser)
+		if !ok && reqBody != nil {
+			rc = io.NopCloser(reqBody)
+		}
+		req.Body = rc
+
 		res, err = rnr.client.Do(req)
 		if err != nil {
 			return err

--- a/testdata/openapi3.yml
+++ b/testdata/openapi3.yml
@@ -48,14 +48,12 @@ paths:
           content:
             application/json:
               schema:
+                type: object
                 properties:
-                  data:
-                    type: object
-                    properties:
-                      username:
-                        type: string
-                    required:
-                      - username
-                      - email
+                  login:
+                    type: string
+                  id:
+                    type: integer
                 required:
-                  - data
+                  - login
+                  - id


### PR DESCRIPTION
# Problem

When performing OAS Spec validation, the following error would occur in rare cases when submitting a request.

* example
```log
http request failed on ‘api test’.steps.oas: Put “http://localhost:8000/api/hoge/394336045384073216?date=202104”: http: ContentLength=591 with Body length 616
```

I couldn't reproduce it in the test code, but it looked like the request body object was being used all over again during validation.

Incidentally, the test scenario in which the problem occurred was reproducible, as it made extensive use of includes.

# Contents of Proposal

It seems to be stable if request doby is reset after verifying OAS Spec but before sending actual request.

Fixed an error in the response definition of the OAS Spec (Github API) that was found when creating the test code.