### PR TITLE
Fix recordToMap

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -158,6 +158,10 @@ func (o *operator) recordToArray(v map[string]interface{}) {
 }
 
 func (o *operator) recordToMap(v map[string]interface{}) {
+	if o.store.loopIndex != nil && *o.store.loopIndex > 0 {
+		// delete values of prevous loop
+		delete(o.store.stepMaps, o.steps[len(o.store.stepMaps)-1].key)
+	}
 	o.store.stepMaps[o.steps[len(o.store.stepMaps)].key] = v
 }
 


### PR DESCRIPTION
Revert https://github.com/k1LoW/runn/blob/3dac4b040e56180cd1340deecf783523144642b5/operator.go#L133


In the Map syntax runbook, there is an error if a new step exists after a looped step.