### PR TITLE
Add `runn loadt` for load test using runbooks

### DIFF
--- a/cmd/loadt.go
+++ b/cmd/loadt.go
@@ -23,7 +23,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -87,7 +86,7 @@ var loadtCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Println(rep)
+		cmd.Println(rep)
 
 		return nil
 	},

--- a/cmd/loadt.go
+++ b/cmd/loadt.go
@@ -1,0 +1,115 @@
+/*
+Copyright © 2022 Ken'ichiro Oyama <k1lowxb@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/k1LoW/duration"
+	"github.com/k1LoW/runn"
+	"github.com/ryo-yamaoka/otchkiss"
+	"github.com/ryo-yamaoka/otchkiss/setting"
+	"github.com/spf13/cobra"
+)
+
+const reportTemplate = `
+Warm up time (--warm-up)....: {{.WarmUpTime}}
+Duration (--duration).......: {{.Duration}}
+Concurrent (--concurrent)...: {{.MaxConcurrent}}
+
+Total.......................: {{.TotalRequests}}
+Succeeded...................: {{.Succeeded}}
+Failed......................: {{.Failed}}
+Error rate..................: {{.ErrorRate}}%
+RunN per seconds............: {{.RPS}}
+Latency ....................: max={{.MaxLatency}}ms min={{.MinLatency}}ms avg={{.AvgLatency}}ms med={{.MedLatency}}ms p(90)={{.Latency90p}}ms p(99)={{.Latency99p}}ms
+`
+
+// loadtCmd represents the loadt command
+var loadtCmd = &cobra.Command{
+	Use:     "loadt [PATH_PATTERN]",
+	Short:   "run load test using runbooks",
+	Long:    `run load test using runbooks.`,
+	Aliases: []string{"loadtest"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+		pathp := strings.Join(args, string(filepath.ListSeparator))
+		opts, err := flags.ToOpts()
+		if err != nil {
+			return err
+		}
+		o, err := runn.Load(pathp, opts...)
+		if err != nil {
+			return err
+		}
+		d, err := duration.Parse(flags.LoadTDuration)
+		if err != nil {
+			return err
+		}
+		w, err := duration.Parse(flags.LoadTWarmUp)
+		if err != nil {
+			return err
+		}
+		s, err := setting.New(flags.LoadTConcurrent, d, w)
+		if err != nil {
+			return err
+		}
+		ot, err := otchkiss.FromConfig(o, s, 100_000_000)
+		if err != nil {
+			return err
+		}
+		if err := ot.Start(ctx); err != nil {
+			return err
+		}
+		rep, err := ot.TemplateReport(reportTemplate)
+		if err != nil {
+			return err
+		}
+		fmt.Println(rep)
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(loadtCmd)
+	loadtCmd.Flags().BoolVarP(&flags.Debug, "debug", "", false, "debug")
+	loadtCmd.Flags().BoolVarP(&flags.FailFast, "fail-fast", "", false, "fail fast")
+	loadtCmd.Flags().BoolVarP(&flags.SkipTest, "skip-test", "", false, `skip "test:" section`)
+	loadtCmd.Flags().BoolVarP(&flags.SkipIncluded, "skip-included", "", false, `skip running the included step by itself`)
+	loadtCmd.Flags().BoolVarP(&flags.GRPCNoTLS, "grpc-no-tls", "", false, "disable TLS use in all gRPC runners")
+	loadtCmd.Flags().StringVarP(&flags.CaptureDir, "capture", "", "", "destination of runbook run capture results")
+	loadtCmd.Flags().StringSliceVarP(&flags.Vars, "var", "", []string{}, `set var to runbook ("key:value")`)
+	loadtCmd.Flags().StringSliceVarP(&flags.Runners, "runner", "", []string{}, `set runner to runbook ("key:dsn")`)
+	loadtCmd.Flags().StringSliceVarP(&flags.Overlays, "overlay", "", []string{}, "overlay values on the runbook")
+	loadtCmd.Flags().StringSliceVarP(&flags.Underlays, "underlay", "", []string{}, "lay values under the runbook")
+	loadtCmd.Flags().IntVarP(&flags.Sample, "sample", "", 0, "run the specified number of runbooks at random")
+	loadtCmd.Flags().StringVarP(&flags.Shuffle, "shuffle", "", "off", `randomize the order of running runbooks ("on","off",N)`)
+	loadtCmd.Flags().StringVarP(&flags.Parallel, "parallel", "", "off", `parallelize runs of runbooks ("on","off",N)`)
+
+	loadtCmd.Flags().IntVarP(&flags.LoadTConcurrent, "concurrent", "", 1, "number of parallel load test runs")
+	loadtCmd.Flags().StringVarP(&flags.LoadTDuration, "duration", "", "10sec", "load test running duration")
+	loadtCmd.Flags().StringVarP(&flags.LoadTWarmUp, "warm-up", "", "5sec", "warn-up time for load test")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,22 +61,25 @@ var intRe = regexp.MustCompile(`^\-?[0-9]+$`)
 var floatRe = regexp.MustCompile(`^\-?[0-9.]+$`)
 
 type Flags struct {
-	Debug        bool
-	FailFast     bool
-	SkipTest     bool
-	SkipIncluded bool
-	GRPCNoTLS    bool
-	CaptureDir   string
-	Vars         []string
-	Runners      []string
-	Overlays     []string
-	Underlays    []string
-	Sample       int
-	Shuffle      string
-	Parallel     string
-	Desc         string
-	Out          string
-	AndRun       bool
+	Debug           bool
+	FailFast        bool
+	SkipTest        bool
+	SkipIncluded    bool
+	GRPCNoTLS       bool
+	CaptureDir      string
+	Vars            []string
+	Runners         []string
+	Overlays        []string
+	Underlays       []string
+	Sample          int
+	Shuffle         string
+	Parallel        string
+	Desc            string
+	Out             string
+	AndRun          bool
+	LoadTConcurrent int
+	LoadTDuration   string
+	LoadTWarmUp     string
 }
 
 func (f *Flags) ToOpts() ([]runn.Option, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,7 +91,6 @@ func (f *Flags) ToOpts() ([]runn.Option, error) {
 		runn.SkipTest(f.SkipTest),
 		runn.SkipIncluded(f.SkipIncluded),
 		runn.GRPCNoTLS(f.GRPCNoTLS),
-		runn.Capture(runn.NewCmdOut(os.Stdout)),
 	}
 	if f.Sample > 0 {
 		opts = append(opts, runn.RunSample(f.Sample))

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -36,8 +36,8 @@ import (
 // runCmd represents the run command
 var runCmd = &cobra.Command{
 	Use:   "run [PATH_PATTERN ...]",
-	Short: "run books",
-	Long:  `run books.`,
+	Short: "run scenarios of runbooks",
+	Long:  `run scenarios of runbooks.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		green := color.New(color.FgGreen).SprintFunc()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -47,6 +47,8 @@ var runCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		opts = append(opts, runn.Capture(runn.NewCmdOut(os.Stdout)))
+
 		o, err := runn.Load(pathp, opts...)
 		if err != nil {
 			return err

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/ory/dockertest/v3 v3.9.1
 	github.com/rs/xid v1.4.0
+	github.com/ryo-yamaoka/otchkiss v0.0.1
 	github.com/spf13/cast v1.5.0
 	github.com/spf13/cobra v1.5.0
 	github.com/tenntenn/golden v0.2.0
@@ -56,6 +57,7 @@ require (
 	github.com/docker/docker v20.10.7+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/fullstorydev/grpcurl v1.8.7 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKoh
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -305,6 +307,8 @@ github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/ryo-yamaoka/otchkiss v0.0.1 h1:Q7mR7/tlgBXOr0oK7rRnFhio+CqR+qdYQKm/FfSo9Rc=
+github.com/ryo-yamaoka/otchkiss v0.0.1/go.mod h1:vx+6R+nhlWXoJbIJvkEPvNxv9sZLHpbevYwvuHqD+4s=
 github.com/sanity-io/litter v1.2.0/go.mod h1:JF6pZUFgu2Q0sBZ+HSV35P8TVPI1TTzEwyu9FXAw2W4=
 github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4/go.mod h1:C1a7PQSMz9NShzorzCiG2fk9+xuCgLkPeCvMHYR2OWg=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=

--- a/operator.go
+++ b/operator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/goccy/go-json"
 	"github.com/k1LoW/stopw"
+	"github.com/ryo-yamaoka/otchkiss"
 	"go.uber.org/multierr"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
@@ -26,6 +27,8 @@ var (
 	cyan   = color.New(color.FgCyan).SprintFunc()
 	yellow = color.New(color.FgYellow).SprintFunc()
 )
+
+var _ otchkiss.Requester = (*operators)(nil)
 
 type step struct {
 	key           string
@@ -939,6 +942,19 @@ func (ops *operators) DumpProfile(w io.Writer) error {
 	if _, err := w.Write(b); err != nil {
 		return err
 	}
+	return nil
+}
+
+func (ops *operators) Init() error {
+	return nil
+}
+
+func (ops *operators) RequestOne(ctx context.Context) error {
+	return ops.RunN(ctx)
+}
+
+func (ops *operators) Terminate() error {
+	ops.Close()
 	return nil
 }
 

--- a/operator_test.go
+++ b/operator_test.go
@@ -265,13 +265,11 @@ func TestLoad(t *testing.T) {
 	tests := []struct {
 		paths    string
 		RUNN_RUN string
-		sample   int
 		want     int
 	}{
 		{
 			"testdata/book/**/*",
 			"",
-			0,
 			func() int {
 				e, err := os.ReadDir("testdata/book/")
 				if err != nil {
@@ -280,30 +278,14 @@ func TestLoad(t *testing.T) {
 				return len(e)
 			}(),
 		},
-		{"testdata/book/**/*", "initdb", 0, 1},
-		{"testdata/book/**/*", "nonexistent", 0, 0},
-		{"testdata/book/**/*", "", 3, 3},
-		{
-			"testdata/book/**/*",
-			"",
-			9999,
-			func() int {
-				e, err := os.ReadDir("testdata/book/")
-				if err != nil {
-					t.Fatal(err)
-				}
-				return len(e)
-			}(),
-		},
+		{"testdata/book/**/*", "initdb", 1},
+		{"testdata/book/**/*", "nonexistent", 0},
 	}
 	for _, tt := range tests {
 		t.Setenv("RUNN_RUN", tt.RUNN_RUN)
 		opts := []Option{
 			Runner("req", "https://api.github.com"),
 			Runner("db", "sqlite://path/to/test.db"),
-		}
-		if tt.sample > 0 {
-			opts = append(opts, RunSample(tt.sample))
 		}
 		ops, err := Load(tt.paths, opts...)
 		if err != nil {
@@ -505,7 +487,8 @@ func TestShard(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				got = append(got, ops.ops...)
+
+				got = append(got, ops.SelectedOperators()...)
 			}
 			if len(got) != len(want) {
 				t.Errorf("got %v\nwant %v", len(got), len(want))


### PR DESCRIPTION
```console
$ runn loadt my.yml

Warm up time (--warm-up)....: 5s
Duration (--duration).......: 10s
Concurrent (--concurrent)...: 1

Total.......................: 892
Succeeded...................: 892
Failed......................: 0
Error rate..................: 0%
RunN per seconds............: 89.2
Latency ....................: max=30.3ms min=7.0ms avg=11.0ms med=9.8ms p(90)=16.3ms p(99)=25.4ms

$ runn loadt -h
run load test using runbooks.

Usage:
  runn loadt [PATH_PATTERN] [flags]

Aliases:
  loadt, loadtest

Flags:
      --capture string     destination of runbook run capture results
      --concurrent int     number of parallel load test runs (default 1)
      --debug              debug
      --duration string    load test running duration (default "10sec")
      --fail-fast          fail fast
      --grpc-no-tls        disable TLS use in all gRPC runners
  -h, --help               help for loadt
      --overlay strings    overlay values on the runbook
      --parallel string    parallelize runs of runbooks ("on","off",N) (default "off")
      --runner strings     set runner to runbook ("key:dsn")
      --sample int         run the specified number of runbooks at random
      --shuffle string     randomize the order of running runbooks ("on","off",N) (default "off")
      --skip-included      skip running the included step by itself
      --skip-test          skip "test:" section
      --underlay strings   lay values under the runbook
      --var strings        set var to runbook ("key:value")
      --warm-up string     warn-up time for load test (default "5sec")
```