### PR TITLE
Support single-line comment

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/antonmedv/expr"
+	"github.com/antonmedv/expr/file"
+	"github.com/antonmedv/expr/parser/lexer"
 )
 
 func evalCond(cond string, store map[string]interface{}) (bool, error) {
@@ -47,6 +49,31 @@ func trimComment(cond string) string {
 		if strings.HasPrefix(strings.Trim(l, " "), commentToken) {
 			continue
 		}
+		s := file.NewSource(l)
+		tokens, err := lexer.Lex(s)
+		if err != nil {
+			trimed = append(trimed, l)
+			continue
+		}
+
+		ccol := -1
+		inClosure := false
+		for _, t := range tokens {
+			switch {
+			case t.Kind == lexer.Bracket && t.Value == "{":
+				inClosure = true
+			case t.Kind == lexer.Bracket && t.Value == "}":
+				inClosure = false
+			case t.Kind == lexer.Operator && t.Value == commentToken && inClosure == false:
+				ccol = t.Column
+				break
+			}
+		}
+		if ccol > 0 {
+			trimed = append(trimed, strings.TrimSuffix(l[:ccol], " "))
+			continue
+		}
+
 		trimed = append(trimed, l)
 	}
 	return strings.Join(trimed, "\n")

--- a/eval_test.go
+++ b/eval_test.go
@@ -63,8 +63,28 @@ func TestTrimComment(t *testing.T) {
 && current.res.body.bar == vars.expectBar`,
 		},
 		{
-			`current.res.status == 200 # This is NOT comment. TODO.`,
-			`current.res.status == 200 # This is NOT comment. TODO.`,
+			`&& current.res.status == 200 # This is comment.`,
+			`&& current.res.status == 200`,
+		},
+		{
+			`&& current.res.status == 200 #This is comment.`,
+			`&& current.res.status == 200`,
+		},
+		{
+			`&& current.res.status == 200 # current.res.status == 200`,
+			`&& current.res.status == 200`,
+		},
+		{
+			`&& current.res.body.foo == 'Hello # World' # This is comment.`,
+			`&& current.res.body.foo == 'Hello # World'`,
+		},
+		{
+			`&& len(map(0..9, {# / 2})) == 5 # This is comment.`,
+			`&& len(map(0..9, {# / 2})) == 5`,
+		},
+		{
+			`&& len(map(0..9, {# / 2})) == 5 # len(map(0..9, {# / 2})) == 5 This is comment.`,
+			`&& len(map(0..9, {# / 2})) == 5`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
ref: #123 

Support single-line comment with #176 

```yaml
test: |
  current.res.status == 200
  # This is comment
  #This is comment
  && current.res.body.foo == vars.expectFoo
  #  This is comment
   # This is comment
  && current.res.body.bar == vars.expectBar # This is comment!!!!!!
```
