### PR TITLE
Implement intersect function

### DIFF
--- a/builtin/intersect.go
+++ b/builtin/intersect.go
@@ -1,0 +1,7 @@
+package builtin
+
+import "github.com/juliangruber/go-intersect"
+
+func Intersect(x, y interface{}) interface{} {
+	return intersect.Simple(x, y)
+}

--- a/builtin/intersect_test.go
+++ b/builtin/intersect_test.go
@@ -1,0 +1,26 @@
+package builtin
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestIntersect(t *testing.T) {
+	tests := []struct {
+		x    interface{}
+		y    interface{}
+		want interface{}
+	}{
+		{[]int{1, 2}, []int{1, 2, 3}, []any{int(1), int(2)}},
+		{[]int{1, 2, 3}, []int{1, 2, 3}, []any{int(1), int(2), int(3)}},
+		{[]int{1, 2, 3, 4}, []int{1, 2, 3}, []any{int(1), int(2), int(3)}},
+		{[]string{"a", "b"}, []string{"b", "c", "d"}, []any{string("b")}},
+	}
+	for _, tt := range tests {
+		got := Intersect(tt.x, tt.y)
+		if diff := cmp.Diff(got, tt.want); diff != "" {
+			t.Errorf("%s", diff)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/josharian/mapfs v0.0.0-20210615234106-095c008854e6 // indirect
 	github.com/josharian/txtarfs v0.0.0-20210615234325-77aca6df5bca // indirect
+	github.com/juliangruber/go-intersect v1.1.0 // indirect
 	github.com/k1LoW/go-github-client/v48 v48.2.3 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/lestrrat-go/option v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,7 @@ github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhP
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=
 github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=
 github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251 h1:k6UDF1uPYOs0iy1HPeotNa155qXRWrzKnqAaGXHLZCE=
 github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251/go.mod h1:gbPR1gPu9dB96mucYIR7T3B7p/78hRVSOuzIWLHK2Y4=
 github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=
@@ -235,6 +236,8 @@ github.com/josharian/txtarfs v0.0.0-20210615234325-77aca6df5bca h1:a8xeK4GsWLE4L
 github.com/josharian/txtarfs v0.0.0-20210615234325-77aca6df5bca/go.mod h1:UbC32ft9G/jG+sZI8wLbIBNIrYr7vp/yqMDa9SxVBNA=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/juliangruber/go-intersect v1.1.0 h1:sc+y5dCjMMx0pAdYk/N6KBm00tD/f3tq+Iox7dYDUrY=
+github.com/juliangruber/go-intersect v1.1.0/go.mod h1:WMau+1kAmnlQnKiikekNJbtGtfmILU/mMU6H7AgKbWQ=
 github.com/k1LoW/curlreq v0.3.2 h1:EpFL5X9WiMv2y/CrSeitITEbwCGeaHbquV3pPpDhtz4=
 github.com/k1LoW/curlreq v0.3.2/go.mod h1:kh0wTrg3kahGoGnAREXK5gYOcTXW7W/TnL8qbHe5Ppc=
 github.com/k1LoW/duration v1.2.0 h1:qq1gWtPh7YROFyerBufVP+ATR11mOOHDInrcC/Xe/6A=
@@ -266,6 +269,7 @@ github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/option.go
+++ b/option.go
@@ -759,6 +759,7 @@ func setupBuiltinFunctions(opts ...Option) []Option {
 		Func("time", builtin.Time),
 		Func("compare", builtin.Compare),
 		Func("diff", builtin.Diff),
+		Func("intersect", builtin.Intersect),
 		Func("input", func(msg, defaultMsg interface{}) string {
 			return prompter.Prompt(cast.ToString(msg), cast.ToString(defaultMsg))
 		}),

--- a/option_test.go
+++ b/option_test.go
@@ -873,6 +873,8 @@ func TestSetupBuiltinFunctions(t *testing.T) {
 		{"bool"},
 		{"time"},
 		{"compare"},
+		{"diff"},
+		{"intersect"},
 		{"sprintf"},
 	}
 	opt := Func("sprintf", fmt.Sprintf)


### PR DESCRIPTION
Background: https://github.com/k1LoW/runn/issues/409#issuecomment-1423742426

I have decided to return intersected array instead of boolean, because that would be more flexible. 

test.yaml
```yaml
desc: intersect
vars:
  v1: [1, 2, 3]
  v2: [2, 3, 4]
steps:
  a:
    test: 2 in intersect(vars.v1, vars.v2)
  b:
    test: 3 in intersect(vars.v1, vars.v2)
  c:
    test: 4 in intersect(vars.v1, vars.v2)
```
result
```
intersect ... failed to run intersect.yaml: test failed on 'intersect'.steps.c: (4 in intersect(vars.v1, vars.v2)) is not true
4 in intersect(vars.v1, vars.v2)
├── 4 => 4
├── intersect(vars.v1, vars.v2) => [2,3]
├── vars.v1 => [1,2,3]
└── vars.v2 => [2,3,4]


1 scenario, 0 skipped, 1 failure
```