### PR TITLE
Convert number var to json compatible type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     services:
       httpbin:
-        image: kennethreitz/httpbin
+        image: kennethreitz/httpbin:latest
+        ports:
+          - 8080:80
     steps:
       - name: Set up Go ${{ matrix.go_version }}
         uses: actions/setup-go@v3
@@ -35,7 +37,7 @@ jobs:
       - name: Run tests
         run: make ci
         env:
-          HTTPBIN_END_POINT: http://httpbin/
+          HTTPBIN_END_POINT: http://localhost:8080/
 
       - name: Run octocov
         uses: k1LoW/octocov-action@v0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
         go_version: [1.18]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    services:
+      httpbin:
+        image: kennethreitz/httpbin
     steps:
       - name: Set up Go ${{ matrix.go_version }}
         uses: actions/setup-go@v3
@@ -31,6 +34,8 @@ jobs:
 
       - name: Run tests
         run: make ci
+        env:
+          HTTPBIN_END_POINT: http://httpbin/
 
       - name: Run octocov
         uses: k1LoW/octocov-action@v0

--- a/book.go
+++ b/book.go
@@ -73,6 +73,7 @@ func loadBook(in io.Reader) (*book, error) {
 		if bk.Vars == nil {
 			bk.Vars = map[string]interface{}{}
 		} else {
+			// To match behavior with json.Marshal
 			b, err := json.Marshal(bk.Vars)
 			if err != nil {
 				return nil, err

--- a/book.go
+++ b/book.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/goccy/go-yaml"
 	"github.com/k1LoW/duration"
 	"github.com/k1LoW/expand"
@@ -71,6 +72,14 @@ func loadBook(in io.Reader) (*book, error) {
 		}
 		if bk.Vars == nil {
 			bk.Vars = map[string]interface{}{}
+		} else {
+			b, err := json.Marshal(bk.Vars)
+			if err != nil {
+				return nil, err
+			}
+			if err := json.Unmarshal(b, &bk.Vars); err != nil {
+				return nil, err
+			}
 		}
 		if bk.Desc == "" {
 			bk.Desc = noDesc

--- a/book_test.go
+++ b/book_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/goccy/go-json"
+	"github.com/google/go-cmp/cmp"
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -36,9 +38,13 @@ func TestNew(t *testing.T) {
 
 func TestLoadBook(t *testing.T) {
 	tests := []struct {
-		path string
+		path      string
+		varsBytes []byte
 	}{
-		{"testdata/book/env.yml"},
+		{
+			"testdata/book/env.yml",
+			[]byte(`{"number": 1, "string": "string", "object": {"property": "property"}, "array": [ {"property": "property"} ] }`),
+		},
 	}
 	debug := false
 	os.Setenv("DEBUG", strconv.FormatBool(debug))
@@ -52,6 +58,14 @@ func TestLoadBook(t *testing.T) {
 		}
 		if want := "5"; o.Interval != want {
 			t.Errorf("got %v\nwant %v", o.Interval, want)
+		}
+		got := o.Vars
+		var want map[string]interface{}
+		if err := json.Unmarshal(tt.varsBytes, &want); err != nil {
+			panic(err)
+		}
+		if diff := cmp.Diff(got, want, nil); diff != "" {
+			t.Errorf("%s", diff)
 		}
 	}
 }

--- a/grpc.go
+++ b/grpc.go
@@ -5,11 +5,12 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/goccy/go-json"
 
 	"github.com/golang/protobuf/jsonpb" //nolint
 	"github.com/golang/protobuf/proto"  //nolint

--- a/operator.go
+++ b/operator.go
@@ -849,7 +849,7 @@ func (o *operator) expand(in interface{}) (interface{}, error) {
 					s = string(bytes)
 				}
 			default:
-				reperr = fmt.Errorf("invalid format: %v\n%s", o, string(b))
+				reperr = fmt.Errorf("invalid format: %T(%v)", o, o)
 			}
 			oldnew = append(oldnew, m[0], s)
 		}

--- a/operator.go
+++ b/operator.go
@@ -837,6 +837,8 @@ func (o *operator) expand(in interface{}) (interface{}, error) {
 				}
 			case int64:
 				s = strconv.Itoa(int(v))
+			case float64:
+				s = strconv.FormatFloat(v, 'f', -1, 64)
 			case int:
 				s = strconv.Itoa(v)
 			case bool:

--- a/operator_test.go
+++ b/operator_test.go
@@ -244,6 +244,24 @@ func TestRunUsingGitHubAPI(t *testing.T) {
 	}
 }
 
+func TestRunUsingHttpbin(t *testing.T) {
+	tests := []struct {
+		path string
+	}{
+		{"testdata/book/httpbin.yml"},
+	}
+	for _, tt := range tests {
+		ctx := context.Background()
+		f, err := New(Book(tt.path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Run(ctx); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
 func TestLoad(t *testing.T) {
 	tests := []struct {
 		path     string

--- a/operator_test.go
+++ b/operator_test.go
@@ -88,6 +88,30 @@ func TestExpand(t *testing.T) {
 			map[string]string{"array": "{{ vars.array }}"},
 			map[string]interface{}{"array": []interface{}{map[string]interface{}{"foo": "test1", "bar": uint64(1)}, map[string]interface{}{"foo": "test2", "bar": uint64(2)}}},
 		},
+		{
+			[]map[string]interface{}{},
+			map[string]interface{}{"float": float64(1)},
+			map[string]string{"float": "{{ vars.float }}"},
+			map[string]interface{}{"float": uint64(1)},
+		},
+		{
+			[]map[string]interface{}{},
+			map[string]interface{}{"float": float64(1.01)},
+			map[string]string{"float": "{{ vars.float }}"},
+			map[string]interface{}{"float": 1.01},
+		},
+		{
+			[]map[string]interface{}{},
+			map[string]interface{}{"float": float64(1.00)},
+			map[string]string{"float": "{{ vars.float }}"},
+			map[string]interface{}{"float": uint64(1)},
+		},
+		{
+			[]map[string]interface{}{},
+			map[string]interface{}{"float": float64(-0.9)},
+			map[string]string{"float": "{{ vars.float }}"},
+			map[string]interface{}{"float": -0.9},
+		},
 	}
 	for _, tt := range tests {
 		o, err := New()

--- a/test.go
+++ b/test.go
@@ -2,13 +2,13 @@ package runn
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/antonmedv/expr"
 	"github.com/antonmedv/expr/file"
 	"github.com/antonmedv/expr/parser/lexer"
+	"github.com/goccy/go-json"
 	"github.com/xlab/treeprint"
 )
 

--- a/testdata/book/env.yml
+++ b/testdata/book/env.yml
@@ -1,3 +1,11 @@
 desc: Tests to interpolate environment variables.
 debug: ${DEBUG:-true}
 interval: ${INTERVAL:-5}
+vars:
+  number: 1
+  string: "string"
+  object:
+    property: "property"
+  array:
+    -
+      property: "property"

--- a/testdata/book/httpbin.yml
+++ b/testdata/book/httpbin.yml
@@ -1,7 +1,7 @@
 desc: testing json request body
 runners:
   req:
-    endpoint: ${ENDPOINT:-https://httpbin.org/}
+    endpoint: ${HTTPBIN_ENDPOINT:-https://httpbin.org/}
 debug: ${DEBUG:-true}
 vars:
   args:

--- a/testdata/book/httpbin.yml
+++ b/testdata/book/httpbin.yml
@@ -1,7 +1,7 @@
 desc: testing json request body
 runners:
   req:
-    endpoint: ${HTTPBIN_ENDPOINT:-https://httpbin.org/}
+    endpoint: ${HTTPBIN_END_POINT:-https://httpbin.org/}
 debug: ${DEBUG:-true}
 vars:
   args:

--- a/testdata/book/httpbin.yml
+++ b/testdata/book/httpbin.yml
@@ -7,7 +7,7 @@ vars:
   args:
     var: "1"
   jsonRequestBody:
-    foo: "test1"
+    foo: "test"
     bar: 1
   arrayJsonRequestBody:
     -
@@ -16,6 +16,7 @@ vars:
     -
       foo: "test2"
       bar: 2
+  external: json://testdata/vars.json
 steps:
   -
     req:
@@ -46,3 +47,14 @@ steps:
     test: |
       steps[4].res.status == 200
       && steps[4].res.body.json == vars.arrayJsonRequestBody
+  -
+    req:
+      /patch:
+        patch:
+          body:
+            application/json: "{{ vars.external }}"
+  -
+    test: |
+      steps[6].res.status == 200
+      && steps[6].res.body.json == vars.external
+      && vars.external == vars.jsonRequestBody

--- a/testdata/book/httpbin.yml
+++ b/testdata/book/httpbin.yml
@@ -1,0 +1,48 @@
+desc: testing json request body
+runners:
+  req:
+    endpoint: ${ENDPOINT:-https://httpbin.org/}
+debug: ${DEBUG:-true}
+vars:
+  args:
+    var: "1"
+  jsonRequestBody:
+    foo: "test1"
+    bar: 1
+  arrayJsonRequestBody:
+    -
+      foo: "test1"
+      bar: 1
+    -
+      foo: "test2"
+      bar: 2
+steps:
+  -
+    req:
+      /get?var={{ vars.args.var }}:
+        get:
+          body: null
+  -
+    test: |
+      steps[0].res.status == 200
+      && steps[0].res.body.args == vars.args
+  -
+    req:
+      /post:
+        post:
+          body:
+            application/json: "{{ vars.jsonRequestBody }}"
+  -
+    test: |
+      steps[2].res.status == 200
+      && steps[2].res.body.json == vars.jsonRequestBody
+  -
+    req:
+      /put:
+        put:
+          body:
+            application/json: "{{ vars.arrayJsonRequestBody }}"
+  -
+    test: |
+      steps[4].res.status == 200
+      && steps[4].res.body.json == vars.arrayJsonRequestBody


### PR DESCRIPTION
# Problem

There was a problem in which the type of the numerical value in the vars defined in yaml was different from the type of the numerical item in the response, causing the test to fail.

The reason is that the libraries used have different behavior when unmarshaling json and yaml.

* Verification Code
    ```go
    package main
    
    import (
	    "fmt"
    
	    "github.com/goccy/go-json"
	    "github.com/goccy/go-yaml"
	    "github.com/google/go-cmp/cmp"
    )
    
    func main() {
	    jb := []byte(`{"one": {"name": "alice", "age":30 }}`)
	    var ji map[string]interface{}
	    if err := json.Unmarshal(jb, &ji); err != nil {
		    panic(err)
	    }
	    yb := []byte(`
    one:
      name: "alice"
      age: 30
    `)
	    var yi map[string]interface{}
	    if err := yaml.Unmarshal(yb, &yi); err != nil {
		    panic(err)
	    }
	    if diff := cmp.Diff(ji, yi, nil); diff != "" {
		    fmt.Printf("%v", diff)
	    }
    }
    ```

* Execution logs
  ```log
    map[string]any{
  	  "one": map[string]any{
  - 		"age":  float64(30),
  + 		"age":  uint64(30),
  		  "name": string("alice"),
  	  },
    }
  
  Program exited.
  ```

I thought we needed to match the behavior when loading yaml, but am I being overly concerned?

The following scenarios test failed
https://github.com/k1LoW/runn/blob/7a826fc128a7e89c9b3435a712659088cbd73fc8/testdata/book/httpbin.yml
https://github.com/k2tzumi/runn/runs/7816805003?check_suite_focus=true#step:6:63

## Proposal for revision

* [Only vars values are reconverted to reproduce json behavior.](https://github.com/k1LoW/runn/commit/54b78d524b38352b393346dfcbdcd2080e2c6d43)
* [Numeric items are now float type, so the expansion process has been changed.](https://github.com/k1LoW/runn/commit/36f73146afaef99dfc8580fc571bce135d3cf33d)
* [Unified the library used for json processing to goccy/go-json to match the behavior.](https://github.com/k1LoW/runn/commit/cf7b6a8b42846678d2fbc67d9d4f70f05c71833e) 
Currently, `goccy/go-json` is compatible with `encoding/json`, but since most of the processing is done by `goccy/go-json`, we thought it would be better to unify them.
* [Refine invalid format message.](https://github.com/k1LoW/runn/commit/fc27e57ef6e9dcf98b37bae248583ebc50eed247)
* [httpbin](https://github.com/postmanlabs/httpbin) can now be integrated into CI for integration testing.