### PR TITLE
Support for DATETIME columns in DBRunner

### DIFF
--- a/db.go
+++ b/db.go
@@ -92,7 +92,7 @@ func (rnr *dbRunner) Run(ctx context.Context, q *dbQuery) error {
 						s := string(v)
 						t := strings.ToUpper(types[i].DatabaseTypeName())
 						switch t {
-						case "TEXT", "VARCHAR", "NVARCHAR":
+						case "TEXT", "CHAR", "VARCHAR", "NVARCHAR":
 							row[c] = s
 						case "DATETIME":
 							dt, err := time.Parse("2006-01-02 15:04:05", s)

--- a/db.go
+++ b/db.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/xo/dburl"
@@ -90,9 +91,17 @@ func (rnr *dbRunner) Run(ctx context.Context, q *dbQuery) error {
 					case []byte:
 						s := string(v)
 						t := strings.ToUpper(types[i].DatabaseTypeName())
-						if strings.Contains(t, "CHAR") || t == "TEXT" {
+						switch t {
+						case "TEXT", "VARCHAR", "NVARCHAR":
 							row[c] = s
-						} else {
+						case "DATETIME":
+							dt, err := time.Parse(s, "2006-01-02 15:04:05")
+
+							if err != nil {
+								return fmt.Errorf("invalid datetime column: evaluated %s, but got %s(%v): %w", c, t, s, err)
+							}
+							row[c] = dt
+						default:
 							num, err := strconv.Atoi(s)
 							if err != nil {
 								return fmt.Errorf("invalid column: evaluated %s, but got %s(%v): %w", c, t, s, err)

--- a/db.go
+++ b/db.go
@@ -95,7 +95,7 @@ func (rnr *dbRunner) Run(ctx context.Context, q *dbQuery) error {
 						case "TEXT", "VARCHAR", "NVARCHAR":
 							row[c] = s
 						case "DATETIME":
-							dt, err := time.Parse(s, "2006-01-02 15:04:05")
+							dt, err := time.Parse("2006-01-02 15:04:05", s)
 
 							if err != nil {
 								return fmt.Errorf("invalid datetime column: evaluated %s, but got %s(%v): %w", c, t, s, err)


### PR DESCRIPTION
fix https://github.com/k1LoW/runn/issues/124

# Reason for concern

* Isn't the DATETIME format different for different types of databases?
Can you identify the format from the DB connection driver?
No generic DateTime formatting library exists?
* What time zone should the date be in?
* How to implement the verification code?
* Support other formats besides DATETIME?
The following types exist, but they are all treated as numbers
DECIMAL, BOOL, INT, BIGINT