### PR TITLE
Introduce `type Capturer interface`

### DIFF
--- a/book.go
+++ b/book.go
@@ -44,6 +44,7 @@ type book struct {
 	runnerErrs    map[string]error
 	beforeFuncs   []func() error
 	afterFuncs    []func() error
+	capturers     capturers
 }
 
 func newBook() *book {

--- a/capturer.go
+++ b/capturer.go
@@ -1,0 +1,229 @@
+package runn
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+
+	"github.com/olekukonko/tablewriter"
+	"google.golang.org/grpc/metadata"
+)
+
+type Capturer interface {
+	CaptureHTTPRequest(req *http.Request)
+	CaptureHTTPResponse(res *http.Response)
+
+	CaptureGRPCStart()
+	CaptureGRPCRequestHeaders(h map[string][]string)
+	CaptureGRPCRequestMessage(m map[string]interface{})
+	CaptureGRPCResponseStatus(status int)
+	CaptureGRPCResponseHeaders(h map[string][]string)
+	CaptureGRPCResponseMessage(m map[string]interface{})
+	CaptureGRPCResponseTrailers(t map[string][]string)
+	CaptureGRPCEnd()
+
+	CaptureDBStatement(stmt string)
+	CaptureDBResponse(res *DBResponse)
+	CaptureExecCommand(command string)
+	CaptureExecStdin(stdin string)
+	CaptureExecStdout(stdin string)
+	CaptureExecStderr(stderr string)
+	SetCurrentIDs(ids []string)
+	Errs() error
+}
+
+type capturers []Capturer
+
+func (cs capturers) captureHTTPRequest(req *http.Request) {
+	for _, c := range cs {
+		c.CaptureHTTPRequest(req)
+	}
+}
+
+func (cs capturers) captureHTTPResponse(res *http.Response) {
+	for _, c := range cs {
+		c.CaptureHTTPResponse(res)
+	}
+}
+
+func (cs capturers) captureGRPCStart() {
+	for _, c := range cs {
+		c.CaptureGRPCStart()
+	}
+}
+func (cs capturers) captureGRPCRequestHeaders(h metadata.MD) {
+	for _, c := range cs {
+		c.CaptureGRPCRequestHeaders(h)
+	}
+}
+
+func (cs capturers) captureGRPCRequestMessage(m map[string]interface{}) {
+	for _, c := range cs {
+		c.CaptureGRPCRequestMessage(m)
+	}
+}
+
+func (cs capturers) captureGRPCResponseStatus(status int) {
+	for _, c := range cs {
+		c.CaptureGRPCResponseStatus(status)
+	}
+}
+
+func (cs capturers) captureGRPCResponseHeaders(h metadata.MD) {
+	for _, c := range cs {
+		c.CaptureGRPCResponseHeaders(h)
+	}
+}
+
+func (cs capturers) captureGRPCResponseMessage(m map[string]interface{}) {
+	for _, c := range cs {
+		c.CaptureGRPCResponseMessage(m)
+	}
+}
+
+func (cs capturers) captureGRPCResponseTrailers(t metadata.MD) {
+	for _, c := range cs {
+		c.CaptureGRPCResponseTrailers(t)
+	}
+}
+
+func (cs capturers) captureGRPCEnd() {
+	for _, c := range cs {
+		c.CaptureGRPCEnd()
+	}
+}
+
+func (cs capturers) captureDBStatement(stmt string) {
+	for _, c := range cs {
+		c.CaptureDBStatement(stmt)
+	}
+}
+
+func (cs capturers) captureDBResponse(res *DBResponse) {
+	for _, c := range cs {
+		c.CaptureDBResponse(res)
+	}
+}
+
+func (cs capturers) captureExecCommand(command string) {
+	for _, c := range cs {
+		c.CaptureExecCommand(command)
+	}
+}
+
+func (cs capturers) captureExecStdin(stdin string) {
+	for _, c := range cs {
+		c.CaptureExecStdin(stdin)
+	}
+}
+
+func (cs capturers) captureExecStdout(stdout string) {
+	for _, c := range cs {
+		c.CaptureExecStdout(stdout)
+	}
+}
+
+func (cs capturers) captureExecStderr(stderr string) {
+	for _, c := range cs {
+		c.CaptureExecStderr(stderr)
+	}
+}
+
+func (cs capturers) setCurrentIDs(ids []string) {
+	for _, c := range cs {
+		c.SetCurrentIDs(ids)
+	}
+}
+
+var _ Capturer = (*debugger)(nil)
+
+type debugger struct {
+	out        io.Writer
+	currentIDs []string
+	errs       error
+}
+
+func NewDebugger(out io.Writer) *debugger {
+	return &debugger{
+		out: out,
+	}
+}
+
+func (d *debugger) CaptureHTTPRequest(req *http.Request) {
+	b, _ := httputil.DumpRequest(req, true)
+	_, _ = fmt.Fprintf(d.out, "-----START HTTP REQUEST-----\n%s\n-----END HTTP REQUEST-----\n", string(b))
+}
+
+func (d *debugger) CaptureHTTPResponse(res *http.Response) {
+	b, _ := httputil.DumpResponse(res, true)
+	_, _ = fmt.Fprintf(d.out, "-----START HTTP RESPONSE-----\n%s\n-----END HTTP RESPONSE-----\n", string(b))
+}
+
+func (d *debugger) CaptureGRPCStart() {
+	_, _ = fmt.Fprint(d.out, "-----START gRPC-----\n")
+}
+
+func (d *debugger) CaptureGRPCRequestHeaders(h map[string][]string)     {}
+func (d *debugger) CaptureGRPCRequestMessage(m map[string]interface{})  {}
+func (d *debugger) CaptureGRPCResponseStatus(status int)                {}
+func (d *debugger) CaptureGRPCResponseHeaders(h map[string][]string)    {}
+func (d *debugger) CaptureGRPCResponseMessage(m map[string]interface{}) {}
+func (d *debugger) CaptureGRPCResponseTrailers(t map[string][]string)   {}
+func (d *debugger) CaptureGRPCEnd() {
+	_, _ = fmt.Fprint(d.out, "-----END gRPC-----\n")
+}
+
+func (d *debugger) CaptureDBStatement(stmt string) {
+	_, _ = fmt.Fprintf(d.out, "-----START QUERY-----\n%s\n-----END QUERY-----\n", stmt)
+}
+
+func (d *debugger) CaptureDBResponse(res *DBResponse) {
+	if len(res.Rows) == 0 {
+		return
+	}
+	_, _ = fmt.Fprint(d.out, "-----START ROWS-----\n")
+	table := tablewriter.NewWriter(d.out)
+	table.SetHeader(res.Columns)
+	table.SetAutoFormatHeaders(false)
+	table.SetAutoWrapText(false)
+	for _, r := range res.Rows {
+		row := make([]string, 0, len(res.Columns))
+		for _, c := range res.Columns {
+			row = append(row, fmt.Sprintf("%v", r[c]))
+		}
+		table.Append(row)
+	}
+	table.Render()
+	c := len(res.Rows)
+	if c == 1 {
+		_, _ = fmt.Fprintf(d.out, "(%d row)\n", len(res.Rows))
+	} else {
+		_, _ = fmt.Fprintf(d.out, "(%d rows)\n", len(res.Rows))
+	}
+	_, _ = fmt.Fprint(d.out, "-----END ROWS-----\n")
+}
+
+func (d *debugger) CaptureExecCommand(command string) {
+	_, _ = fmt.Fprintf(d.out, "-----START COMMAND-----\n%s\n-----END COMMAND-----\n", command)
+}
+
+func (d *debugger) CaptureExecStdin(stdin string) {
+	_, _ = fmt.Fprintf(d.out, "-----START STDIN-----\n%s\n-----END STDIN-----\n", stdin)
+}
+
+func (d *debugger) CaptureExecStdout(stdout string) {
+	_, _ = fmt.Fprintf(d.out, "-----START STDIN-----\n%s\n-----END STDIN-----\n", stdout)
+}
+
+func (d *debugger) CaptureExecStderr(stderr string) {
+	_, _ = fmt.Fprintf(d.out, "-----START STDERR-----\n%s\n-----END STDERR-----\n", stderr)
+}
+
+func (d *debugger) SetCurrentIDs(ids []string) {
+	d.currentIDs = ids
+}
+
+func (d *debugger) Errs() error {
+	return d.errs
+}

--- a/capturer.go
+++ b/capturer.go
@@ -166,7 +166,7 @@ func (d *debugger) CaptureHTTPResponse(res *http.Response) {
 }
 
 func (d *debugger) CaptureGRPCStart(service, method string) {
-	_, _ = fmt.Fprint(d.out, "-----START gRPC-----\n")
+	_, _ = fmt.Fprintf(d.out, "-----START gRPC-----\nservice: %s\nmethod: %s\n", service, method)
 }
 
 func (d *debugger) CaptureGRPCRequestHeaders(h map[string][]string) {

--- a/capturer.go
+++ b/capturer.go
@@ -28,10 +28,12 @@ type Capturer interface {
 
 	CaptureDBStatement(stmt string)
 	CaptureDBResponse(res *DBResponse)
+
 	CaptureExecCommand(command string)
 	CaptureExecStdin(stdin string)
 	CaptureExecStdout(stdin string)
 	CaptureExecStderr(stderr string)
+
 	SetCurrentIDs(ids []string)
 	Errs() error
 }

--- a/capturer.go
+++ b/capturer.go
@@ -14,14 +14,14 @@ type Capturer interface {
 	CaptureHTTPRequest(req *http.Request)
 	CaptureHTTPResponse(res *http.Response)
 
-	CaptureGRPCStart()
+	CaptureGRPCStart(service, method string)
 	CaptureGRPCRequestHeaders(h map[string][]string)
 	CaptureGRPCRequestMessage(m map[string]interface{})
 	CaptureGRPCResponseStatus(status int)
 	CaptureGRPCResponseHeaders(h map[string][]string)
 	CaptureGRPCResponseMessage(m map[string]interface{})
 	CaptureGRPCResponseTrailers(t map[string][]string)
-	CaptureGRPCEnd()
+	CaptureGRPCEnd(service, method string)
 
 	CaptureDBStatement(stmt string)
 	CaptureDBResponse(res *DBResponse)
@@ -47,9 +47,9 @@ func (cs capturers) captureHTTPResponse(res *http.Response) {
 	}
 }
 
-func (cs capturers) captureGRPCStart() {
+func (cs capturers) captureGRPCStart(service, method string) {
 	for _, c := range cs {
-		c.CaptureGRPCStart()
+		c.CaptureGRPCStart(service, method)
 	}
 }
 func (cs capturers) captureGRPCRequestHeaders(h metadata.MD) {
@@ -88,9 +88,9 @@ func (cs capturers) captureGRPCResponseTrailers(t metadata.MD) {
 	}
 }
 
-func (cs capturers) captureGRPCEnd() {
+func (cs capturers) captureGRPCEnd(service, method string) {
 	for _, c := range cs {
-		c.CaptureGRPCEnd()
+		c.CaptureGRPCEnd(service, method)
 	}
 }
 
@@ -160,7 +160,7 @@ func (d *debugger) CaptureHTTPResponse(res *http.Response) {
 	_, _ = fmt.Fprintf(d.out, "-----START HTTP RESPONSE-----\n%s\n-----END HTTP RESPONSE-----\n", string(b))
 }
 
-func (d *debugger) CaptureGRPCStart() {
+func (d *debugger) CaptureGRPCStart(service, method string) {
 	_, _ = fmt.Fprint(d.out, "-----START gRPC-----\n")
 }
 
@@ -170,7 +170,7 @@ func (d *debugger) CaptureGRPCResponseStatus(status int)                {}
 func (d *debugger) CaptureGRPCResponseHeaders(h map[string][]string)    {}
 func (d *debugger) CaptureGRPCResponseMessage(m map[string]interface{}) {}
 func (d *debugger) CaptureGRPCResponseTrailers(t map[string][]string)   {}
-func (d *debugger) CaptureGRPCEnd() {
+func (d *debugger) CaptureGRPCEnd(service, method string) {
 	_, _ = fmt.Fprint(d.out, "-----END gRPC-----\n")
 }
 

--- a/capturer_test.go
+++ b/capturer_test.go
@@ -1,0 +1,67 @@
+package runn
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/tenntenn/golden"
+)
+
+var testDebuggerHostRe = regexp.MustCompile(`(?s)Host:[^\r\n]+\r\n`)
+var testDebuggerDateRe = regexp.MustCompile(`(?s)Date:[^\r\n]+\r\n`)
+
+func TestDebugger(t *testing.T) {
+	tests := []struct {
+		book string
+	}{
+		{"testdata/book/http.yml"},
+		{"testdata/book/grpc.yml"},
+		{"testdata/book/db.yml"},
+		{"testdata/book/exec.yml"},
+	}
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.book, func(t *testing.T) {
+			out := new(bytes.Buffer)
+			hs := testHTTPServer(t)
+			gs := testGRPCServer(t, false)
+			db := testSQLiteDB(t)
+			opts := []Option{
+				Book(tt.book),
+				HTTPRunner("req", hs.URL, hs.Client()),
+				GrpcRunner("greq", gs.Conn()),
+				DBRunner("db", db),
+				Capture(NewDebugger(out)),
+			}
+			o, err := New(opts...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := o.Run(ctx); err != nil {
+				t.Error(err)
+			}
+
+			got := out.String()
+			if strings.Contains(tt.book, "http.yml") {
+				got = testDebuggerHostRe.ReplaceAllString(got, "Host: replace.example.com\r\n")
+				got = testDebuggerDateRe.ReplaceAllString(got, "Date: Wed, 07 Sep 2022 06:28:20 GMT\r\n")
+			}
+
+			f := fmt.Sprintf("%s.debugger", filepath.Base(tt.book))
+			if os.Getenv("UPDATE_GOLDEN") != "" {
+				golden.Update(t, "testdata", f, got)
+				return
+			}
+
+			if diff := golden.Diff(t, "testdata", f, got); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/db_test.go
+++ b/db_test.go
@@ -42,7 +42,7 @@ func TestDBRun(t *testing.T) {
 INSERT INTO users (username, password, email, created) VALUES ('alice', 'passw0rd', 'alice@example.com', datetime('2017-12-05'));`,
 			map[string]interface{}{
 				"last_insert_id": int64(1),
-				"raws_affected":  int64(1),
+				"rows_affected":  int64(1),
 			},
 		},
 		{

--- a/db_test.go
+++ b/db_test.go
@@ -2,11 +2,13 @@ package runn
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/xo/dburl"
 )
 
 func TestDBRun(t *testing.T) {
@@ -161,4 +163,20 @@ SELECT COUNT(*) AS count FROM users;
 			t.Errorf("%s", diff)
 		}
 	}
+}
+
+func testSQLiteDB(t *testing.T) *sql.DB {
+	t.Helper()
+	p, err := os.CreateTemp("", "tmp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Remove(p.Name())
+	})
+	db, err := dburl.Open(fmt.Sprintf("sqlite://%s", p.Name()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db
 }

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/rs/xid v1.4.0
 	github.com/spf13/cast v1.5.0
 	github.com/spf13/cobra v1.5.0
+	github.com/tenntenn/golden v0.2.0
 	github.com/xlab/treeprint v1.1.0
 	github.com/xo/dburl v0.11.0
 	go.uber.org/multierr v1.8.0
@@ -55,6 +56,8 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/invopop/yaml v0.2.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/josharian/mapfs v0.0.0-20210615234106-095c008854e6 // indirect
+	github.com/josharian/txtarfs v0.0.0-20210615234325-77aca6df5bca // indirect
 	github.com/lestrrat-go/option v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
@@ -77,6 +80,7 @@ require (
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/tools v0.1.5 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
 	google.golang.org/genproto v0.0.0-20220722212130-b98a9ff5e252 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,10 @@ github.com/jhump/protoreflect v1.12.0 h1:1NQ4FpWMgn3by/n1X0fbeKEUxP1wBt7+Oitpv01
 github.com/jhump/protoreflect v1.12.0/go.mod h1:JytZfP5d0r8pVNLZvai7U/MCuTWITgrI4tTg7puQFKI=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/josharian/mapfs v0.0.0-20210615234106-095c008854e6 h1:c+ctPFdISggaSNCfU1IueNBAsqetJSvMcpQlT+0OVdY=
+github.com/josharian/mapfs v0.0.0-20210615234106-095c008854e6/go.mod h1:Rv/momJI8DgrWnBZip+SgagpcgORIZQE5SERlxNb8LY=
+github.com/josharian/txtarfs v0.0.0-20210615234325-77aca6df5bca h1:a8xeK4GsWLE4LYo5VI4u1Cn7ZvT1NtXouXR3DdKLB8Q=
+github.com/josharian/txtarfs v0.0.0-20210615234325-77aca6df5bca/go.mod h1:UbC32ft9G/jG+sZI8wLbIBNIrYr7vp/yqMDa9SxVBNA=
 github.com/k1LoW/duration v1.1.0 h1:KEIL/aAGL//DnGMCiMrxSgRcVw4nM0ur6KSC9kEBsDo=
 github.com/k1LoW/duration v1.1.0/go.mod h1:MEWYmZ4Agei4RDvERiInjZAhcZStYLp6y7+ZrpaAMJQ=
 github.com/k1LoW/exec v0.2.0 h1:b3mOuJtNgPWpvpdW/fRz64wDS7tskW/deAslTyCL9e8=
@@ -256,6 +260,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/tenntenn/golden v0.2.0 h1:ENbHNS5P2Bcnh2QWQcwtNPDYnIvFGuK4lKVDkCq4AHs=
+github.com/tenntenn/golden v0.2.0/go.mod h1:OB8A7xwUZ9xE19KXoOMPl223hhcH4uD8oeQS9fLTiEE=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
@@ -346,6 +352,9 @@ golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
+golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/grpc.go
+++ b/grpc.go
@@ -144,8 +144,8 @@ func (rnr *grpcRunner) Run(ctx context.Context, r *grpcRequest) error {
 	stub := grpcdynamic.NewStubWithMessageFactory(rnr.cc, mf)
 	req := mf.NewMessage(md.GetInputType())
 
-	rnr.operator.capturers.captureGRPCStart()
-	defer rnr.operator.capturers.captureGRPCEnd()
+	rnr.operator.capturers.captureGRPCStart(r.service, r.method)
+	defer rnr.operator.capturers.captureGRPCEnd(r.service, r.method)
 
 	switch {
 	case !md.IsServerStreaming() && !md.IsClientStreaming():

--- a/http.go
+++ b/http.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/http/httputil"
 	"net/url"
 	"path"
 	"strings"
@@ -142,10 +141,9 @@ func (rnr *httpRunner) Run(ctx context.Context, r *httpRequest) error {
 		for k, v := range r.headers {
 			req.Header.Set(k, v)
 		}
-		if rnr.operator.debug {
-			b, _ := httputil.DumpRequest(req, true)
-			rnr.operator.Debugf("-----START HTTP REQUEST-----\n%s\n-----END HTTP REQUEST-----\n", string(b))
-		}
+
+		rnr.operator.capturers.captureHTTPRequest(req)
+
 		if err := rnr.validator.ValidateRequest(ctx, req); err != nil {
 			return err
 		}
@@ -173,10 +171,9 @@ func (rnr *httpRunner) Run(ctx context.Context, r *httpRequest) error {
 		for k, v := range r.headers {
 			req.Header.Set(k, v)
 		}
-		if rnr.operator.debug {
-			b, _ := httputil.DumpRequest(req, true)
-			rnr.operator.Debugf("-----START HTTP REQUEST-----\n%s\n-----END HTTP REQUEST-----\n", string(b))
-		}
+
+		rnr.operator.capturers.captureHTTPRequest(req)
+
 		if err := rnr.validator.ValidateRequest(ctx, req); err != nil {
 			return err
 		}
@@ -188,10 +185,8 @@ func (rnr *httpRunner) Run(ctx context.Context, r *httpRequest) error {
 		return fmt.Errorf("invalid http runner: %s", rnr.name)
 	}
 
-	if rnr.operator.debug {
-		b, _ := httputil.DumpResponse(res, true)
-		rnr.operator.Debugf("-----START HTTP RESPONSE-----\n%s\n-----END HTTP RESPONSE-----\n", string(b))
-	}
+	rnr.operator.capturers.captureHTTPResponse(res)
+
 	if err := rnr.validator.ValidateResponse(ctx, req, res); err != nil {
 		var target *UnsupportedError
 		if errors.As(err, &target) {

--- a/http_test.go
+++ b/http_test.go
@@ -6,11 +6,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/goccy/go-yaml"
+	"github.com/k1LoW/httpstub"
 )
 
 func TestHTTPRunnerRunUsingGitHubAPI(t *testing.T) {
@@ -224,4 +227,24 @@ func TestHTTPRunnerWithHandler(t *testing.T) {
 			t.Errorf("got %v\nwant %v", got, tt.want)
 		}
 	}
+}
+
+func testHTTPServer(t *testing.T) *httptest.Server {
+	r := httpstub.NewRouter(t)
+	r.Method(http.MethodPost).Path("/users").Response(http.StatusCreated, nil)
+	r.Method(http.MethodGet).Path("/users/1").Header("Content-Type", "application/json").ResponseString(http.StatusOK, `{"data":{"username":"alice"}}`)
+	r.Method(http.MethodGet).Path("/private").Match(func(r *http.Request) bool {
+		ah := r.Header.Get("Authorization")
+		return !strings.Contains(ah, "Bearer")
+	}).Header("Content-Type", "application/json").ResponseString(http.StatusForbidden, `{"error":"Forbidden"}`)
+	r.Method(http.MethodGet).Path("/private").Match(func(r *http.Request) bool {
+		ah := r.Header.Get("Authorization")
+		return strings.Contains(ah, "Bearer")
+	}).Response(http.StatusOK, nil)
+	ts := r.Server()
+	t.Cleanup(func() {
+		ts.Close()
+	})
+
+	return ts
 }

--- a/http_validator_test.go
+++ b/http_validator_test.go
@@ -31,8 +31,8 @@ paths:
                 - username
                 - password
       responses:
-        '200':
-          description: OK
+        '201':
+          description: Created
         '400':
           description: Error
           content:
@@ -77,6 +77,17 @@ paths:
       responses:
         '200':
           description: OK
+        '404':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                  - error
       security:
       - Bearer: []
 components:  
@@ -102,7 +113,7 @@ func TestOpenApi3Validator(t *testing.T) {
 				Body:   io.NopCloser(strings.NewReader(`{"username": "alice", "password": "passw0rd"}`)),
 			},
 			&http.Response{
-				StatusCode: http.StatusOK,
+				StatusCode: http.StatusCreated,
 				Body:       nil,
 			},
 			false,
@@ -131,7 +142,7 @@ func TestOpenApi3Validator(t *testing.T) {
 				Body:   io.NopCloser(strings.NewReader(`{"username": "alice"}`)),
 			},
 			&http.Response{
-				StatusCode: http.StatusOK,
+				StatusCode: http.StatusCreated,
 				Body:       nil,
 			},
 			true,

--- a/include.go
+++ b/include.go
@@ -83,6 +83,7 @@ func (o *operator) newNestedOperator(parent *step, opts ...Option) (*operator, e
 	oo.t = o.thisT
 	oo.thisT = o.thisT
 	oo.sw = o.sw
+	oo.capturers = o.capturers
 	oo.parent = parent
 	oo.store.parentVars = o.store.toMap()
 	return oo, nil

--- a/operator.go
+++ b/operator.go
@@ -99,6 +99,7 @@ type operator struct {
 	beforeFuncs []func() error
 	afterFuncs  []func() error
 	sw          *stopw.Span
+	capturers   capturers
 }
 
 func (o *operator) record(v map[string]interface{}) {
@@ -180,6 +181,10 @@ func New(opts ...Option) (*operator, error) {
 		beforeFuncs: bk.beforeFuncs,
 		afterFuncs:  bk.afterFuncs,
 		sw:          stopw.New(),
+	}
+
+	if o.debug {
+		o.capturers = append(o.capturers, NewDebugger(o.out))
 	}
 
 	if bk.path != "" {
@@ -652,7 +657,8 @@ func (o *operator) runInternal(ctx context.Context) error {
 	// steps
 	for i, s := range o.steps {
 		err := func() error {
-			ids := append(o.ids(), s.key)
+			ids := s.ids()
+			o.capturers.setCurrentIDs(ids)
 			defer o.sw.Start(toInterfaces(ids)...).Stop()
 			if i != 0 {
 				time.Sleep(o.interval)

--- a/operator.go
+++ b/operator.go
@@ -181,6 +181,7 @@ func New(opts ...Option) (*operator, error) {
 		beforeFuncs: bk.beforeFuncs,
 		afterFuncs:  bk.afterFuncs,
 		sw:          stopw.New(),
+		capturers:   bk.capturers,
 	}
 
 	if o.debug {

--- a/option.go
+++ b/option.go
@@ -349,6 +349,14 @@ func AfterFunc(fn func() error) Option {
 	}
 }
 
+// Capture - Register the capturer to capture steps.
+func Capture(c Capturer) Option {
+	return func(bk *book) error {
+		bk.capturers = append(bk.capturers, c)
+		return nil
+	}
+}
+
 // setupBuiltinFunctions - Set up built-in functions to runner
 func setupBuiltinFunctions(opts ...Option) []Option {
 	// Built-in functions are added at the beginning of an option and are overridden by subsequent options

--- a/test_test.go
+++ b/test_test.go
@@ -66,7 +66,7 @@ func TestValues(t *testing.T) {
 		{`body contains "<h1>hello</hello>"`, []string{"body", `"<h1>hello</hello>"`}},
 		{`res.body.data.key contains "xxxxxx"`, []string{"res.body.data.key", `"xxxxxx"`}},
 		{`res.headers["Content-Type"] == "application/json"`, []string{`res.headers["Content-Type"]`, `"application/json"`}},
-		{`current.raws[0]`, []string{`current.raws[0]`}},
+		{`current.rows[0]`, []string{`current.rows[0]`}},
 		{`body[0]["key"].data`, []string{`body[0]["key"].data`}},
 		{`res.headers["Content-Type"][0] == "application/json"`, []string{`res.headers["Content-Type"][0]`, `"application/json"`}},
 		{`res.body.data.projects[0].name == "myproject"`, []string{`res.body.data.projects[0].name`, `"myproject"`}},

--- a/testdata/book/http.yml
+++ b/testdata/book/http.yml
@@ -1,0 +1,47 @@
+desc: Test using HTTP
+runners:
+  req: https://example.com
+steps:
+  postusers:
+    desc: Post /users
+    req:
+      /users:
+        post:
+          body:
+            application/json:
+              username: alice
+              password: passw0rd
+    test: |
+      current.res.status == 201
+  getusers:
+    desc: Get /users/1
+    req:
+      /users/1:
+        get:
+          body:
+            application/json:
+              nil
+    test: |
+      current.res.status == 200 && current.res.body.data.username == 'alice'
+  forbidden:
+    desc: Get /private
+    req:
+      /private:
+        get:
+          body:
+            application/json:
+              nil
+    test: |
+      current.res.status == 403 && current.res.body.error == 'Forbidden'
+  getprivate:
+    desc: Get /private with token
+    req:
+      /private:
+        get:
+          headers:
+            Authorization: 'Bearer xxxxx'
+          body:
+            application/json:
+              nil
+    test: |
+      current.res.status == 200

--- a/testdata/db.yml.debugger.golden
+++ b/testdata/db.yml.debugger.golden
@@ -1,0 +1,53 @@
+-----START QUERY-----
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT UNIQUE NOT NULL,
+  password TEXT NOT NULL,
+  email TEXT UNIQUE NOT NULL,
+  created NUMERIC NOT NULL,
+  updated NUMERIC
+)
+-----END QUERY-----
+-----START QUERY-----
+INSERT INTO users (username, password, email, created) VALUES ('alice', 'passw0rd', 'alice@example.com', datetime('2017-12-05'))
+-----END QUERY-----
+-----START QUERY-----
+INSERT INTO users (username, password, email, created) VALUES ('bob', 'passw0rd', 'bob@example.com', datetime('2022-02-22'))
+-----END QUERY-----
+-----START QUERY-----
+SELECT * FROM users;
+-----END QUERY-----
+-----START ROWS-----
++----+----------+----------+-------------------+---------------------+---------+
+| id | username | password |       email       |       created       | updated |
++----+----------+----------+-------------------+---------------------+---------+
+|  1 | alice    | passw0rd | alice@example.com | 2017-12-05 00:00:00 | <nil>   |
+|  2 | bob      | passw0rd | bob@example.com   | 2022-02-22 00:00:00 | <nil>   |
++----+----------+----------+-------------------+---------------------+---------+
+(2 rows)
+-----END ROWS-----
+-----START QUERY-----
+INSERT INTO users (username, password, email, created) VALUES ('charlie', 'passw0rd', 'charlie@example.com', datetime('2022-02-22'))
+-----END QUERY-----
+-----START QUERY-----
+SELECT * FROM users WHERE id = 3
+-----END QUERY-----
+-----START ROWS-----
++----+----------+----------+---------------------+---------------------+---------+
+| id | username | password |        email        |       created       | updated |
++----+----------+----------+---------------------+---------------------+---------+
+|  3 | charlie  | passw0rd | charlie@example.com | 2022-02-22 00:00:00 | <nil>   |
++----+----------+----------+---------------------+---------------------+---------+
+(1 row)
+-----END ROWS-----
+-----START QUERY-----
+SELECT COUNT(*) AS c FROM users
+-----END QUERY-----
+-----START ROWS-----
++---+
+| c |
++---+
+| 3 |
++---+
+(1 row)
+-----END ROWS-----

--- a/testdata/exec.yml.debugger.golden
+++ b/testdata/exec.yml.debugger.golden
@@ -1,0 +1,22 @@
+-----START COMMAND-----
+echo hello world!!
+-----END COMMAND-----
+-----START STDOUT-----
+hello world!!
+
+-----END STDOUT-----
+-----START STDERR-----
+
+-----END STDERR-----
+-----START COMMAND-----
+cat
+-----END COMMAND-----
+-----START STDIN-----
+hello world!!
+-----END STDIN-----
+-----START STDOUT-----
+hello world!!
+-----END STDOUT-----
+-----START STDERR-----
+
+-----END STDERR-----

--- a/testdata/grpc.yml.debugger.golden
+++ b/testdata/grpc.yml.debugger.golden
@@ -1,0 +1,123 @@
+>>>>>START gRPC (grpctest.GrpcTestService/Hello)>>>>>
+-----START gRPC REQUEST HEADERS-----
+authentication: ["tokenhello"]
+-----END gRPC REQUEST HEADERS-----
+-----START gRPC REQUEST MESSAGE-----
+name: "alice"
+num: 3
+request_time: "2022-06-25T05:24:43.861872Z"
+-----END gRPC REQUEST MESSAGE-----
+-----START gRPC RESPONSE STATUS-----
+OK (0)
+-----END gRPC RESPONSE STATUS-----
+-----START gRPC RESPONSE HEADERS-----
+content-type: ["application/grpc"]
+hello: ["header"]
+-----END gRPC RESPONSE HEADERS-----
+-----START gRPC RESPONSE TRAILERS-----
+hello: ["trailer"]
+-----END gRPC RESPONSE TRAILERS-----
+-----START gRPC RESPONSE MESSAGE-----
+create_time: "2022-06-25T05:24:43.861872Z"
+message: "hello"
+num: 32
+-----END gRPC RESPONSE MESSAGE-----
+<<<<<END gRPC (grpctest.GrpcTestService/Hello)<<<<<
+>>>>>START gRPC (grpctest.GrpcTestService/ListHello)>>>>>
+-----START gRPC REQUEST HEADERS-----
+authentication: ["tokenlisthello"]
+-----END gRPC REQUEST HEADERS-----
+-----START gRPC REQUEST MESSAGE-----
+name: "bob"
+num: 4
+request_time: "2022-06-25T05:24:43.861872Z"
+-----END gRPC REQUEST MESSAGE-----
+-----START gRPC RESPONSE STATUS-----
+OK (0)
+-----END gRPC RESPONSE STATUS-----
+-----START gRPC RESPONSE MESSAGE-----
+create_time: "2022-06-25T05:24:43.861872Z"
+message: "hello"
+num: 33
+-----END gRPC RESPONSE MESSAGE-----
+-----START gRPC RESPONSE STATUS-----
+OK (0)
+-----END gRPC RESPONSE STATUS-----
+-----START gRPC RESPONSE MESSAGE-----
+create_time: "2022-06-25T05:24:44.382783Z"
+message: "hello"
+num: 34
+-----END gRPC RESPONSE MESSAGE-----
+-----START gRPC RESPONSE HEADERS-----
+content-type: ["application/grpc"]
+listhello: ["header"]
+-----END gRPC RESPONSE HEADERS-----
+-----START gRPC RESPONSE TRAILERS-----
+listhello: ["trailer"]
+-----END gRPC RESPONSE TRAILERS-----
+<<<<<END gRPC (grpctest.GrpcTestService/ListHello)<<<<<
+>>>>>START gRPC (grpctest.GrpcTestService/MultiHello)>>>>>
+-----START gRPC REQUEST HEADERS-----
+authentication: ["tokenmultihello"]
+-----END gRPC REQUEST HEADERS-----
+-----START gRPC REQUEST MESSAGE-----
+name: "alice"
+num: 5
+request_time: "2022-06-25T05:24:43.861872Z"
+-----END gRPC REQUEST MESSAGE-----
+-----START gRPC REQUEST MESSAGE-----
+name: "bob"
+num: 6
+request_time: "2022-06-25T05:24:43.861872Z"
+-----END gRPC REQUEST MESSAGE-----
+-----START gRPC RESPONSE STATUS-----
+OK (0)
+-----END gRPC RESPONSE STATUS-----
+-----START gRPC RESPONSE MESSAGE-----
+create_time: "2022-06-25T05:24:45.382783Z"
+message: "hello"
+num: 35
+-----END gRPC RESPONSE MESSAGE-----
+-----START gRPC RESPONSE HEADERS-----
+content-type: ["application/grpc"]
+multihello: ["header"]
+-----END gRPC RESPONSE HEADERS-----
+-----START gRPC RESPONSE TRAILERS-----
+multihello: ["trailer"]
+-----END gRPC RESPONSE TRAILERS-----
+<<<<<END gRPC (grpctest.GrpcTestService/MultiHello)<<<<<
+>>>>>START gRPC (grpctest.GrpcTestService/HelloChat)>>>>>
+-----START gRPC REQUEST HEADERS-----
+authentication: ["tokenhellochat"]
+-----END gRPC REQUEST HEADERS-----
+-----START gRPC REQUEST MESSAGE-----
+name: "alice"
+num: 7
+request_time: "2022-06-25T05:24:43.861872Z"
+-----END gRPC REQUEST MESSAGE-----
+-----START gRPC RESPONSE STATUS-----
+OK (0)
+-----END gRPC RESPONSE STATUS-----
+-----START gRPC RESPONSE HEADERS-----
+content-type: ["application/grpc"]
+hellochat: ["header"]
+-----END gRPC RESPONSE HEADERS-----
+-----START gRPC RESPONSE MESSAGE-----
+create_time: "2022-06-25T05:24:46.382783Z"
+message: "hello"
+num: 34
+-----END gRPC RESPONSE MESSAGE-----
+-----START gRPC REQUEST MESSAGE-----
+name: "bob"
+num: 8
+request_time: "2022-06-25T05:24:43.861872Z"
+-----END gRPC REQUEST MESSAGE-----
+-----START gRPC REQUEST MESSAGE-----
+name: "charlie"
+num: 9
+request_time: "2022-06-25T05:24:43.861872Z"
+-----END gRPC REQUEST MESSAGE-----
+-----START gRPC RESPONSE TRAILERS-----
+
+-----END gRPC RESPONSE TRAILERS-----
+<<<<<END gRPC (grpctest.GrpcTestService/HelloChat)<<<<<

--- a/testdata/http.yml.debugger.golden
+++ b/testdata/http.yml.debugger.golden
@@ -1,0 +1,59 @@
+-----START HTTP REQUEST-----
+POST /users HTTP/1.1
+Host: replace.example.com
+Content-Type: application/json
+
+{"password":"passw0rd","username":"alice"}
+-----END HTTP REQUEST-----
+-----START HTTP RESPONSE-----
+HTTP/1.1 201 Created
+Content-Length: 0
+Date: Wed, 07 Sep 2022 06:28:20 GMT
+
+
+-----END HTTP RESPONSE-----
+-----START HTTP REQUEST-----
+GET /users/1 HTTP/1.1
+Host: replace.example.com
+Content-Type: application/json
+
+"nil"
+-----END HTTP REQUEST-----
+-----START HTTP RESPONSE-----
+HTTP/1.1 200 OK
+Content-Length: 29
+Content-Type: application/json
+Date: Wed, 07 Sep 2022 06:28:20 GMT
+
+{"data":{"username":"alice"}}
+-----END HTTP RESPONSE-----
+-----START HTTP REQUEST-----
+GET /private HTTP/1.1
+Host: replace.example.com
+Content-Type: application/json
+
+"nil"
+-----END HTTP REQUEST-----
+-----START HTTP RESPONSE-----
+HTTP/1.1 403 Forbidden
+Content-Length: 21
+Content-Type: application/json
+Date: Wed, 07 Sep 2022 06:28:20 GMT
+
+{"error":"Forbidden"}
+-----END HTTP RESPONSE-----
+-----START HTTP REQUEST-----
+GET /private HTTP/1.1
+Host: replace.example.com
+Authorization: Bearer xxxxx
+Content-Type: application/json
+
+"nil"
+-----END HTTP REQUEST-----
+-----START HTTP RESPONSE-----
+HTTP/1.1 200 OK
+Date: Wed, 07 Sep 2022 06:28:20 GMT
+Content-Length: 0
+
+
+-----END HTTP RESPONSE-----


### PR DESCRIPTION
ref: #116 

Introduce `type Capturer interface` to capture Runbook execution logs in various formats.

As a first step, reimplement Debug log using `type Capturer interface`.