### PR TITLE
Append compare function

### DIFF
--- a/option.go
+++ b/option.go
@@ -357,16 +357,20 @@ func setupBuiltinFunctions(opts ...Option) []Option {
 		Func("string", func(v interface{}) string { return cast.ToString(v) }),
 		Func("int", func(v interface{}) int { return cast.ToInt(v) }),
 		Func("bool", func(v interface{}) bool { return cast.ToBool(v) }),
-		Func("diff", cmp.Diff),
-		Func("ignoreMapEntries", func(ignoreKeys ...string) cmp.Option {
-			return cmpopts.IgnoreMapEntries(func(key string, val interface{}) bool {
+		Func("compare", func(x, y interface{}, ignoreKeys ...string) bool {
+			diff := cmp.Diff(x, y, cmpopts.IgnoreMapEntries(func(key string, val interface{}) bool {
 				for _, ignore := range ignoreKeys {
 					if key == ignore {
 						return true
 					}
 				}
 				return false
-			})
+			}))
+
+			// FIXME: Debug output of diffs
+
+			return diff == ""
+
 		}),
 	},
 		opts...,

--- a/option.go
+++ b/option.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/bmatcuk/doublestar/v4"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/spf13/cast"
 	"google.golang.org/grpc"
@@ -355,6 +357,17 @@ func setupBuiltinFunctions(opts ...Option) []Option {
 		Func("string", func(v interface{}) string { return cast.ToString(v) }),
 		Func("int", func(v interface{}) int { return cast.ToInt(v) }),
 		Func("bool", func(v interface{}) bool { return cast.ToBool(v) }),
+		Func("diff", cmp.Diff),
+		Func("ignoreMapEntries", func(ignoreKeys ...string) cmp.Option {
+			return cmpopts.IgnoreMapEntries(func(key string, val interface{}) bool {
+				for _, ignore := range ignoreKeys {
+					if key == ignore {
+						return true
+					}
+				}
+				return false
+			})
+		}),
 	},
 		opts...,
 	)

--- a/testdata/book/httpbin.yml
+++ b/testdata/book/httpbin.yml
@@ -21,8 +21,12 @@ vars:
   loopVars:
     - "testdata/vars.json"
     - "testdata/vars_array.json"
+  wantBody:
+    Content-Type: "application/json"
+    freeform: "foo"
 steps:
   -
+    desc: Specify request contents by converting variables with built-in functions
     req:
       /get?var={{ urlencode(vars.args.var) }}:
         get:
@@ -31,6 +35,7 @@ steps:
       steps[0].res.status == 200
       && steps[0].res.body.args == vars.args
   -
+    desc: Specify variables in the request body
     req:
       /post:
         post:
@@ -40,6 +45,7 @@ steps:
       steps[1].res.status == 200
       && steps[1].res.body.json == vars.jsonRequestBody
   -
+    desc: Specify array variables in the request body
     req:
       /put:
         put:
@@ -49,6 +55,7 @@ steps:
       steps[2].res.status == 200
       && steps[2].res.body.json == vars.arrayJsonRequestBody
   -
+    desc: Evaluate response contents with variables
     req:
       /patch:
         patch:
@@ -59,6 +66,7 @@ steps:
       && steps[3].res.body.json == vars.external
       && vars.external == vars.jsonRequestBody
   -
+    desc: Parameters are changed and executed for the number of times specified by the variable
     loop: vars.loopCount
     req:
       /delete:
@@ -70,6 +78,7 @@ steps:
       steps[4].res.status == 200
       && steps[4].res.body.json.count == i
   -
+    desc: The status code is retried until it reaches 200
     loop:
       count: 5
       until: 'steps[5].res.status == 200'
@@ -85,6 +94,7 @@ steps:
     test: |
       steps[5].res.status == 200
   -
+    desc: The include section is executed repeatedly
     loop:
       count: len(vars.loopVars)
     include:
@@ -92,3 +102,12 @@ steps:
       vars:
         jsonRequestBody: 'json://{{ vars.loopVars[i] }}'
         counter: i
+  -
+    desc: All the same except Content-Length
+    req:
+      /response-headers?freeform={{ vars.wantBody.freeform }}:
+        get:
+          body: null
+    test: |
+      steps[8].res.status == 200
+      && diff(steps[8].res.body, vars.wantBody, ignoreMapEntries("Content-Length")) == ""

--- a/testdata/book/httpbin.yml
+++ b/testdata/book/httpbin.yml
@@ -110,4 +110,4 @@ steps:
           body: null
     test: |
       steps[8].res.status == 200
-      && diff(steps[8].res.body, vars.wantBody, ignoreMapEntries("Content-Length")) == ""
+      && compare(steps[8].res.body, vars.wantBody, "Content-Length")


### PR DESCRIPTION
# Purpose

Exclude some Entries when validating the response body so that it can be compared with vars.

* Example
  ```yml
    -
      desc: All the same except Content-Length
      req:
        /response-headers?freeform={{ vars.wantBody.freeform }}:
          get:
            body: null
      test: |
        steps[8].res.status == 200
        && compare(steps[8].res.body, vars.wantBody, "Content-Length")
  ```


# Improvement details

* Define `go-cmp/cmp` compare functions as built-in functions
Is the selection of the library to be used reasonable?

# Issue

* debug output is not optimized for syntax with functions
  ```
  -----START TEST CONDITION-----
  steps[8].res.status == 200
  && compare(steps[8].res.body, vars.wantBody, "Content-Length")
  
  
  ├── steps[8].res.status => 200
  ├── 200 => 200
  ├── compare(steps[8].res.body => ?
  ├── vars.wantBody => {"Content-Type":"application/json","freeform":"foo"}
  ├── "Content-Length" => "Content-Length"
  └── ) => ?
  -----END TEST CONDITION-----
  ```
* Diff contents are not output to debug
It might be better to use a built-in function to determine debug flags and output them directly
* Specifying which Entries to exclude is only supported for the first level.
* ~~Not a concise evaluation formula.~~