### PR TITLE
Removed reset process for request Body for temporary support

### DIFF
--- a/http.go
+++ b/http.go
@@ -257,6 +257,10 @@ func (rnr *httpRunner) Run(ctx context.Context, r *httpRequest) error {
 			return err
 		}
 		// reset Request.Body
+		reqBody, err := r.encodeBody()
+		if err != nil {
+			return err
+		}
 		rc, ok := reqBody.(io.ReadCloser)
 		if !ok && reqBody != nil {
 			rc = io.NopCloser(reqBody)

--- a/http.go
+++ b/http.go
@@ -227,10 +227,6 @@ func (rnr *httpRunner) Run(ctx context.Context, r *httpRequest) error {
 	if err != nil {
 		return err
 	}
-	cl, err := io.Copy(io.Discard, reqBody)
-	if err != nil {
-		return err
-	}
 
 	var (
 		req *http.Request
@@ -266,6 +262,10 @@ func (rnr *httpRunner) Run(ctx context.Context, r *httpRequest) error {
 			rc = io.NopCloser(reqBody)
 		}
 		req.Body = rc
+		cl, err := io.Copy(io.Discard, rc)
+		if err != nil {
+			return err
+		}
 		req.ContentLength = cl
 
 		r.setContentTypeHeader(req)

--- a/http.go
+++ b/http.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -228,7 +227,7 @@ func (rnr *httpRunner) Run(ctx context.Context, r *httpRequest) error {
 	if err != nil {
 		return err
 	}
-	cl, err := io.Copy(ioutil.Discard, reqBody)
+	cl, err := io.Copy(io.Discard, reqBody)
 	if err != nil {
 		return err
 	}

--- a/http.go
+++ b/http.go
@@ -253,8 +253,17 @@ func (rnr *httpRunner) Run(ctx context.Context, r *httpRequest) error {
 		if err := rnr.validator.ValidateRequest(ctx, req); err != nil {
 			return err
 		}
-		// reset ContentLength
+		// reset Request.Body
+		reqBody, err := r.encodeBody()
+		if err != nil {
+			return err
+		}
+		rc, ok := reqBody.(io.ReadCloser)
+		if !ok && reqBody != nil {
+			rc = io.NopCloser(reqBody)
+		}
 		req.ContentLength = int64(br.Len())
+		req.Body = rc
 
 		r.setContentTypeHeader(req)
 		for k, v := range r.headers {

--- a/http.go
+++ b/http.go
@@ -252,16 +252,6 @@ func (rnr *httpRunner) Run(ctx context.Context, r *httpRequest) error {
 		if err := rnr.validator.ValidateRequest(ctx, req); err != nil {
 			return err
 		}
-		// reset Request.Body
-		reqBody, err := r.encodeBody()
-		if err != nil {
-			return err
-		}
-		rc, ok := reqBody.(io.ReadCloser)
-		if !ok && reqBody != nil {
-			rc = io.NopCloser(reqBody)
-		}
-		req.Body = rc
 
 		r.setContentTypeHeader(req)
 		for k, v := range r.headers {

--- a/http_validator.go
+++ b/http_validator.go
@@ -177,7 +177,6 @@ func (v *openApi3Validator) responseInput(req *http.Request, res *http.Response)
 		if err != nil {
 			return nil, err
 		}
-		req.ContentLength = int64(len(b))
 		res.Body = io.NopCloser(bytes.NewBuffer(b))
 		body = io.NopCloser(bytes.NewBuffer(b))
 	}

--- a/http_validator.go
+++ b/http_validator.go
@@ -178,6 +178,7 @@ func (v *openApi3Validator) responseInput(req *http.Request, res *http.Response)
 			return nil, err
 		}
 		res.Body = io.NopCloser(bytes.NewBuffer(b))
+		req.ContentLength = int64(len(b))
 		body = io.NopCloser(bytes.NewBuffer(b))
 	}
 	return &openapi3filter.ResponseValidationInput{

--- a/http_validator.go
+++ b/http_validator.go
@@ -177,8 +177,8 @@ func (v *openApi3Validator) responseInput(req *http.Request, res *http.Response)
 		if err != nil {
 			return nil, err
 		}
-		res.Body = io.NopCloser(bytes.NewBuffer(b))
 		req.ContentLength = int64(len(b))
+		res.Body = io.NopCloser(bytes.NewBuffer(b))
 		body = io.NopCloser(bytes.NewBuffer(b))
 	}
 	return &openapi3filter.ResponseValidationInput{


### PR DESCRIPTION
# Triggers for Change

https://github.com/k1LoW/runn/releases/tag/v0.51.0

The previously addressed issue has reappeared in the above version.

https://github.com/k1LoW/runn/pull/91

The following library versions have changed due to the pkgs update

github.com/getkin/kin-openapi@v0.106.0 -> github.com/getkin/kin-openapi@v0.109.0

The contents of the release are as follows
https://github.com/getkin/kin-openapi/releases/tag/v0.109.0

# What we verified

1. If `skipValidateRequest: false`, no error occurred
2. Downgraded to `github.com/getkin/kin-openapi@v0.108.0` version and no more errors

# Cause Considerations

We believe the error recurred due to the following PR
https://github.com/getkin/kin-openapi/pull/672

The request body reset process in #91 is no longer needed due to modifications to the library itself.
On the contrary, the inclusion of provisional support seems to have caused the content length to be caught in the content length check.

# Changes

Deleted the process supported by #91 
My project is working well with this response.

# Worries

There may be an impact on the functionality of Multipart Form Data