### PR TITLE
Prefer step desc if exist in debug printing

### DIFF
--- a/debugger_test.go
+++ b/debugger_test.go
@@ -72,3 +72,40 @@ func TestDebugger(t *testing.T) {
 		})
 	}
 }
+
+func TestDebuggerWithStderr(t *testing.T) {
+	tests := []struct {
+		book string
+	}{
+		{"testdata/book/step_by_step_desc.yml"},
+	}
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.book, func(t *testing.T) {
+			out := new(bytes.Buffer)
+			opts := []Option{
+				Book(tt.book),
+				Stderr(out),
+			}
+			o, err := New(opts...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := o.Run(ctx); err != nil {
+				t.Error(err)
+			}
+
+			got := out.String()
+
+			f := fmt.Sprintf("%s.debugger", filepath.Base(tt.book))
+			if os.Getenv("UPDATE_GOLDEN") != "" {
+				golden.Update(t, "testdata", f, got)
+				return
+			}
+
+			if diff := golden.Diff(t, "testdata", f, got); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/operator.go
+++ b/operator.go
@@ -695,7 +695,9 @@ func (o *operator) runInternal(ctx context.Context) (rerr error) {
 					return nil
 				}
 			}
-			if s.runnerKey != "" {
+			if s.desc != "" {
+				o.Debugf(cyan("Run '%s' on %s\n"), s.desc, o.stepName(i))
+			} else if s.runnerKey != "" {
 				o.Debugf(cyan("Run '%s' on %s\n"), s.runnerKey, o.stepName(i))
 			}
 

--- a/testdata/book/step_by_step_desc.yml
+++ b/testdata/book/step_by_step_desc.yml
@@ -1,0 +1,15 @@
+desc: Exec test with desc
+debug: true
+steps:
+  -
+    desc: 'Print "hello world!!"'
+    exec:
+      command: echo hello world!!
+  -
+    desc: 'Print "hello world!!" again'
+    exec:
+      command: cat
+      stdin: '{{ steps[0].stdout }}'
+  -
+    desc: 'Check result of previous command contains "hello"'
+    test: 'steps[1].stdout contains "hello"'

--- a/testdata/step_by_step_desc.yml.debugger.golden
+++ b/testdata/step_by_step_desc.yml.debugger.golden
@@ -1,0 +1,28 @@
+Run 'Print "hello world!!"' on 'Exec test with desc'.steps[0]
+-----START COMMAND-----
+echo hello world!!
+-----END COMMAND-----
+-----START STDOUT-----
+hello world!!
+
+-----END STDOUT-----
+-----START STDERR-----
+
+-----END STDERR-----
+
+Run 'Print "hello world!!" again' on 'Exec test with desc'.steps[1]
+-----START COMMAND-----
+cat
+-----END COMMAND-----
+-----START STDIN-----
+hello world!!
+-----END STDIN-----
+-----START STDOUT-----
+hello world!!
+-----END STDOUT-----
+-----START STDERR-----
+
+-----END STDERR-----
+
+Run 'Check result of previous command contains "hello"' on 'Exec test with desc'.steps[2]
+Run 'test' on 'Exec test with desc'.steps[2]


### PR DESCRIPTION
Hello, thanks to great tool.

I've modified debug printing uses description for step if exists.

For example, there is a scenario file like below:
```yml
desc: 'A scenario file which has step by step desc'
steps:
  -
    desc: 'Print "hello world!!"'
    exec:
      command: echo hello world!!
  -
    desc: 'Print "hello world!!" again'
    exec:
      command: cat
      stdin: '{{ steps[0].stdout }}'
  -
    desc: 'Check result of previous command contains "hello"'
    test: 'steps[1].stdout contains "hello"'
```

Currently `runn --debug` prints like follows:
```console
Run 'exec' on 'Exec test'.steps[0] # <--- 🤔 
-----START COMMAND-----
echo hello world!!
-----END COMMAND-----
-----START STDOUT-----
hello world!!

-----END STDOUT-----
...
```

And now `runn --debug` prints debug info with step's description like follows:
```console
Run 'printing "hello world"' on 'Exec test'.steps[0]
-----START COMMAND-----
echo hello world!!
-----END COMMAND-----
-----START STDOUT-----
hello world!!

-----END STDOUT-----
...
```