### PR TITLE
Print step description on failure if available

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -831,7 +831,11 @@ func (o *operator) runInternal(ctx context.Context) (rerr error) {
 					}
 					o.Debugf(cyan("Run '%s' on %s\n"), testRunnerKey, o.stepName(i))
 					if err := s.testRunner.Run(ctx, s.testCond); err != nil {
-						return fmt.Errorf("test failed on %s: %v", o.stepName(i), err)
+						if s.desc != "" {
+							return fmt.Errorf("test failed on %s '%s': %v", o.stepName(i), s.desc, err)
+						} else {
+							return fmt.Errorf("test failed on %s: %v", o.stepName(i), err)
+						}
 					}
 					if !run {
 						run = true
@@ -932,12 +936,14 @@ func (o *operator) testName() string {
 
 func (o *operator) stepName(i int) string {
 	var prefix string
+
 	if o.store.loopIndex != nil {
 		prefix = fmt.Sprintf(".loop[%d]", *o.store.loopIndex)
 	}
 	if o.useMap {
 		return fmt.Sprintf("'%s'.steps.%s%s", o.desc, o.steps[i].key, prefix)
 	}
+
 	return fmt.Sprintf("'%s'.steps[%d]%s", o.desc, i, prefix)
 }
 

--- a/operator_test.go
+++ b/operator_test.go
@@ -810,6 +810,37 @@ func TestLoop(t *testing.T) {
 	}
 }
 
+func TestFailWithStepDesc(t *testing.T) {
+	tests := []struct {
+		book              string
+		expectedSubString string
+	}{
+		{
+			book:              "testdata/book/failure_with_step_desc.yml",
+			expectedSubString: "this is description",
+		},
+	}
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.book, func(t *testing.T) {
+			out := new(bytes.Buffer)
+			opts := []Option{
+				Book(tt.book),
+				Stderr(out),
+			}
+			o, err := New(opts...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = o.Run(ctx)
+
+			if !strings.Contains(err.Error(), tt.expectedSubString) {
+				t.Errorf("expected: \"%s\" is contained in result but not.\ngot string: %s", tt.expectedSubString, err.Error())
+			}
+		})
+	}
+}
+
 func newRunNResult(t *testing.T, total int64, results map[string]result) *runNResult {
 	r := &runNResult{}
 	r.Total.Store(total)

--- a/testdata/book/failure_with_step_desc.yml
+++ b/testdata/book/failure_with_step_desc.yml
@@ -1,0 +1,5 @@
+desc: Always failure scenario with step desc
+steps:
+  -
+    desc: 'this is description'
+    test: 'false'


### PR DESCRIPTION
Currently, the step descriptions do not seem to be printed when a scenario fails.
I think this PR will be useful for identifying the step that caused the failure more quickly when the number of steps is large or the scenario has high complexity.

before: 
```console
$ runn run testdata/book/failure_with_step_desc.yml
Always failure scenario with step desc ... failed to run testdata/book/failure_with_step_desc.yml: test failed on 'Always failure scenario with step desc'.steps[0]: (false) is not true
false
└── false => false


1 scenario, 0 skipped, 1 failure
```

after:
```console
$ runn run testdata/book/failure_with_step_desc.yml 
Always failure scenario with step desc ... failed to run testdata/book/failure_with_step_desc.yml: test failed on 'Always failure scenario with step desc'.steps[0] 'this is description': (false) is not true
false
└── false => false


1 scenario, 0 skipped, 1 failure
```

### Special note

The formatting of output may need some tidying up 🤔 