### PR TITLE
Support for appending steps via `runn new`

### DIFF
--- a/runbook.go
+++ b/runbook.go
@@ -3,6 +3,7 @@ package runn
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -25,6 +26,18 @@ func NewRunbook(desc string) *runbook {
 	}
 	r := &runbook{Desc: desc}
 	return r
+}
+
+func LoadRunbook(in io.Reader) (*runbook, error) {
+	b, err := io.ReadAll(in)
+	if err != nil {
+		return nil, err
+	}
+	rb := runbook{}
+	if err := yaml.Unmarshal(b, &rb); err != nil {
+		return nil, err
+	}
+	return &rb, nil
 }
 
 func (rb *runbook) AppendStep(in ...string) error {


### PR DESCRIPTION
## Usage

```console
$ runn new --out http.yml -- curl https://httpbin.org/json -H "accept: application/json"
$ runn new --out http.yml -- curl https://httpbin.org/xml -H "accept: application/json"
$ cat http.yml
desc: Generated by `runn new`
runners:
  req: https://httpbin.org
steps:
- req:
    /json:
      get:
        headers:
          Accept: application/json
        body: null
- req:
    /xml:
      get:
        headers:
          Accept: application/json
        body: null
$
```