### PR TITLE
Fix buildTree()

### DIFF
--- a/test.go
+++ b/test.go
@@ -158,6 +158,8 @@ func indexNode(i *ast.IndexNode) string {
 		return fmt.Sprintf(`%s["%s"]`, n, v.Value)
 	case *ast.IntegerNode:
 		return fmt.Sprintf(`%s[%d]`, n, v.Value)
+	case *ast.IdentifierNode:
+		return fmt.Sprintf(`%s[%s]`, n, v.Value)
 	default:
 		return ""
 	}

--- a/test_test.go
+++ b/test_test.go
@@ -42,6 +42,20 @@ func TestBuildTree(t *testing.T) {
 └── "hello world" => "hello world"
 `,
 		},
+		{
+			"vars.tests[i] == vars.wants[i]",
+			map[string]interface{}{
+				"vars": map[string]interface{}{
+					"tests": []int{1, 2, 3},
+					"wants": []int{0, 1, 2},
+				},
+				"i": 1,
+			},
+			`vars.tests[i] == vars.wants[i]
+├── vars.tests[i] => 2
+└── vars.wants[i] => 1
+`,
+		},
 	}
 	for _, tt := range tests {
 		got, err := buildTree(tt.cond, tt.store)
@@ -76,6 +90,8 @@ func TestValues(t *testing.T) {
 		{`printf('%s world', vars.key) == 'hello world'`, []string{`printf("%s world", vars.key)`, `"%s world"`, `vars.key`, `"hello world"`}},
 		{`compare(steps[8].res.body, vars.wantBody, "Content-Length")`, []string{`compare(steps[8].res.body, vars.wantBody, "Content-Length")`, `steps[8].res.body`, `vars.wantBody`, `"Content-Length"`}},
 		{`len("hello")`, []string{`len("hello")`, `"hello"`}},
+		{`vars.tests[i]`, []string{`vars.tests[i]`}},
+		{`vars.tests[i] == vars.wants[j]`, []string{`vars.tests[i]`, `vars.wants[j]`}},
 	}
 	for _, tt := range tests {
 		got, err := values(tt.cond)


### PR DESCRIPTION
ref: https://github.com/k1LoW/runn/pull/180#issuecomment-1263707873

Fix the following incorrect displays

```
vars.tests[i] == vars.wants[i]
├──  => ?
└──  => ?
```