### PR TITLE
Add Chrominium to Docker image for supporting CDP

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -90,3 +90,19 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ steps.latest_version.outputs.version }}
             org.opencontainers.image.source=https://github.com/k1LoW/runn
+
+      - name: Build and push (slim)
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.slim
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/k1low/runn:latest-slim
+            ghcr.io/k1low/runn:${{ steps.latest_version.outputs.version }}-slim
+          labels: |
+            org.opencontainers.image.name=runn
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.latest_version.outputs.version }}
+            org.opencontainers.image.source=https://github.com/k1LoW/runn

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -11,11 +11,6 @@ RUN make build
 
 FROM debian:bullseye-slim
 
-RUN apt-get update \
-    && apt-get install -y chromium \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /workdir/runn ./usr/bin
 


### PR DESCRIPTION
```console
$ docker build . -t runn-test
$ docker container run -it --rm --name test -v $PWD/testdata/book:/books runn-test run books/pkg_go_dev.yml
Test using CDP ... ok

1 scenario, 0 skipped, 0 failures
```