### PR TITLE
Add functions to cast as built-in functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,9 @@ See [Language Definition](https://github.com/antonmedv/expr/blob/master/docs/Lan
 ### Built-in functions
 
 - `urlencode` ... [url.QueryEscape](https://pkg.go.dev/net/url#QueryEscape)
+- `string` ... [cast.ToString](https://pkg.go.dev/github.com/spf13/cast#ToString)
+- `int` ... [cast.ToInt](https://pkg.go.dev/github.com/spf13/cast#ToInt)
+- `bool` ... [cast.ToBool](https://pkg.go.dev/github.com/spf13/cast#ToBool)
 
 ## Option
 

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.14
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/rs/xid v1.4.0
+	github.com/spf13/cast v1.5.0
 	github.com/spf13/cobra v1.5.0
 	github.com/xlab/treeprint v1.1.0
 	github.com/xo/dburl v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
+github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/tcell v1.3.0/go.mod h1:Hjvr+Ofd+gLglo7RYKxxnzCBmev3BzsS67MebKS4zMM=
 github.com/getkin/kin-openapi v0.97.0 h1:bsvXZeuGiCW43ZKy6xOY5qfT5fCRYmnJwierblSrHCU=
@@ -116,6 +117,7 @@ github.com/k1LoW/httpstub v0.3.2/go.mod h1:+DdiOxIHHtRxNc4oHk997R2jYEytpj5s3E2+q
 github.com/k1LoW/stopw v0.7.0 h1:PB2uLR5Dd0o2n0dJik8iFtor7FC700BRqMAQTyek7F0=
 github.com/k1LoW/stopw v0.7.0/go.mod h1:YzYHAs+C2G8O46iozN8yfC4K/SeuB73C3VQDBqN5+9Y=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -164,10 +166,13 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
+github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sanity-io/litter v1.2.0/go.mod h1:JF6pZUFgu2Q0sBZ+HSV35P8TVPI1TTzEwyu9FXAw2W4=
+github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
+github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
 github.com/spf13/cobra v1.5.0 h1:X+jTBEBqF0bHN+9cSMgmfuvv2VHJ9ezmFNf9Y/XstYU=
 github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/operator.go
+++ b/operator.go
@@ -923,7 +923,6 @@ func (o *operator) stepName(i int) string {
 
 func (o *operator) expand(in interface{}) (interface{}, error) {
 	store := o.store.toMap()
-	store["string"] = func(in interface{}) string { return fmt.Sprintf("%v", in) }
 	b, err := yaml.Marshal(in)
 	if err != nil {
 		return nil, err

--- a/option.go
+++ b/option.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/jhump/protoreflect/desc"
+	"github.com/spf13/cast"
 	"google.golang.org/grpc"
 )
 
@@ -351,6 +352,7 @@ func setupBuiltinFunctions(opts ...Option) []Option {
 	return append([]Option{
 		// NOTE: Please add here the built-in functions you want to enable.
 		Func("urlencode", url.QueryEscape),
+		Func("string", func(v interface{}) string { return cast.ToString(v) }),
 	},
 		opts...,
 	)

--- a/option.go
+++ b/option.go
@@ -353,6 +353,7 @@ func setupBuiltinFunctions(opts ...Option) []Option {
 		// NOTE: Please add here the built-in functions you want to enable.
 		Func("urlencode", url.QueryEscape),
 		Func("string", func(v interface{}) string { return cast.ToString(v) }),
+		Func("int", func(v interface{}) int { return cast.ToInt(v) }),
 	},
 		opts...,
 	)

--- a/option.go
+++ b/option.go
@@ -354,6 +354,7 @@ func setupBuiltinFunctions(opts ...Option) []Option {
 		Func("urlencode", url.QueryEscape),
 		Func("string", func(v interface{}) string { return cast.ToString(v) }),
 		Func("int", func(v interface{}) int { return cast.ToInt(v) }),
+		Func("bool", func(v interface{}) bool { return cast.ToBool(v) }),
 	},
 		opts...,
 	)


### PR DESCRIPTION
# Purpose

Add functions for casting as built-in functions to allow flexible use of values.

## Added functions

- `string` ... move internally configured as a built-in function
- `int` ... 🆕 
- `bool` ... 🆕 