### PR TITLE
Change function signature of GrpcRunner and Add GrpcRunnerWithOptions

### DIFF
--- a/option.go
+++ b/option.go
@@ -324,13 +324,27 @@ func DBRunner(name string, client Querier) Option {
 }
 
 // GrpcRunner - Set gRPC runner to runbook.
-func GrpcRunner(name string, cc *grpc.ClientConn, opts ...grpcRunnerOption) Option {
+func GrpcRunner(name string, cc *grpc.ClientConn) Option {
 	return func(bk *book) error {
 		delete(bk.runnerErrs, name)
 		r := &grpcRunner{
 			name: name,
 			cc:   cc,
 			mds:  map[string]*desc.MethodDescriptor{},
+		}
+		bk.grpcRunners[name] = r
+		return nil
+	}
+}
+
+// GrpcRunnerWithOptions - Set gRPC runner to runbook using options.
+func GrpcRunnerWithOptions(name, target string, opts ...grpcRunnerOption) Option {
+	return func(bk *book) error {
+		delete(bk.runnerErrs, name)
+		r := &grpcRunner{
+			name:   name,
+			target: target,
+			mds:    map[string]*desc.MethodDescriptor{},
 		}
 		if len(opts) > 0 {
 			c := &grpcRunnerConfig{}

--- a/option_test.go
+++ b/option_test.go
@@ -731,7 +731,7 @@ func TestOptionGRPCNoTLS(t *testing.T) {
 			}
 			for i, tls := range tt.TLSs {
 				key := fmt.Sprintf("greq%d", i)
-				opts = append(opts, GrpcRunner(key, nil, TLS(tls)))
+				opts = append(opts, GrpcRunnerWithOptions(key, "", TLS(tls)))
 			}
 			o, err := New(opts...)
 			if err != nil {


### PR DESCRIPTION
`runn.GrpcRunner` 's options had nothing enabled.

So we made the function signature similar to SSHRunner/SSHRunnerWithOptions