### PR TITLE
Add `concurrency:` for ensuring that only a single runbook using the same group will run at a time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,14 @@ steps:
 
 - `outcome` ... the result of a completed (`success`, `failure`, `skipped`).
 
+### `concurrency:`
+
+Runbooks with the same key are assured of a single run at the same time.
+
+``` yaml
+concurrency: use-shared-db
+```
+
 ### `steps:`
 
 Steps to run in runbook.

--- a/README.md
+++ b/README.md
@@ -1628,12 +1628,12 @@ $ runn run path/to/**/*.yml --capture path/to/dir
 You can use the `runn loadt` command for load testing using runbooks.
 
 ``` console
-$ runn loadt --concurrent 2 path/to/*.yml
+$ runn loadt --load-concurrent 2 path/to/*.yml
 
 Number of runbooks per RunN...: 15
 Warm up time (--warm-up)......: 5s
 Duration (--duration).........: 10s
-Concurrent (--concurrent).....: 2
+Concurrent (--load-concurrent): 2
 
 Total.........................: 12
 Succeeded.....................: 12
@@ -1647,12 +1647,12 @@ Latency ......................: max=1,835.1ms min=1,451.3ms avg=1,627.8ms med=1,
 It also checks the results of the load test with the `--threshold` option. If the condition is not met, it returns exit status 1.
 
 ``` console
-$ runn loadt --concurrent 2 --threshold 'error_rate < 10' path/to/*.yml
+$ runn loadt --load-concurrent 2 --threshold 'error_rate < 10' path/to/*.yml
 
 Number of runbooks per RunN...: 15
 Warm up time (--warm-up)......: 5s
 Duration (--duration).........: 10s
-Concurrent (--concurrent).....: 2
+Concurrent (--load-concurrent): 2
 
 Total.........................: 13
 Succeeded.....................: 12

--- a/book.go
+++ b/book.go
@@ -38,6 +38,7 @@ type book struct {
 	intervalStr      string
 	interval         time.Duration
 	loop             *Loop
+	concurrency      string
 	useMap           bool
 	t                *testing.T
 	included         bool

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/jhump/protoreflect v1.14.1
 	github.com/juliangruber/go-intersect v1.1.0
+	github.com/k1LoW/concgroup v1.0.0
 	github.com/k1LoW/curlreq v0.3.2
 	github.com/k1LoW/duration v1.2.0
 	github.com/k1LoW/exec v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/juliangruber/go-intersect v1.1.0 h1:sc+y5dCjMMx0pAdYk/N6KBm00tD/f3tq+Iox7dYDUrY=
 github.com/juliangruber/go-intersect v1.1.0/go.mod h1:WMau+1kAmnlQnKiikekNJbtGtfmILU/mMU6H7AgKbWQ=
+github.com/k1LoW/concgroup v1.0.0 h1:iVD/xulNDLsHQwFQ93w8A6QakO6YA2dJLJ6H4M+L2No=
+github.com/k1LoW/concgroup v1.0.0/go.mod h1:cD18DUBcac9rl5mf8aK5MwITLeSoodExDG4dI7vp79k=
 github.com/k1LoW/curlreq v0.3.2 h1:EpFL5X9WiMv2y/CrSeitITEbwCGeaHbquV3pPpDhtz4=
 github.com/k1LoW/curlreq v0.3.2/go.mod h1:kh0wTrg3kahGoGnAREXK5gYOcTXW7W/TnL8qbHe5Ppc=
 github.com/k1LoW/duration v1.2.0 h1:qq1gWtPh7YROFyerBufVP+ATR11mOOHDInrcC/Xe/6A=

--- a/operator_test.go
+++ b/operator_test.go
@@ -526,6 +526,7 @@ func TestShard(t *testing.T) {
 				cmpopts.IgnoreUnexported(ignore...),
 				cmpopts.IgnoreFields(stopw.Span{}, "ID"),
 				cmpopts.IgnoreFields(operator{}, "id"),
+				cmpopts.IgnoreFields(operator{}, "concurrency"),
 				cmpopts.IgnoreFields(cdpRunner{}, "ctx"),
 				cmpopts.IgnoreFields(cdpRunner{}, "cancel"),
 				cmpopts.IgnoreFields(sshRunner{}, "client"),

--- a/option.go
+++ b/option.go
@@ -82,6 +82,7 @@ func Overlay(path string) Option {
 		bk.debug = loaded.debug
 		bk.skipTest = loaded.skipTest
 		bk.loop = loaded.loop
+		bk.concurrency = loaded.concurrency
 		bk.grpcNoTLS = loaded.grpcNoTLS
 		bk.interval = loaded.interval
 		return nil

--- a/runbook.go
+++ b/runbook.go
@@ -16,30 +16,32 @@ import (
 )
 
 type runbook struct {
-	Desc     string                 `yaml:"desc"`
-	Runners  map[string]interface{} `yaml:"runners,omitempty"`
-	Vars     map[string]interface{} `yaml:"vars,omitempty"`
-	Steps    []yaml.MapSlice        `yaml:"steps"`
-	Debug    bool                   `yaml:"debug,omitempty"`
-	Interval string                 `yaml:"interval,omitempty"`
-	If       string                 `yaml:"if,omitempty"`
-	SkipTest bool                   `yaml:"skipTest,omitempty"`
-	Loop     interface{}            `yaml:"loop,omitempty"`
+	Desc        string                 `yaml:"desc"`
+	Runners     map[string]interface{} `yaml:"runners,omitempty"`
+	Vars        map[string]interface{} `yaml:"vars,omitempty"`
+	Steps       []yaml.MapSlice        `yaml:"steps"`
+	Debug       bool                   `yaml:"debug,omitempty"`
+	Interval    string                 `yaml:"interval,omitempty"`
+	If          string                 `yaml:"if,omitempty"`
+	SkipTest    bool                   `yaml:"skipTest,omitempty"`
+	Loop        interface{}            `yaml:"loop,omitempty"`
+	Concurrency string                 `yaml:"concurrency,omitempty"`
 
 	useMap   bool
 	stepKeys []string
 }
 
 type runbookMapped struct {
-	Desc     string                 `yaml:"desc,omitempty"`
-	Runners  map[string]interface{} `yaml:"runners,omitempty"`
-	Vars     map[string]interface{} `yaml:"vars,omitempty"`
-	Steps    yaml.MapSlice          `yaml:"steps,omitempty"`
-	Debug    bool                   `yaml:"debug,omitempty"`
-	Interval string                 `yaml:"interval,omitempty"`
-	If       string                 `yaml:"if,omitempty"`
-	SkipTest bool                   `yaml:"skipTest,omitempty"`
-	Loop     interface{}            `yaml:"loop,omitempty"`
+	Desc        string                 `yaml:"desc,omitempty"`
+	Runners     map[string]interface{} `yaml:"runners,omitempty"`
+	Vars        map[string]interface{} `yaml:"vars,omitempty"`
+	Steps       yaml.MapSlice          `yaml:"steps,omitempty"`
+	Debug       bool                   `yaml:"debug,omitempty"`
+	Interval    string                 `yaml:"interval,omitempty"`
+	If          string                 `yaml:"if,omitempty"`
+	SkipTest    bool                   `yaml:"skipTest,omitempty"`
+	Loop        interface{}            `yaml:"loop,omitempty"`
+	Concurrency string                 `yaml:"concurrency,omitempty"`
 }
 
 func NewRunbook(desc string) *runbook {
@@ -347,6 +349,7 @@ func (rb *runbook) toBook() (*book, error) {
 			return nil, err
 		}
 	}
+	bk.concurrency = rb.Concurrency
 	bk.useMap = rb.useMap
 	bk.stepKeys = rb.stepKeys
 


### PR DESCRIPTION
Fix #453 