### PR TITLE
The values of `runners:` and `vars:` in the included runbook accept variables from the parent runbook.

### DIFF
--- a/option.go
+++ b/option.go
@@ -28,50 +28,11 @@ type Option func(*book) error
 // Book - Load runbook.
 func Book(path string) Option {
 	return func(bk *book) error {
-		loaded, err := LoadBook(path)
+		loaded, err := loadBook(path, nil)
 		if err != nil {
 			return err
 		}
-		bk.path = loaded.path
-		bk.desc = loaded.desc
-		bk.ifCond = loaded.ifCond
-		bk.useMap = loaded.useMap
-		for k, r := range loaded.runners {
-			bk.runners[k] = r
-		}
-		for k, r := range loaded.httpRunners {
-			bk.httpRunners[k] = r
-		}
-		for k, r := range loaded.dbRunners {
-			bk.dbRunners[k] = r
-		}
-		for k, r := range loaded.grpcRunners {
-			bk.grpcRunners[k] = r
-		}
-		for k, r := range loaded.cdpRunners {
-			bk.cdpRunners[k] = r
-		}
-		for k, r := range loaded.sshRunners {
-			bk.sshRunners[k] = r
-		}
-		for k, v := range loaded.vars {
-			bk.vars[k] = v
-		}
-		bk.runnerErrs = loaded.runnerErrs
-		bk.rawSteps = loaded.rawSteps
-		bk.stepKeys = loaded.stepKeys
-		if !bk.debug {
-			bk.debug = loaded.debug
-		}
-		if !bk.skipTest {
-			bk.skipTest = loaded.skipTest
-		}
-		bk.loop = loaded.loop
-		bk.grpcNoTLS = loaded.grpcNoTLS
-		if loaded.intervalStr != "" {
-			bk.interval = loaded.interval
-		}
-		return nil
+		return bk.merge(loaded)
 	}
 }
 
@@ -81,7 +42,7 @@ func Overlay(path string) Option {
 		if len(bk.rawSteps) == 0 {
 			return errors.New("overlays are unusable without its base runbook")
 		}
-		loaded, err := LoadBook(path)
+		loaded, err := loadBook(path, nil)
 		if err != nil {
 			return err
 		}
@@ -133,7 +94,7 @@ func Underlay(path string) Option {
 		if len(bk.rawSteps) == 0 {
 			return errors.New("underlays are unusable without its base runbook")
 		}
-		loaded, err := LoadBook(path)
+		loaded, err := loadBook(path, nil)
 		if err != nil {
 			return err
 		}
@@ -755,6 +716,17 @@ func Stderr(w io.Writer) Option {
 	return func(bk *book) error {
 		bk.stderr = w
 		return nil
+	}
+}
+
+// bookWithStore - Load runbook with store
+func bookWithStore(path string, store map[string]interface{}) Option {
+	return func(bk *book) error {
+		loaded, err := loadBook(path, store)
+		if err != nil {
+			return err
+		}
+		return bk.merge(loaded)
 	}
 }
 

--- a/option.go
+++ b/option.go
@@ -816,6 +816,13 @@ func runnGrpcRunner(name string, r *grpcRunner) Option {
 	}
 }
 
+func runnSSHRunner(name string, r *sshRunner) Option {
+	return func(bk *book) error {
+		bk.sshRunners[name] = r
+		return nil
+	}
+}
+
 var (
 	AsTestHelper = T
 	Runbook      = Book

--- a/testdata/book/use_parent_store_runners.yml
+++ b/testdata/book/use_parent_store_runners.yml
@@ -1,0 +1,11 @@
+desc: Use parent store vars
+if: included
+runners:
+  req: '{{ parent.vars.httprunner }}'
+steps:
+  -
+    req:
+      /get:
+        get:
+          body: null
+    test: current.res.status == 200

--- a/testdata/book/use_parent_store_vars.yml
+++ b/testdata/book/use_parent_store_vars.yml
@@ -1,0 +1,7 @@
+desc: Use parent store vars
+if: included
+vars:
+  baz: '{{ parent.vars.foo }}'
+steps:
+  -
+    test: vars.baz == 'bar'

--- a/vars.go
+++ b/vars.go
@@ -15,33 +15,35 @@ const varsSupportScheme string = "json://"
 func evaluateSchema(value interface{}, operationRoot string, store map[string]interface{}) (interface{}, error) {
 	switch v := value.(type) {
 	case string:
-		if strings.HasPrefix(v, varsSupportScheme) {
-			fn := v[len(varsSupportScheme):]
-			if operationRoot != "" {
-				fn = filepath.Join(operationRoot, fn)
-			}
-			byteArray, err := readFile(fn)
-			if err != nil {
-				return value, fmt.Errorf("read external files error: %w", err)
-			}
-			if store != nil && strings.HasSuffix(fn, ".json.template") {
-				tmpl, err := template.New(fn).Parse(string(byteArray))
-				if err != nil {
-					return value, fmt.Errorf("template parse error: %w", err)
-				}
-				buf := new(bytes.Buffer)
-				if err := tmpl.Execute(buf, store); err != nil {
-					return value, fmt.Errorf("template excute error: %w", err)
-				}
-				byteArray = buf.Bytes()
-			}
-			var jsonObj interface{}
-			if err := json.Unmarshal(byteArray, &jsonObj); err != nil {
-				return value, fmt.Errorf("unmarshal error: %w", err)
-			}
-
-			return jsonObj, nil
+		if !strings.HasPrefix(v, varsSupportScheme) {
+			return value, nil
 		}
+		// json://
+		fn := v[len(varsSupportScheme):]
+		if operationRoot != "" {
+			fn = filepath.Join(operationRoot, fn)
+		}
+		byteArray, err := readFile(fn)
+		if err != nil {
+			return value, fmt.Errorf("read external files error: %w", err)
+		}
+		if store != nil && strings.HasSuffix(fn, ".json.template") {
+			tmpl, err := template.New(fn).Parse(string(byteArray))
+			if err != nil {
+				return value, fmt.Errorf("template parse error: %w", err)
+			}
+			buf := new(bytes.Buffer)
+			if err := tmpl.Execute(buf, store); err != nil {
+				return value, fmt.Errorf("template excute error: %w", err)
+			}
+			byteArray = buf.Bytes()
+		}
+		var jsonObj interface{}
+		if err := json.Unmarshal(byteArray, &jsonObj); err != nil {
+			return value, fmt.Errorf("unmarshal error: %w", err)
+		}
+
+		return jsonObj, nil
 	}
 
 	return value, nil


### PR DESCRIPTION
Fix #442 