### PR TITLE
Support `--grpc-no-tls` option for CLI and `GRPCNoTLS` option for test helper

### DIFF
--- a/book.go
+++ b/book.go
@@ -41,6 +41,7 @@ type book struct {
 	included       bool
 	failFast       bool
 	skipIncluded   bool
+	grpcNoTLS      bool
 	runMatch       *regexp.Regexp
 	runSample      int
 	runShardIndex  int

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -94,6 +94,7 @@ func init() {
 	newCmd.Flags().StringVarP(&desc, "desc", "", "", "description of runbook")
 	newCmd.Flags().StringVarP(&out, "out", "", "", "output path of runbook")
 	newCmd.Flags().BoolVarP(&andRun, "and-run", "", false, "run created runbook and capture the response for test")
+	newCmd.Flags().BoolVarP(&grpcNoTLS, "grpc-no-tls", "", false, "disable TLS use in all gRPC runners")
 }
 
 func runAndCapture(ctx context.Context, o *os.File, fn func(*os.File) error) error {
@@ -118,7 +119,13 @@ func runAndCapture(ctx context.Context, o *os.File, fn func(*os.File) error) err
 		return err
 	}
 
-	oo, err := runn.New(runn.Book(tf.Name()), runn.Capture(capture.Runbook(td, capture.RunbookLoadDesc(true))))
+	opts := []runn.Option{
+		runn.Book(tf.Name()),
+		runn.Capture(capture.Runbook(td, capture.RunbookLoadDesc(true))),
+		runn.GRPCNoTLS(grpcNoTLS),
+	}
+
+	oo, err := runn.New(opts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,7 @@ var (
 	failFast     bool
 	skipTest     bool
 	skipIncluded bool
+	grpcNoTLS    bool
 	captureDir   string
 	overlays     []string
 	underlays    []string

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -92,6 +92,7 @@ func init() {
 	runCmd.Flags().BoolVarP(&failFast, "fail-fast", "", false, "fail fast")
 	runCmd.Flags().BoolVarP(&skipTest, "skip-test", "", false, `skip "test:" section`)
 	runCmd.Flags().BoolVarP(&skipIncluded, "skip-included", "", false, `skip running the included step by itself`)
+	runCmd.Flags().BoolVarP(&grpcNoTLS, "grpc-no-tls", "", false, "disable TLS use in all gRPC runners")
 	runCmd.Flags().StringVarP(&captureDir, "capture", "", "", "destination of runbook run capture results")
 	runCmd.Flags().StringSliceVarP(&overlays, "overlay", "", []string{}, "overlay values on the runbook")
 	runCmd.Flags().StringSliceVarP(&underlays, "underlay", "", []string{}, "lay values under the runbook")
@@ -105,6 +106,7 @@ func collectOpts() ([]runn.Option, error) {
 		runn.Debug(debug),
 		runn.SkipTest(skipTest),
 		runn.SkipIncluded(skipIncluded),
+		runn.GRPCNoTLS(grpcNoTLS),
 		runn.Capture(runn.NewCmdOut(os.Stdout)),
 	}
 	if sample > 0 {

--- a/operator.go
+++ b/operator.go
@@ -201,6 +201,10 @@ func New(opts ...Option) (*operator, error) {
 	}
 	for k, v := range bk.grpcRunners {
 		v.operator = o
+		if bk.grpcNoTLS {
+			useTLS := false
+			v.tls = &useTLS
+		}
 		o.grpcRunners[k] = v
 	}
 

--- a/option.go
+++ b/option.go
@@ -54,6 +54,7 @@ func Book(path string) Option {
 		if !bk.skipTest {
 			bk.skipTest = loaded.skipTest
 		}
+		bk.grpcNoTLS = loaded.grpcNoTLS
 		if loaded.intervalStr != "" {
 			bk.interval = loaded.interval
 		}
@@ -100,6 +101,7 @@ func Overlay(path string) Option {
 		bk.stepKeys = append(bk.stepKeys, loaded.stepKeys...)
 		bk.debug = loaded.debug
 		bk.skipTest = loaded.skipTest
+		bk.grpcNoTLS = loaded.grpcNoTLS
 		bk.interval = loaded.interval
 		return nil
 	}
@@ -435,6 +437,14 @@ func SkipTest(enable bool) Option {
 	}
 }
 
+// GRPCNoTLS - Disable TLS use in all gRPC runners
+func GRPCNoTLS(noTLS bool) Option {
+	return func(bk *book) error {
+		bk.grpcNoTLS = noTLS
+		return nil
+	}
+}
+
 // BeforeFunc - Register the function to be run before the runbook is run.
 func BeforeFunc(fn func() error) Option {
 	return func(bk *book) error {
@@ -457,23 +467,6 @@ func Capture(c Capturer) Option {
 		bk.capturers = append(bk.capturers, c)
 		return nil
 	}
-}
-
-// setupBuiltinFunctions - Set up built-in functions to runner
-func setupBuiltinFunctions(opts ...Option) []Option {
-	// Built-in functions are added at the beginning of an option and are overridden by subsequent options
-	return append([]Option{
-		// NOTE: Please add here the built-in functions you want to enable.
-		Func("urlencode", url.QueryEscape),
-		Func("string", func(v interface{}) string { return cast.ToString(v) }),
-		Func("int", func(v interface{}) int { return cast.ToInt(v) }),
-		Func("bool", func(v interface{}) bool { return cast.ToBool(v) }),
-		Func("time", builtin.Time),
-		Func("compare", builtin.Compare),
-		Func("diff", builtin.Diff),
-	},
-		opts...,
-	)
 }
 
 // RunMatch - Run only runbooks with matching paths.
@@ -533,6 +526,23 @@ func RunParallel(enable bool, max int64) Option {
 		bk.runParallelMax = max
 		return nil
 	}
+}
+
+// setupBuiltinFunctions - Set up built-in functions to runner
+func setupBuiltinFunctions(opts ...Option) []Option {
+	// Built-in functions are added at the beginning of an option and are overridden by subsequent options
+	return append([]Option{
+		// NOTE: Please add here the built-in functions you want to enable.
+		Func("urlencode", url.QueryEscape),
+		Func("string", func(v interface{}) string { return cast.ToString(v) }),
+		Func("int", func(v interface{}) int { return cast.ToInt(v) }),
+		Func("bool", func(v interface{}) bool { return cast.ToBool(v) }),
+		Func("time", builtin.Time),
+		Func("compare", builtin.Compare),
+		Func("diff", builtin.Diff),
+	},
+		opts...,
+	)
 }
 
 func included(included bool) Option {

--- a/option.go
+++ b/option.go
@@ -311,7 +311,7 @@ func GrpcRunner(name string, cc *grpc.ClientConn, opts ...grpcRunnerOption) Opti
 			r.tls = c.TLS
 			if c.cacert != nil {
 				r.cacert = c.cacert
-			} else {
+			} else if c.CACert != "" {
 				b, err := os.ReadFile(c.CACert)
 				if err != nil {
 					bk.runnerErrs[name] = err
@@ -321,7 +321,7 @@ func GrpcRunner(name string, cc *grpc.ClientConn, opts ...grpcRunnerOption) Opti
 			}
 			if c.cert != nil {
 				r.cert = c.cert
-			} else {
+			} else if c.Cert != "" {
 				b, err := os.ReadFile(c.Cert)
 				if err != nil {
 					bk.runnerErrs[name] = err
@@ -331,7 +331,7 @@ func GrpcRunner(name string, cc *grpc.ClientConn, opts ...grpcRunnerOption) Opti
 			}
 			if c.key != nil {
 				r.key = c.key
-			} else {
+			} else if c.Key != "" {
 				b, err := os.ReadFile(c.Key)
 				if err != nil {
 					bk.runnerErrs[name] = err


### PR DESCRIPTION
## Usage

```console
$ runn new --grpc-no-tls --and-run -- grpcurl -d '{"greeting": "hello"}' grpcb.in:9000 hello.HelloService/SayHello
desc: Generated by `runn new`
runners:
  greq: grpc://grpcb.in:9000
steps:
- greq:
    hello.HelloService/SayHello:
      message:
        greeting: hello
  test: |
    current.res.headers['content-type'][0] == "application/grpc"
    && compare(current.res.message, {"reply":"hello hello"})
    && current.res.status == 0
```

ref: https://grpcb.in/