### PR TITLE
Fixing goreleaser deprecated

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,6 +46,7 @@ archives:
       - CREDITS
       - README.md
       - CHANGELOG.md
+    rlcp: true
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,6 @@ prerelease_for_tagpr:
 
 release:
 	git push origin main --tag
-	goreleaser --rm-dist
+	goreleaser --clean
 
 .PHONY: default test


### PR DESCRIPTION
Some DEPRECATED messages were being output when running goreleaser.
https://github.com/k1LoW/runn/actions/runs/4149255449/jobs/7178039915#step:5:13
https://github.com/k1LoW/runn/actions/runs/4149255449/jobs/7178039915#step:5:20