### PR TITLE
Add `--threshold` option for checking result of loadt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1583,6 +1583,66 @@ or
 $ runn run path/to/**/*.yml --capture path/to/dir
 ```
 
+## Load test using runbooks
+
+You can use the `runn loadt` command for load testing using runbooks.
+
+``` console
+$ runn loadt --concurrent 2 path/to/*.yml
+
+Number of runbooks per RunN...: 15
+Warm up time (--warm-up)......: 5s
+Duration (--duration).........: 10s
+Concurrent (--concurrent).....: 2
+
+Total.........................: 12
+Succeeded.....................: 12
+Failed........................: 0
+Error rate....................: 0%
+RunN per seconds..............: 1.2
+Latency ......................: max=1,835.1ms min=1,451.3ms avg=1,627.8ms med=1,619.8ms p(90)=1,741.5ms p(99)=1,788.4ms
+
+```
+
+It also checks the results of the load test with the `--threshold` option. If the condition is not met, it returns exit status 1.
+
+``` console
+$ runn loadt --concurrent 2 --threshold 'error_rate < 10' path/to/*.yml
+
+Number of runbooks per RunN...: 15
+Warm up time (--warm-up)......: 5s
+Duration (--duration).........: 10s
+Concurrent (--concurrent).....: 2
+
+Total.........................: 13
+Succeeded.....................: 12
+Failed........................: 1
+Error rate....................: 7.6%
+RunN per seconds..............: 1.3
+Latency ......................: max=1,790.2ms min=95.0ms avg=1,541.4ms med=1,640.4ms p(90)=1,749.7ms p(99)=1,786.5ms
+
+Error: (error_rate < 10) is not true
+error_rate < 10
+├── error_rate => 14.285714285714285
+└── 10 => 10
+```
+
+### Variables for threshold
+
+| Variable name | Type | Description |
+| --- | --- | --- |
+| `total` | `int` | Total |
+| `succeeded` | `int` | Succeeded |
+| `failed` | `int` | Failed |
+| `error_rate` | `float` | Error rate |
+| `rps` | `float` | RunN per seconds |
+| `max` | `float` | Latency (max) |
+| `mid` | `float` | Latency (mid) |
+| `min` | `float` | Latency (min) |
+| `p90` | `float` | Latency (p(90)) |
+| `p99` | `float` | Latency (p(99)) |
+| `avg` | `float` | Latency (avg) |
+
 ## Install
 
 ### As a CLI tool

--- a/cmd/loadt.go
+++ b/cmd/loadt.go
@@ -104,7 +104,9 @@ var loadtCmd = &cobra.Command{
 			return err
 		}
 		cmd.Println(rep)
-
+		if err := runn.CheckThreshold(flgs.LoadTThreshold, d, ot.Result); err != nil {
+			return err
+		}
 		return nil
 	},
 }
@@ -131,4 +133,5 @@ func init() {
 	loadtCmd.Flags().IntVarP(&flgs.LoadTConcurrent, "concurrent", "", 1, flgs.Usage("LoadTConcurrent"))
 	loadtCmd.Flags().StringVarP(&flgs.LoadTDuration, "duration", "", "10sec", flgs.Usage("LoadTDuration"))
 	loadtCmd.Flags().StringVarP(&flgs.LoadTWarmUp, "warm-up", "", "5sec", flgs.Usage("LoadTWarmUp"))
+	loadtCmd.Flags().StringVarP(&flgs.LoadTThreshold, "threshold", "", "", flgs.Usage("LoadTThreshold"))
 }

--- a/eval.go
+++ b/eval.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/antonmedv/expr"
 	"github.com/antonmedv/expr/ast"
@@ -13,6 +14,7 @@ import (
 	"github.com/goccy/go-json"
 	"github.com/goccy/go-yaml"
 	"github.com/k1LoW/expand"
+	or "github.com/ryo-yamaoka/otchkiss/result"
 	"github.com/xlab/treeprint"
 )
 
@@ -91,6 +93,70 @@ func EvalExpand(in, store interface{}) (interface{}, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+func CheckThreshold(threshold string, d time.Duration, r *or.Result) error {
+	if threshold == "" {
+		return nil
+	}
+	succeeded := r.Succeeded()
+	failed := r.Failed()
+	total := succeeded + failed
+
+	max, err := r.PercentileLatency(100)
+	if err != nil {
+		return err
+	}
+	min, err := r.PercentileLatency(0)
+	if err != nil {
+		return err
+	}
+	p99, err := r.PercentileLatency(99)
+	if err != nil {
+		return err
+	}
+	p90, err := r.PercentileLatency(90)
+	if err != nil {
+		return err
+	}
+	p50, err := r.PercentileLatency(50)
+	if err != nil {
+		return err
+	}
+
+	ll := r.Latencies()
+	var avg float64
+	for _, l := range ll {
+		avg += l
+	}
+	avg = avg / float64(len(ll))
+
+	store := map[string]interface{}{
+		"total":      total,
+		"succeeded":  succeeded,
+		"failed":     failed,
+		"error_rate": float64(failed) / float64(total) * 100,
+		"rps":        float64(total) / d.Seconds(),
+		"max":        max * 1000,
+		"mid":        p50 * 1000,
+		"min":        min * 1000,
+		"p90":        p90 * 1000,
+		"p99":        p99 * 1000,
+		"avg":        avg * 1000,
+	}
+
+	tf, err := EvalCond(threshold, store)
+	if err != nil {
+		return err
+	}
+	if !tf {
+		bt, err := buildTree(threshold, store)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("(%s) is not true\n%s", threshold, bt)
+	}
+	return nil
 }
 
 func buildTree(cond string, store interface{}) (string, error) {

--- a/eval_test.go
+++ b/eval_test.go
@@ -1,10 +1,13 @@
 package runn
 
 import (
+	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	or "github.com/ryo-yamaoka/otchkiss/result"
 )
 
 func TestBuildTree(t *testing.T) {
@@ -199,6 +202,42 @@ func TestTrimComment(t *testing.T) {
 			got := trimComment(tt.in)
 			if diff := cmp.Diff(got, tt.want, nil); diff != "" {
 				t.Errorf("%s", diff)
+			}
+		})
+	}
+}
+
+func TestCheckThreshold(t *testing.T) {
+	tests := []struct {
+		threshold string
+		wantErr   bool
+	}{
+		{"", false},
+		{"succeeded > 10", false},
+		{"failed < 10", true},
+		{"error_rate < 33", true},
+	}
+
+	r := &or.Result{}
+	for i := 0; i < 100; i++ {
+		r.AppendSuccess(1)
+	}
+	for i := 0; i < 50; i++ {
+		r.AppendFail(1, errors.New("fail"))
+	}
+	d := time.Second
+
+	for _, tt := range tests {
+		t.Run(tt.threshold, func(t *testing.T) {
+			err := CheckThreshold(tt.threshold, d, r)
+			if err != nil {
+				if tt.wantErr {
+					return
+				}
+				t.Errorf("got err: %s", err)
+			}
+			if tt.wantErr {
+				t.Error("want error")
 			}
 		})
 	}

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -42,6 +42,7 @@ type Flags struct {
 	LoadTConcurrent int      `usage:"number of parallel load test runs"`
 	LoadTDuration   string   `usage:"load test running duration"`
 	LoadTWarmUp     string   `usage:"warn-up time for load test"`
+	LoadTThreshold  string   `usage:"if this threshold condition is not met, loadt command returns exit status 1 (EXIT_FAILURE)"`
 	Profile         bool     `usage:"profile runs of runbooks"`
 	ProfileOut      string   `usage:"profile output path"`
 	ProfileDepth    int      `usage:"depth of profile"`


### PR DESCRIPTION
Fix #374 

## Usage 

```console
$ runn loadt --concurrent 2 --threshold 'error_rate < 20' path/to/*.yml
```