### PR TITLE
Support uint64 expand

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -917,6 +917,8 @@ func (o *operator) expand(in interface{}) (interface{}, error) {
 				}
 			case int64:
 				s = strconv.Itoa(int(v))
+			case uint64:
+				s = strconv.Itoa(int(v))
 			case float64:
 				s = strconv.FormatFloat(v, 'f', -1, 64)
 			case int:

--- a/operator_test.go
+++ b/operator_test.go
@@ -119,6 +119,12 @@ func TestExpand(t *testing.T) {
 			map[string]string{"escape": "{{ urlencode(vars.escape) }}"},
 			map[string]interface{}{"escape": "C%2B%2B"},
 		},
+		{
+			[]map[string]interface{}{},
+			map[string]interface{}{"uint64": uint64(4600)},
+			map[string]string{"uint64": "{{ vars.uint64 }}"},
+			map[string]interface{}{"uint64": uint64(4600)},
+		},
 	}
 	for _, tt := range tests {
 		o, err := New()


### PR DESCRIPTION
# Problem

Errors were occurring when trying to process uint64 during variable expansion.

```
invalid format: evaluated vars.uint64 , but got uint64(4600)
```

Let uint64 support.

I was able to verify this on a unit test level, but could not reproduce the error when run through RunBook.
I reproduced this when using the brew version, but I wonder if it has anything to do with it?