### PR TITLE
Add `input` `secret` `select` to built-in function for interactive input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1322,6 +1322,9 @@ See [Language Definition](https://github.com/antonmedv/expr/blob/master/docs/Lan
 - `bool` ... [cast.ToBool](https://pkg.go.dev/github.com/spf13/cast#ToBool)
 - `compare` ... Compare two values ( `func(x, y interface{}, ignoreKeys ...string) bool` ).
 - `diff` ... Difference between two values ( `func(x, y interface{}, ignoreKeys ...string) string` ).
+- `input` ... [prompter.Prompt](https://pkg.go.dev/github.com/Songmu/prompter#Prompt)
+- `secret` ... [prompter.Password](https://pkg.go.dev/github.com/Songmu/prompter#Password)
+- `select` ... [prompter.Choose](https://pkg.go.dev/github.com/Songmu/prompter#Choose)
 
 ## Option
 

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,12 @@ go 1.19
 
 require (
 	github.com/Songmu/axslogparser v1.4.0
+	github.com/Songmu/prompter v0.5.1
 	github.com/ajg/form v1.5.1
 	github.com/antonmedv/expr v1.9.0
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/bmatcuk/doublestar/v4 v4.2.0
+	github.com/chromedp/cdproto v0.0.0-20220924210414-0e3390be1777
 	github.com/chromedp/chromedp v0.8.6
 	github.com/cli/safeexec v1.0.0
 	github.com/fatih/color v1.13.0
@@ -54,7 +56,6 @@ require (
 	github.com/Songmu/go-ltsv v0.1.0 // indirect
 	github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
-	github.com/chromedp/cdproto v0.0.0-20220924210414-0e3390be1777 // indirect
 	github.com/chromedp/sysutil v1.0.0 // indirect
 	github.com/containerd/continuity v0.3.0 // indirect
 	github.com/docker/cli v20.10.14+incompatible // indirect
@@ -98,6 +99,7 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	golang.org/x/net v0.1.0 // indirect
 	golang.org/x/sys v0.1.0 // indirect
+	golang.org/x/term v0.1.0 // indirect
 	golang.org/x/text v0.4.0 // indirect
 	golang.org/x/tools v0.2.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/Songmu/axslogparser v1.4.0/go.mod h1:tAOlIWRn5Y5tLfZ4zlAdbkvrx21Jmu7S
 github.com/Songmu/go-ltsv v0.0.0-20181014062614-c30af2b7b171/go.mod h1:LBP+tS9C2iiUoR7AGPaZYY+kjXgB5eZxZKbSEBL9UFw=
 github.com/Songmu/go-ltsv v0.1.0 h1:veR1K9TBM0PiGpxKobcJg78uiZw/FPlStpgnCHe+4tQ=
 github.com/Songmu/go-ltsv v0.1.0/go.mod h1:s3gHTN5/CPDucnCAJxoFg35cXGk+X/b04pg627Kksi0=
+github.com/Songmu/prompter v0.5.1 h1:IAsttKsOZWSDw7bV1mtGn9TAmLFAjXbp9I/eYmUUogo=
+github.com/Songmu/prompter v0.5.1/go.mod h1:CS3jEPD6h9IaLaG6afrl1orTgII9+uDWuw95dr6xHSw=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -490,6 +492,8 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.1.0 h1:g6Z6vPFA9dYBAF7DWcH6sCcOntplXsDKcliusYijMlw=
+golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/option.go
+++ b/option.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Songmu/prompter"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/k1LoW/runn/builtin"
 	"github.com/spf13/cast"
@@ -592,6 +593,19 @@ func setupBuiltinFunctions(opts ...Option) []Option {
 		Func("time", builtin.Time),
 		Func("compare", builtin.Compare),
 		Func("diff", builtin.Diff),
+		Func("input", func(msg, defaultMsg interface{}) string {
+			return prompter.Prompt(cast.ToString(msg), cast.ToString(defaultMsg))
+		}),
+		Func("secret", func(msg interface{}) string {
+			return prompter.Password(cast.ToString(msg))
+		}),
+		Func("select", func(msg interface{}, list []interface{}, defaultSelect interface{}) string {
+			choices := []string{}
+			for _, v := range list {
+				choices = append(choices, cast.ToString(v))
+			}
+			return prompter.Choose(cast.ToString(msg), choices, cast.ToString(defaultSelect))
+		}),
 	},
 		opts...,
 	)


### PR DESCRIPTION
ref: #296 

```console
$ cat prompt.yml
desc: Prompt
steps:
  -
    bind:
      twitterID: input("Enter your twitter ID", "default")
  -
    dump: twitterID
$ go run ./cmd/runn/main.go run prompt.yml
Enter your twitter ID [default]: k1LoW
k1LoW
Prompt ... ok

1 scenario, 0 skipped, 0 failures
```