### PR TITLE
Error if duplicate step keys are found in the runbook in Map syntax.

### DIFF
--- a/book.go
+++ b/book.go
@@ -127,16 +127,23 @@ func loadBook(in io.Reader) (*book, error) {
 		bk.interval = d
 	}
 
+	keys := map[string]struct{}{}
 	for _, s := range m.Steps {
 		bk.Steps = append(bk.Steps, s.Value.(map[string]interface{}))
+		var k string
 		switch v := s.Key.(type) {
 		case string:
-			bk.stepKeys = append(bk.stepKeys, v)
+			k = v
 		case uint64:
-			bk.stepKeys = append(bk.stepKeys, fmt.Sprintf("%d", v))
+			k = fmt.Sprintf("%d", v)
 		default:
-			bk.stepKeys = append(bk.stepKeys, fmt.Sprintf("%v", v))
+			k = fmt.Sprintf("%v", v)
 		}
+		bk.stepKeys = append(bk.stepKeys, k)
+		if _, ok := keys[k]; ok {
+			return nil, fmt.Errorf("duplicate step keys: %s", k)
+		}
+		keys[k] = struct{}{}
 	}
 	return bk, nil
 }

--- a/book_test.go
+++ b/book_test.go
@@ -16,15 +16,23 @@ import (
 
 func TestNew(t *testing.T) {
 	tests := []struct {
-		path string
+		path    string
+		wantErr bool
 	}{
-		{"testdata/book/book.yml"},
-		{"testdata/book/map.yml"},
+		{"testdata/book/book.yml", false},
+		{"testdata/book/map.yml", false},
+		{"testdata/notexist.yml", true},
 	}
 	for _, tt := range tests {
 		o, err := New(Book(tt.path))
 		if err != nil {
-			t.Fatal(err)
+			if !tt.wantErr {
+				t.Errorf("got %v", err)
+			}
+			continue
+		}
+		if tt.wantErr {
+			t.Errorf("want err")
 		}
 		if want := 1; len(o.httpRunners) != want {
 			t.Errorf("got %v\nwant %v", len(o.httpRunners), want)

--- a/testdata/duplicate.yml
+++ b/testdata/duplicate.yml
@@ -1,0 +1,10 @@
+desc: Duplicate step keys
+steps:
+  a:
+    test: true
+  b:
+    test: true
+  c:
+    test: true
+  a:
+    test: true


### PR DESCRIPTION
Should be an error if there are duplicate keys in the runbook in Map syntax.

```yaml
desc: Duplicate step keys
steps:
  a:
    test: true
  b:
    test: true
  c:
    test: true
  a: # duplicate !!!
    test: true
```