### PR TITLE
[BREAKING] Support `--skip-included` option for CLI

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -50,17 +50,19 @@ var listCmd = &cobra.Command{
 		table.SetBorder(false)
 
 		pathp := strings.Join(args, string(filepath.ListSeparator))
-		paths, err := runn.Paths(pathp)
+		opts, err := collectOpts()
 		if err != nil {
 			return err
 		}
-		for _, p := range paths {
-			b, err := runn.LoadBook(p)
-			if err != nil {
-				continue
-			}
-			desc := b.Desc()
-			table.Append([]string{desc, p, b.If()})
+		o, err := runn.Load(pathp, opts...)
+		if err != nil {
+			return err
+		}
+		for _, oo := range o.Operators() {
+			desc := oo.Desc()
+			p := oo.BookPath()
+			cond := oo.Cond()
+			table.Append([]string{desc, p, cond})
 		}
 
 		table.Render()
@@ -71,4 +73,5 @@ var listCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(listCmd)
+	listCmd.Flags().BoolVarP(&skipIncluded, "skip-included", "", false, `skip running the included step by itself`)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -40,14 +40,15 @@ import (
 )
 
 var (
-	debug      bool
-	failFast   bool
-	skipTest   bool
-	captureDir string
-	overlays   []string
-	underlays  []string
-	shuffle    string
-	parallel   string
+	debug        bool
+	failFast     bool
+	skipTest     bool
+	skipIncluded bool
+	captureDir   string
+	overlays     []string
+	underlays    []string
+	shuffle      string
+	parallel     string
 )
 
 // runCmd represents the run command
@@ -101,7 +102,8 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 	runCmd.Flags().BoolVarP(&debug, "debug", "", false, "debug")
 	runCmd.Flags().BoolVarP(&failFast, "fail-fast", "", false, "fail fast")
-	runCmd.Flags().BoolVarP(&skipTest, "skip-test", "", false, "skip test")
+	runCmd.Flags().BoolVarP(&skipTest, "skip-test", "", false, `skip "test:" section`)
+	runCmd.Flags().BoolVarP(&skipIncluded, "skip-included", "", false, `skip running the included step by itself`)
 	runCmd.Flags().StringVarP(&captureDir, "capture", "", "", "destination of runbook run capture results")
 	runCmd.Flags().StringSliceVarP(&overlays, "overlay", "", []string{}, "overlay values on the runbook")
 	runCmd.Flags().StringSliceVarP(&underlays, "underlay", "", []string{}, "lay values under the runbook")
@@ -113,6 +115,7 @@ func collectOpts() ([]runn.Option, error) {
 	opts := []runn.Option{
 		runn.Debug(debug),
 		runn.SkipTest(skipTest),
+		runn.SkipIncluded(skipIncluded),
 		runn.Capture(runn.NewCmdOut(os.Stdout)),
 	}
 	if shuffle != "" {


### PR DESCRIPTION
Support `--skip-included` option for CLI ( `runn run` `runn list` ).
Instead, an error occurs if the runbook file is invalid.