### PR TITLE
Support create runbook from access log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/k1LoW/runn
 go 1.18
 
 require (
+	github.com/Songmu/axslogparser v1.4.0
 	github.com/ajg/form v1.5.1
 	github.com/antonmedv/expr v1.9.0
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
@@ -26,6 +27,7 @@ require (
 	github.com/k1LoW/stopw v0.7.0
 	github.com/lestrrat-go/backoff/v2 v2.0.8
 	github.com/lib/pq v1.10.6
+	github.com/mattn/go-isatty v0.0.14
 	github.com/mattn/go-sqlite3 v1.14.14
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/ory/dockertest/v3 v3.9.1
@@ -45,6 +47,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
+	github.com/Songmu/go-ltsv v0.0.0-20181014062614-c30af2b7b171 // indirect
 	github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/containerd/continuity v0.3.0 // indirect
@@ -66,7 +69,6 @@ require (
 	github.com/lestrrat-go/option v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
-	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-jsonpointer v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mattn/go-shellwords v1.0.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,10 @@ github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VM
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
+github.com/Songmu/axslogparser v1.4.0 h1:cCBU44fFED0XgXDi2OqNycLeJ8JAK0//NoGYwgOj2FQ=
+github.com/Songmu/axslogparser v1.4.0/go.mod h1:tAOlIWRn5Y5tLfZ4zlAdbkvrx21Jmu7SaK0vtlYmaic=
+github.com/Songmu/go-ltsv v0.0.0-20181014062614-c30af2b7b171 h1:nwdeQV2pNjaTv3os4N4/bKDqv0PxW/9DoEAdtW6sY9o=
+github.com/Songmu/go-ltsv v0.0.0-20181014062614-c30af2b7b171/go.mod h1:LBP+tS9C2iiUoR7AGPaZYY+kjXgB5eZxZKbSEBL9UFw=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/runbook_test.go
+++ b/runbook_test.go
@@ -26,6 +26,20 @@ func TestAppendStep(t *testing.T) {
 			{"echo", "hello", "world"},
 			{"echo", "hello", "world2"},
 		}},
+		{"axslog", [][]string{
+			// from https://github.com/Songmu/axslogparser/blob/master/axslogparser_test.go
+			{`10.0.0.11 - - [11/Jun/2017:05:56:04 +0900] "GET / HTTP/1.1" 200 741 "-" "mackerel-http-checker/0.0.1" "-"`},
+			{`test.example.com 10.0.0.11 - Songmu Yaxing [11/Jun/2017:05:56:04 +0900] "GET / HTTP/1.1" 200 741`},
+			{"time:08/Mar/2017:14:12:40 +0900\t" +
+				"host:192.0.2.1\t" +
+				"req:POST /api/v0/tsdb HTTP/1.1\t" +
+				"status:200\t" +
+				"size:36\t" +
+				"ua:mackerel-agent/0.31.2 (Revision 775fad2)\t" +
+				"reqtime:0.087\t" +
+				"taken_sec:0.087\t" +
+				"vhost:mackerel.io"},
+		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/testdata/axslog.append_step.golden
+++ b/testdata/axslog.append_step.golden
@@ -1,0 +1,21 @@
+desc: axslog
+runners:
+  req: http://10.0.0.11
+  req2: http://192.0.2.1
+steps:
+- req:
+    /:
+      get:
+        headers:
+          User-Agent: mackerel-http-checker/0.0.1
+        body: null
+- req:
+    /:
+      get:
+        body: null
+- req2:
+    /api/v0/tsdb:
+      post:
+        headers:
+          User-Agent: mackerel-agent/0.31.2 (Revision 775fad2)
+        body: null


### PR DESCRIPTION
## Usage

```console
$ cat access_log
10.0.0.11 - - [11/Jun/2017:05:56:04 +0900] "GET / HTTP/1.1" 200 741 "-" "mackerel-http-checker/0.0.1" "-"
10.0.0.11 - - [11/Jun/2017:06:56:04 +0900] "GET /path/to HTTP/1.1" 200 741 "-" "mackerel-http-checker/0.0.1" "-"
$ cat access_log | runn new
desc: Generated by `runn new`
runners:
  req: http://10.0.0.11
steps:
- req:
    /:
      get:
        headers:
          User-Agent: mackerel-http-checker/0.0.1
        body: null
- req:
    /path/to:
      get:
        headers:
          User-Agent: mackerel-http-checker/0.0.1
        body: null
$
```

Idea by @k2tzumi / [Parser](https://github.com/Songmu/axslogparser) by @Songmu

Thank you!!