### PR TITLE
Move the parsing operation of runbook(YAML) from operator{} to book{} to clarify responsibilities

### DIFF
--- a/book.go
+++ b/book.go
@@ -21,21 +21,21 @@ import (
 const noDesc = "[No Description]"
 
 type book struct {
-	Desc          string                   `yaml:"desc,omitempty"`
-	Runners       map[string]interface{}   `yaml:"runners,omitempty"`
-	Vars          map[string]interface{}   `yaml:"vars,omitempty"`
-	Steps         []map[string]interface{} `yaml:"steps,omitempty"`
-	Debug         bool                     `yaml:"debug,omitempty"`
-	Interval      string                   `yaml:"interval,omitempty"`
-	If            string                   `yaml:"if,omitempty"`
-	SkipTest      bool                     `yaml:"skipTest,omitempty"`
-	funcs         map[string]interface{}   `yaml:"-"`
+	desc          string
+	runners       map[string]interface{}
+	vars          map[string]interface{}
+	steps         []map[string]interface{}
+	debug         bool
+	ifCond        string
+	skipTest      bool
+	funcs         map[string]interface{}
 	stepKeys      []string
 	path          string // runbook file path
 	httpRunners   map[string]*httpRunner
 	dbRunners     map[string]*dbRunner
 	grpcRunners   map[string]*grpcRunner
 	profile       bool
+	intervalStr   string
 	interval      time.Duration
 	useMap        bool
 	t             *testing.T
@@ -52,18 +52,15 @@ type book struct {
 	capturers     capturers
 }
 
-func newBook() *book {
-	return &book{
-		Runners:     map[string]interface{}{},
-		Vars:        map[string]interface{}{},
-		Steps:       []map[string]interface{}{},
-		funcs:       map[string]interface{}{},
-		httpRunners: map[string]*httpRunner{},
-		dbRunners:   map[string]*dbRunner{},
-		grpcRunners: map[string]*grpcRunner{},
-		interval:    0 * time.Second,
-		runnerErrs:  map[string]error{},
-	}
+type usingListedSteps struct {
+	Desc     string                   `yaml:"desc,omitempty"`
+	Runners  map[string]interface{}   `yaml:"runners,omitempty"`
+	Vars     map[string]interface{}   `yaml:"vars,omitempty"`
+	Steps    []map[string]interface{} `yaml:"steps,omitempty"`
+	Debug    bool                     `yaml:"debug,omitempty"`
+	Interval string                   `yaml:"interval,omitempty"`
+	If       string                   `yaml:"if,omitempty"`
+	SkipTest bool                     `yaml:"skipTest,omitempty"`
 }
 
 type usingMappedSteps struct {
@@ -77,12 +74,42 @@ type usingMappedSteps struct {
 	SkipTest bool                   `yaml:"skipTest,omitempty"`
 }
 
+func newBook() *book {
+	return &book{
+		runners:     map[string]interface{}{},
+		vars:        map[string]interface{}{},
+		steps:       []map[string]interface{}{},
+		funcs:       map[string]interface{}{},
+		httpRunners: map[string]*httpRunner{},
+		dbRunners:   map[string]*dbRunner{},
+		grpcRunners: map[string]*grpcRunner{},
+		interval:    0 * time.Second,
+		runnerErrs:  map[string]error{},
+	}
+}
+
+func newListed() usingListedSteps {
+	return usingListedSteps{
+		Runners: map[string]interface{}{},
+		Vars:    map[string]interface{}{},
+		Steps:   []map[string]interface{}{},
+	}
+}
+
 func newMapped() usingMappedSteps {
 	return usingMappedSteps{
 		Runners: map[string]interface{}{},
 		Vars:    map[string]interface{}{},
 		Steps:   yaml.MapSlice{},
 	}
+}
+
+func (bk *book) Desc() string {
+	return bk.desc
+}
+
+func (bk *book) If() string {
+	return bk.ifCond
 }
 
 func loadBook(in io.Reader) (*book, error) {
@@ -98,7 +125,29 @@ func loadBook(in io.Reader) (*book, error) {
 		}
 	}
 
-	for k, v := range bk.Runners {
+	if bk.desc == "" {
+		bk.desc = noDesc
+	}
+	if bk.intervalStr != "" {
+		d, err := duration.Parse(bk.intervalStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid interval: %w", err)
+		}
+		bk.interval = d
+	}
+
+	// To match behavior with json.Marshal
+	{
+		b, err := json.Marshal(bk.vars)
+		if err != nil {
+			return nil, fmt.Errorf("invalid vars: %w", err)
+		}
+		if err := json.Unmarshal(b, &bk.vars); err != nil {
+			return nil, fmt.Errorf("invalid vars: %w", err)
+		}
+	}
+
+	for k, v := range bk.runners {
 		if err := validateRunnerKey(k); err != nil {
 			return nil, err
 		}
@@ -107,7 +156,7 @@ func loadBook(in io.Reader) (*book, error) {
 		}
 	}
 
-	for i, s := range bk.Steps {
+	for i, s := range bk.steps {
 		if err := validateStepKeys(s); err != nil {
 			return nil, fmt.Errorf("invalid steps[%d]. %w: %s", i, err, s)
 		}
@@ -117,27 +166,19 @@ func loadBook(in io.Reader) (*book, error) {
 }
 
 func unmarshalAsListedSteps(b []byte, bk *book) error {
-	if err := yaml.Unmarshal(b, bk); err != nil {
+	l := newListed()
+	if err := yaml.Unmarshal(b, &l); err != nil {
 		return err
 	}
-	if bk.Runners == nil {
-		bk.Runners = map[string]interface{}{}
-	}
-	if bk.Vars == nil {
-		bk.Vars = map[string]interface{}{}
-	} else {
-		// To match behavior with json.Marshal
-		b, err := json.Marshal(bk.Vars)
-		if err != nil {
-			return err
-		}
-		if err := json.Unmarshal(b, &bk.Vars); err != nil {
-			return err
-		}
-	}
-	if bk.Desc == "" {
-		bk.Desc = noDesc
-	}
+	bk.useMap = false
+	bk.desc = l.Desc
+	bk.runners = l.Runners
+	bk.vars = l.Vars
+	bk.debug = l.Debug
+	bk.intervalStr = l.Interval
+	bk.ifCond = l.If
+	bk.skipTest = l.SkipTest
+	bk.steps = l.Steps
 	return nil
 }
 
@@ -147,28 +188,17 @@ func unmarshalAsMappedSteps(b []byte, bk *book) error {
 		return err
 	}
 	bk.useMap = true
-	bk.Desc = m.Desc
-	bk.Runners = m.Runners
-	bk.Vars = m.Vars
-	bk.Debug = m.Debug
-	if bk.Desc == "" {
-		bk.Desc = noDesc
-	}
-	bk.Interval = m.Interval
-	bk.If = m.If
-	bk.SkipTest = m.SkipTest
-
-	if bk.Interval != "" {
-		d, err := duration.Parse(bk.Interval)
-		if err != nil {
-			return err
-		}
-		bk.interval = d
-	}
+	bk.desc = m.Desc
+	bk.runners = m.Runners
+	bk.vars = m.Vars
+	bk.debug = m.Debug
+	bk.intervalStr = m.Interval
+	bk.ifCond = m.If
+	bk.skipTest = m.SkipTest
 
 	keys := map[string]struct{}{}
 	for _, s := range m.Steps {
-		bk.Steps = append(bk.Steps, s.Value.(map[string]interface{}))
+		bk.steps = append(bk.steps, s.Value.(map[string]interface{}))
 		var k string
 		switch v := s.Key.(type) {
 		case string:

--- a/book.go
+++ b/book.go
@@ -228,20 +228,20 @@ func (bk *book) parseRunner(k string, v interface{}) error {
 	case string:
 		switch {
 		case strings.Index(vv, "https://") == 0 || strings.Index(vv, "http://") == 0:
-			hc, err := newHTTPRunner(k, vv, nil)
+			hc, err := newHTTPRunner(k, vv)
 			if err != nil {
 				return err
 			}
 			bk.httpRunners[k] = hc
 		case strings.Index(vv, "grpc://") == 0:
 			addr := strings.TrimPrefix(vv, "grpc://")
-			gc, err := newGrpcRunner(k, addr, nil)
+			gc, err := newGrpcRunner(k, addr)
 			if err != nil {
 				return err
 			}
 			bk.grpcRunners[k] = gc
 		default:
-			dc, err := newDBRunner(k, vv, nil)
+			dc, err := newDBRunner(k, vv)
 			if err != nil {
 				return err
 			}
@@ -259,7 +259,7 @@ func (bk *book) parseRunner(k string, v interface{}) error {
 		if err := yaml.Unmarshal(tmp, c); err == nil {
 			if c.Endpoint != "" {
 				detect = true
-				r, err := newHTTPRunner(k, c.Endpoint, nil)
+				r, err := newHTTPRunner(k, c.Endpoint)
 				if err != nil {
 					return err
 				}
@@ -281,7 +281,7 @@ func (bk *book) parseRunner(k string, v interface{}) error {
 			if err := yaml.Unmarshal(tmp, c); err == nil {
 				if c.Addr != "" {
 					detect = true
-					r, err := newGrpcRunner(k, c.Addr, nil)
+					r, err := newGrpcRunner(k, c.Addr)
 					if err != nil {
 						return err
 					}

--- a/book.go
+++ b/book.go
@@ -24,7 +24,7 @@ type book struct {
 	desc          string
 	runners       map[string]interface{}
 	vars          map[string]interface{}
-	steps         []map[string]interface{}
+	rawSteps      []map[string]interface{}
 	debug         bool
 	ifCond        string
 	skipTest      bool
@@ -78,7 +78,7 @@ func newBook() *book {
 	return &book{
 		runners:     map[string]interface{}{},
 		vars:        map[string]interface{}{},
-		steps:       []map[string]interface{}{},
+		rawSteps:    []map[string]interface{}{},
 		funcs:       map[string]interface{}{},
 		httpRunners: map[string]*httpRunner{},
 		dbRunners:   map[string]*dbRunner{},
@@ -156,7 +156,7 @@ func loadBook(in io.Reader) (*book, error) {
 		}
 	}
 
-	for i, s := range bk.steps {
+	for i, s := range bk.rawSteps {
 		if err := validateStepKeys(s); err != nil {
 			return nil, fmt.Errorf("invalid steps[%d]. %w: %s", i, err, s)
 		}
@@ -178,7 +178,7 @@ func unmarshalAsListedSteps(b []byte, bk *book) error {
 	bk.intervalStr = l.Interval
 	bk.ifCond = l.If
 	bk.skipTest = l.SkipTest
-	bk.steps = l.Steps
+	bk.rawSteps = l.Steps
 	return nil
 }
 
@@ -198,7 +198,7 @@ func unmarshalAsMappedSteps(b []byte, bk *book) error {
 
 	keys := map[string]struct{}{}
 	for _, s := range m.Steps {
-		bk.steps = append(bk.steps, s.Value.(map[string]interface{}))
+		bk.rawSteps = append(bk.rawSteps, s.Value.(map[string]interface{}))
 		var k string
 		switch v := s.Key.(type) {
 		case string:

--- a/book_test.go
+++ b/book_test.go
@@ -96,7 +96,7 @@ func TestApplyOptions(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		got := bk.Funcs["urlencode"]
+		got := bk.funcs["urlencode"]
 		if reflect.ValueOf(got).Pointer() != reflect.ValueOf(tt.want).Pointer() {
 			t.Errorf("got %v\nwant %v", got, tt.want)
 		}

--- a/book_test.go
+++ b/book_test.go
@@ -57,26 +57,28 @@ func TestLoadBook(t *testing.T) {
 		},
 	}
 	debug := false
-	os.Setenv("DEBUG", strconv.FormatBool(debug))
+	t.Setenv("DEBUG", strconv.FormatBool(debug))
 	for _, tt := range tests {
-		o, err := LoadBook(tt.path)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if want := debug; o.Debug != want {
-			t.Errorf("got %v\nwant %v", o.Debug, want)
-		}
-		if want := "5"; o.Interval != want {
-			t.Errorf("got %v\nwant %v", o.Interval, want)
-		}
-		got := o.Vars
-		var want map[string]interface{}
-		if err := json.Unmarshal(tt.varsBytes, &want); err != nil {
-			panic(err)
-		}
-		if diff := cmp.Diff(got, want, nil); diff != "" {
-			t.Errorf("%s", diff)
-		}
+		t.Run(tt.path, func(t *testing.T) {
+			o, err := LoadBook(tt.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if want := debug; o.debug != want {
+				t.Errorf("got %v\nwant %v", o.debug, want)
+			}
+			if want := "5ms"; o.intervalStr != want {
+				t.Errorf("got %v\nwant %v", o.intervalStr, want)
+			}
+			got := o.vars
+			var want map[string]interface{}
+			if err := json.Unmarshal(tt.varsBytes, &want); err != nil {
+				panic(err)
+			}
+			if diff := cmp.Diff(got, want, nil); diff != "" {
+				t.Errorf("%s", diff)
+			}
+		})
 	}
 }
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -57,8 +57,8 @@ var listCmd = &cobra.Command{
 				if err != nil {
 					continue
 				}
-				desc := b.Desc
-				table.Append([]string{desc, p, b.If})
+				desc := b.Desc()
+				table.Append([]string{desc, p, b.If()})
 			}
 		}
 

--- a/db.go
+++ b/db.go
@@ -27,15 +27,14 @@ type DBResponse struct {
 	Rows         []map[string]interface{}
 }
 
-func newDBRunner(name, dsn string, o *operator) (*dbRunner, error) {
+func newDBRunner(name, dsn string) (*dbRunner, error) {
 	db, err := dburl.Open(dsn)
 	if err != nil {
 		return nil, err
 	}
 	return &dbRunner{
-		name:     name,
-		client:   db,
-		operator: o,
+		name:   name,
+		client: db,
 	}, nil
 }
 

--- a/db_test.go
+++ b/db_test.go
@@ -71,10 +71,11 @@ SELECT COUNT(*) AS count FROM users;
 			if err != nil {
 				t.Fatal(err)
 			}
-			r, err := newDBRunner("db", dsn, o)
+			r, err := newDBRunner("db", dsn)
 			if err != nil {
 				t.Fatal(err)
 			}
+			r.operator = o
 			q := &dbQuery{stmt: tt.stmt}
 			if err := r.Run(ctx, q); err != nil {
 				t.Error(err)

--- a/grpc.go
+++ b/grpc.go
@@ -71,12 +71,11 @@ type grpcRequest struct {
 	messages []*grpcMessage
 }
 
-func newGrpcRunner(name, target string, o *operator) (*grpcRunner, error) {
+func newGrpcRunner(name, target string) (*grpcRunner, error) {
 	return &grpcRunner{
-		name:     name,
-		target:   target,
-		mds:      map[string]*desc.MethodDescriptor{},
-		operator: o,
+		name:   name,
+		target: target,
+		mds:    map[string]*desc.MethodDescriptor{},
 	}, nil
 }
 

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -247,11 +247,11 @@ func TestGrpcRunner(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			r, err := newGrpcRunner("greq", ts.Addr(), o)
+			r, err := newGrpcRunner("greq", ts.Addr())
 			if err != nil {
 				t.Fatal(err)
 			}
+			r.operator = o
 			if err := r.Run(ctx, tt.req); err != nil {
 				t.Error(err)
 			}
@@ -307,15 +307,16 @@ func TestGrpcRunner(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			r, err := newGrpcRunner("greq", ts.Addr(), o)
+			r, err := newGrpcRunner("greq", ts.Addr())
+			if err != nil {
+				t.Fatal(err)
+			}
+			r.operator = o
 			r.tls = &useTLS
 			r.cacert = testutil.Cacert
 			r.cert = testutil.Cert
 			r.key = testutil.Key
 			r.skipVerify = false
-			if err != nil {
-				t.Fatal(err)
-			}
 			if err := r.Run(ctx, tt.req); err != nil {
 				t.Error(err)
 			}

--- a/http.go
+++ b/http.go
@@ -40,7 +40,7 @@ type httpRequest struct {
 	body      interface{}
 }
 
-func newHTTPRunner(name, endpoint string, o *operator) (*httpRunner, error) {
+func newHTTPRunner(name, endpoint string) (*httpRunner, error) {
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
@@ -52,16 +52,14 @@ func newHTTPRunner(name, endpoint string, o *operator) (*httpRunner, error) {
 			Timeout: time.Second * 30,
 		},
 		validator: newNopValidator(),
-		operator:  o,
 	}, nil
 }
 
-func newHTTPRunnerWithHandler(name string, h http.Handler, o *operator) (*httpRunner, error) {
+func newHTTPRunnerWithHandler(name string, h http.Handler) (*httpRunner, error) {
 	return &httpRunner{
 		name:      name,
 		handler:   h,
 		validator: newNopValidator(),
-		operator:  o,
 	}, nil
 }
 

--- a/http_test.go
+++ b/http_test.go
@@ -53,10 +53,11 @@ func TestHTTPRunnerRunUsingGitHubAPI(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i, tt := range tests {
-		r, err := newHTTPRunner("req", endpoint, o)
+		r, err := newHTTPRunner("req", endpoint)
 		if err != nil {
 			t.Fatal(err)
 		}
+		r.operator = o
 		if tt.useOpenApi3Validator {
 			c := &httpRunnerConfig{
 				OpenApi3DocLocation:  "testdata/openapi3.yml",
@@ -211,10 +212,11 @@ func TestHTTPRunnerWithHandler(t *testing.T) {
 	for i, tt := range tests {
 		s := http.NewServeMux()
 		s.HandleFunc(tt.pattern, tt.handlerFunc)
-		r, err := newHTTPRunnerWithHandler(t.Name(), s, o)
+		r, err := newHTTPRunnerWithHandler(t.Name(), s)
 		if err != nil {
 			t.Fatal(err)
 		}
+		r.operator = o
 		if err := r.Run(ctx, tt.req); err != nil {
 			t.Error(err)
 			continue

--- a/operator.go
+++ b/operator.go
@@ -154,22 +154,22 @@ func New(opts ...Option) (*operator, error) {
 		store: store{
 			steps:    []map[string]interface{}{},
 			stepMap:  map[string]map[string]interface{}{},
-			vars:     bk.Vars,
+			vars:     bk.vars,
 			funcs:    bk.funcs,
 			bindVars: map[string]interface{}{},
 			useMap:   bk.useMap,
 		},
 		useMap:      bk.useMap,
-		desc:        bk.Desc,
-		debug:       bk.Debug,
+		desc:        bk.desc,
+		debug:       bk.debug,
 		profile:     bk.profile,
 		interval:    bk.interval,
 		t:           bk.t,
 		thisT:       bk.t,
 		failFast:    bk.failFast,
 		included:    bk.included,
-		cond:        bk.If,
-		skipTest:    bk.SkipTest,
+		cond:        bk.ifCond,
+		skipTest:    bk.skipTest,
 		out:         os.Stderr,
 		bookPath:    bk.path,
 		beforeFuncs: bk.beforeFuncs,
@@ -230,7 +230,7 @@ func New(opts ...Option) (*operator, error) {
 		return nil, merr
 	}
 
-	for i, s := range bk.Steps {
+	for i, s := range bk.steps {
 		key := fmt.Sprintf("%d", i)
 		if o.useMap {
 			key = bk.stepKeys[i]

--- a/operator.go
+++ b/operator.go
@@ -230,7 +230,7 @@ func New(opts ...Option) (*operator, error) {
 		return nil, merr
 	}
 
-	for i, s := range bk.steps {
+	for i, s := range bk.rawSteps {
 		key := fmt.Sprintf("%d", i)
 		if o.useMap {
 			key = bk.stepKeys[i]

--- a/operator_test.go
+++ b/operator_test.go
@@ -170,12 +170,14 @@ func TestNewOption(t *testing.T) {
 			true,
 		},
 	}
-	for _, tt := range tests {
-		_, err := New(tt.opts...)
-		got := (err != nil)
-		if got != tt.wantErr {
-			t.Errorf("got %v\nwant %v", got, tt.wantErr)
-		}
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			_, err := New(tt.opts...)
+			got := (err != nil)
+			if got != tt.wantErr {
+				t.Errorf("got %v\nwant %v", got, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/option.go
+++ b/option.go
@@ -66,7 +66,7 @@ func Book(path string) Option {
 			}
 			bk.vars[k] = ev
 		}
-		bk.steps = loaded.steps
+		bk.rawSteps = loaded.rawSteps
 		bk.stepKeys = loaded.stepKeys
 		if !bk.debug {
 			bk.debug = loaded.debug

--- a/option.go
+++ b/option.go
@@ -32,12 +32,12 @@ func Book(path string) Option {
 		if err != nil {
 			return err
 		}
-		bk.Desc = loaded.Desc
-		bk.If = loaded.If
+		bk.desc = loaded.desc
+		bk.ifCond = loaded.ifCond
 		bk.useMap = loaded.useMap
-		for k, r := range loaded.Runners {
+		for k, r := range loaded.runners {
 			if r != nil {
-				bk.Runners[k] = r
+				bk.runners[k] = r
 			}
 		}
 		for k, r := range loaded.httpRunners {
@@ -55,7 +55,7 @@ func Book(path string) Option {
 				bk.grpcRunners[k] = r
 			}
 		}
-		for k, v := range loaded.Vars {
+		for k, v := range loaded.vars {
 			root, err := loaded.generateOperatorRoot()
 			if err != nil {
 				return err
@@ -64,18 +64,17 @@ func Book(path string) Option {
 			if err != nil {
 				return err
 			}
-			bk.Vars[k] = ev
+			bk.vars[k] = ev
 		}
-		bk.Steps = loaded.Steps
+		bk.steps = loaded.steps
 		bk.stepKeys = loaded.stepKeys
-		if !bk.Debug {
-			bk.Debug = loaded.Debug
+		if !bk.debug {
+			bk.debug = loaded.debug
 		}
-		if !bk.SkipTest {
-			bk.SkipTest = loaded.SkipTest
+		if !bk.skipTest {
+			bk.skipTest = loaded.skipTest
 		}
-		if loaded.Interval != "" {
-			bk.Interval = loaded.Interval
+		if loaded.intervalStr != "" {
 			bk.interval = loaded.interval
 		}
 		bk.path = loaded.path
@@ -86,7 +85,7 @@ func Book(path string) Option {
 // Desc - Set description to runbook
 func Desc(desc string) Option {
 	return func(bk *book) error {
-		bk.Desc = desc
+		bk.desc = desc
 		return nil
 	}
 }
@@ -278,7 +277,7 @@ func Var(k string, v interface{}) Option {
 		if err != nil {
 			return err
 		}
-		bk.Vars[k] = ev
+		bk.vars[k] = ev
 		return nil
 	}
 }
@@ -294,8 +293,8 @@ func Func(k string, v interface{}) Option {
 // Debug - Enable debug output
 func Debug(debug bool) Option {
 	return func(bk *book) error {
-		if !bk.Debug {
-			bk.Debug = debug
+		if !bk.debug {
+			bk.debug = debug
 		}
 		return nil
 	}
@@ -341,8 +340,8 @@ func SkipIncluded(enable bool) Option {
 // SkipTest - Skip test section
 func SkipTest(enable bool) Option {
 	return func(bk *book) error {
-		if !bk.SkipTest {
-			bk.SkipTest = enable
+		if !bk.skipTest {
+			bk.skipTest = enable
 		}
 		return nil
 	}
@@ -509,7 +508,7 @@ func Paths(pathp string) ([]string, error) {
 func GetDesc(opt Option) string {
 	b := newBook()
 	_ = opt(b)
-	return b.Desc
+	return b.desc
 }
 
 func runnHTTPRunner(name string, r *httpRunner) Option {

--- a/option.go
+++ b/option.go
@@ -96,7 +96,12 @@ func Runner(name, dsn string, opts ...httpRunnerOption) Option {
 	return func(bk *book) error {
 		delete(bk.runnerErrs, name)
 		if len(opts) == 0 {
-			bk.Runners[name] = dsn
+			if err := validateRunnerKey(name); err != nil {
+				return err
+			}
+			if err := bk.parseRunner(name, dsn); err != nil {
+				bk.runnerErrs[name] = err
+			}
 			return nil
 		}
 		c := &httpRunnerConfig{}
@@ -281,7 +286,7 @@ func Var(k string, v interface{}) Option {
 // Func - Set function to runner
 func Func(k string, v interface{}) Option {
 	return func(bk *book) error {
-		bk.Funcs[k] = v
+		bk.funcs[k] = v
 		return nil
 	}
 }

--- a/option.go
+++ b/option.go
@@ -112,7 +112,7 @@ func Runner(name, dsn string, opts ...httpRunnerOption) Option {
 		}
 		switch {
 		case c.OpenApi3DocLocation != "":
-			r, err := newHTTPRunner(name, dsn, nil)
+			r, err := newHTTPRunner(name, dsn)
 			if err != nil {
 				bk.runnerErrs[name] = err
 				return nil
@@ -136,7 +136,7 @@ func Runner(name, dsn string, opts ...httpRunnerOption) Option {
 func HTTPRunner(name, endpoint string, client *http.Client, opts ...httpRunnerOption) Option {
 	return func(bk *book) error {
 		delete(bk.runnerErrs, name)
-		r, err := newHTTPRunner(name, endpoint, nil)
+		r, err := newHTTPRunner(name, endpoint)
 		if err != nil {
 			return err
 		}
@@ -166,7 +166,7 @@ func HTTPRunner(name, endpoint string, client *http.Client, opts ...httpRunnerOp
 func HTTPRunnerWithHandler(name string, h http.Handler, opts ...httpRunnerOption) Option {
 	return func(bk *book) error {
 		delete(bk.runnerErrs, name)
-		r, err := newHTTPRunnerWithHandler(name, h, nil)
+		r, err := newHTTPRunnerWithHandler(name, h)
 		if err != nil {
 			bk.runnerErrs[name] = err
 			return nil

--- a/option_test.go
+++ b/option_test.go
@@ -23,7 +23,7 @@ func TestOptionBook(t *testing.T) {
 		if err := opt(bk); err != nil {
 			t.Fatal(err)
 		}
-		got := bk.Desc
+		got := bk.desc
 		if got != tt.want {
 			t.Errorf("got %v\nwant %v", got, tt.want)
 		}
@@ -38,7 +38,7 @@ func TestOptionDesc(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := bk.Desc
+	got := bk.desc
 	want := "hello"
 	if got != want {
 		t.Errorf("got %v\nwant %v", got, want)
@@ -110,7 +110,7 @@ func TestOptionHTTPRunner(t *testing.T) {
 		}
 
 		{
-			got := len(bk.Runners)
+			got := len(bk.runners)
 			if got != tt.wantRunners {
 				t.Errorf("got %v\nwant %v", got, tt.wantRunners)
 			}
@@ -155,7 +155,7 @@ func TestOptionHTTPRunnerWithHandler(t *testing.T) {
 		}
 
 		{
-			got := len(bk.Runners)
+			got := len(bk.runners)
 			if got != tt.wantRunners {
 				t.Errorf("got %v\nwant %v", got, tt.wantRunners)
 			}
@@ -200,7 +200,7 @@ func TestOptionDBRunner(t *testing.T) {
 		}
 
 		{
-			got := len(bk.Runners)
+			got := len(bk.runners)
 			if got != tt.wantRunners {
 				t.Errorf("got %v\nwant %v", got, tt.wantRunners)
 			}
@@ -225,8 +225,8 @@ func TestOptionDBRunner(t *testing.T) {
 func TestOptionVar(t *testing.T) {
 	bk := newBook()
 
-	if len(bk.Vars) != 0 {
-		t.Fatalf("got %v\nwant %v", len(bk.Vars), 0)
+	if len(bk.vars) != 0 {
+		t.Fatalf("got %v\nwant %v", len(bk.vars), 0)
 	}
 
 	opt := Var("key", "value")
@@ -234,7 +234,7 @@ func TestOptionVar(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := bk.Vars["key"].(string)
+	got := bk.vars["key"].(string)
 	want := "value"
 	if got != want {
 		t.Errorf("got %v\nwant %v", got, want)
@@ -244,8 +244,8 @@ func TestOptionVar(t *testing.T) {
 func TestOptionFunc(t *testing.T) {
 	bk := newBook()
 
-	if len(bk.Vars) != 0 {
-		t.Fatalf("got %v\nwant %v", len(bk.Vars), 0)
+	if len(bk.vars) != 0 {
+		t.Fatalf("got %v\nwant %v", len(bk.vars), 0)
 	}
 
 	opt := Func("sprintf", fmt.Sprintf)

--- a/option_test.go
+++ b/option_test.go
@@ -50,14 +50,13 @@ func TestOptionRunner(t *testing.T) {
 		name            string
 		dsn             string
 		opts            []httpRunnerOption
-		wantRunners     int
 		wantHTTPRunners int
 		wantDBRunners   int
 		wantErrs        int
 	}{
-		{"req", "https://example.com/api/v1", nil, 1, 0, 0, 0},
-		{"db", "mysql://localhost/testdb", nil, 1, 0, 0, 0},
-		{"req", "https://example.com/api/v1", []httpRunnerOption{OpenApi3("testdata/openapi3.yml")}, 0, 1, 0, 0},
+		{"req", "https://example.com/api/v1", nil, 1, 0, 0},
+		{"db", "mysql://localhost/testdb", nil, 0, 1, 0},
+		{"req", "https://example.com/api/v1", []httpRunnerOption{OpenApi3("testdata/openapi3.yml")}, 1, 0, 0},
 	}
 	for _, tt := range tests {
 		bk := newBook()
@@ -65,13 +64,6 @@ func TestOptionRunner(t *testing.T) {
 		opt := Runner(tt.name, tt.dsn, tt.opts...)
 		if err := opt(bk); err != nil {
 			t.Fatal(err)
-		}
-
-		{
-			got := len(bk.Runners)
-			if got != tt.wantRunners {
-				t.Errorf("got %v\nwant %v", got, tt.wantRunners)
-			}
 		}
 
 		{
@@ -261,7 +253,7 @@ func TestOptionFunc(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := bk.Funcs["sprintf"].(func(string, ...interface{}) string)
+	got := bk.funcs["sprintf"].(func(string, ...interface{}) string)
 	want := fmt.Sprintf
 	if got("%s!", "hello") != want("%s!", "hello") {
 		t.Errorf("got %v\nwant %v", got("%s!", "hello"), want("%s!", "hello"))

--- a/testdata/book/env.yml
+++ b/testdata/book/env.yml
@@ -1,6 +1,6 @@
 desc: Tests to interpolate environment variables.
 debug: ${DEBUG:-true}
-interval: ${INTERVAL:-5}
+interval: ${INTERVAL:-5ms}
 vars:
   number: 1
   string: "string"


### PR DESCRIPTION
Currently, the initial parsing (yaml.Unmarshal) of the runbook is performed by operator{} and book{}, so we will centralize it in book{}.