### PR TITLE
[TEST] loop: section

### DIFF
--- a/testdata/book/httpbin.yml
+++ b/testdata/book/httpbin.yml
@@ -17,13 +17,13 @@ vars:
       foo: "test2"
       bar: 2
   external: json://testdata/vars.json
+  loopCount: 3
 steps:
   -
     req:
       /get?var={{ vars.args.var }}:
         get:
           body: null
-  -
     test: |
       steps[0].res.status == 200
       && steps[0].res.body.args == vars.args
@@ -33,28 +33,48 @@ steps:
         post:
           body:
             application/json: "{{ vars.jsonRequestBody }}"
-  -
     test: |
-      steps[2].res.status == 200
-      && steps[2].res.body.json == vars.jsonRequestBody
+      steps[1].res.status == 200
+      && steps[1].res.body.json == vars.jsonRequestBody
   -
     req:
       /put:
         put:
           body:
             application/json: "{{ vars.arrayJsonRequestBody }}"
-  -
     test: |
-      steps[4].res.status == 200
-      && steps[4].res.body.json == vars.arrayJsonRequestBody
+      steps[2].res.status == 200
+      && steps[2].res.body.json == vars.arrayJsonRequestBody
   -
     req:
       /patch:
         patch:
           body:
             application/json: "{{ vars.external }}"
-  -
     test: |
-      steps[6].res.status == 200
-      && steps[6].res.body.json == vars.external
+      steps[3].res.status == 200
+      && steps[3].res.body.json == vars.external
       && vars.external == vars.jsonRequestBody
+  -
+    loop: vars.loopCount
+    req:
+      /delete:
+        delete:
+          body:
+            application/json:
+              count: "{{ i }}"
+    test: |
+      steps[4].res.status == 200
+      && steps[4].res.body.json.count == i
+  -
+    loop:
+      count: 5
+      until: 'steps[5].res.status != "200"'
+      minInterval: 0.5
+      maxInterval: 10
+    req:
+      /status/{{ 204 - i }}:
+        get:
+          body: null
+    test: |
+      steps[5].res.status == (204 - i)

--- a/testdata/book/httpbin.yml
+++ b/testdata/book/httpbin.yml
@@ -18,6 +18,9 @@ vars:
       bar: 2
   external: json://testdata/vars.json
   loopCount: 3
+  loopVars:
+    - "testdata/vars.json"
+    - "testdata/vars_array.json"
 steps:
   -
     req:
@@ -78,3 +81,15 @@ steps:
           body: null
     test: |
       steps[5].res.status == (204 - i)
+  -
+    test: |
+      steps[5].res.status == 204
+    # FIXME: I'd like to see the last status be 200.
+  -
+    loop:
+      count: len(vars.loopVars)
+    include:
+      path: httpbin_include.yml
+      vars:
+        jsonRequestBody: 'json://{{ vars.loopVars[i] }}'
+        counter: i

--- a/testdata/book/httpbin_include.yml
+++ b/testdata/book/httpbin_include.yml
@@ -1,0 +1,19 @@
+desc: testing include
+runners:
+  req:
+    endpoint: ${HTTPBIN_END_POINT:-https://httpbin.org/}
+vars:
+  jsonRequestBody:
+    foo: "test"
+    bar: 1
+  counter: 0
+steps:
+  -
+    req:
+      /post?count={{ vars.counter }}:
+        post:
+          body:
+            application/json: "{{ vars.jsonRequestBody }}"
+    test: |
+      steps[0].res.status == 200
+      && steps[0].res.body.json == vars.jsonRequestBody


### PR DESCRIPTION
refs https://github.com/k1LoW/runn/pull/97

# Verification

- Ability to set loop counter from vars.
- Ability to use indexes in requests and tests in loop processing
- Ability to replace the retry process with a loop
- Ability to perform loop processing in combination with include

# What has not been verified

- To be retried when HTTP request times out
Error with `DeadlineExceeded`. May not have been handled originally
- The ability to refer to the results of an iterative process in a separate step.
- Ability to read external json using a loop counter.
#93 will be omitted from the response.
