### PR TITLE
Support `force:` section to force all steps to run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,14 @@ Skip all `test:` sections
 skipTest: true
 ```
 
+### `force:`
+
+Force all steps to run.
+
+``` yaml
+force: true
+```
+
 ### `loop:`
 
 Loop setting for runbook.
@@ -1451,6 +1459,15 @@ It is also possible to skip all `test:` sections in the included runbook.
   include:
     path: path/to/signup.yml
     skipTest: true
+```
+
+It is also possible to force all steps in the included runbook to run.
+
+``` yaml
+-
+  include:
+    path: path/to/signup.yml
+    force: true
 ```
 
 ### Bind Runner: bind variables

--- a/book.go
+++ b/book.go
@@ -42,6 +42,7 @@ type book struct {
 	useMap           bool
 	t                *testing.T
 	included         bool
+	force            bool
 	failFast         bool
 	skipIncluded     bool
 	grpcNoTLS        bool
@@ -485,6 +486,9 @@ func (bk *book) merge(loaded *book) error {
 	}
 	if !bk.skipTest {
 		bk.skipTest = loaded.skipTest
+	}
+	if !bk.force {
+		bk.force = loaded.force
 	}
 	bk.loop = loaded.loop
 	bk.grpcNoTLS = loaded.grpcNoTLS

--- a/include.go
+++ b/include.go
@@ -15,6 +15,7 @@ type includeConfig struct {
 	path     string
 	vars     map[string]interface{}
 	skipTest bool
+	force    bool
 	step     *step
 }
 
@@ -113,6 +114,7 @@ func (o *operator) newNestedOperator(parent *step, opts ...Option) (*operator, e
 	popts = append(popts, Debug(o.debug))
 	popts = append(popts, Profile(o.profile))
 	popts = append(popts, SkipTest(o.skipTest))
+	popts = append(popts, Force(o.force))
 	for k, f := range o.store.funcs {
 		popts = append(popts, Func(k, f))
 	}

--- a/operator_test.go
+++ b/operator_test.go
@@ -858,19 +858,23 @@ func TestFailWithStepDesc(t *testing.T) {
 
 func TestStepResult(t *testing.T) {
 	tests := []struct {
-		book string
-		want []*stepResult
+		book  string
+		force bool
+		want  []*stepResult
 	}{
-		{"testdata/book/always_success.yml", []*stepResult{{skipped: false, err: nil}, {skipped: false, err: nil}, {skipped: false, err: nil}}},
-		{"testdata/book/always_failure.yml", []*stepResult{{skipped: false, err: nil}, {skipped: false, err: errors.New("some error")}, {skipped: true, err: nil}}},
-		{"testdata/book/skip_test.yml", []*stepResult{{skipped: true, err: nil}, {skipped: false, err: nil}}},
-		{"testdata/book/only_if_included.yml", []*stepResult{{skipped: true, err: nil}, {skipped: true, err: nil}}},
+		{"testdata/book/always_success.yml", false, []*stepResult{{skipped: false, err: nil}, {skipped: false, err: nil}, {skipped: false, err: nil}}},
+		{"testdata/book/always_failure.yml", false, []*stepResult{{skipped: false, err: nil}, {skipped: false, err: errors.New("some error")}, {skipped: true, err: nil}}},
+		{"testdata/book/skip_test.yml", false, []*stepResult{{skipped: true, err: nil}, {skipped: false, err: nil}}},
+		{"testdata/book/only_if_included.yml", false, []*stepResult{{skipped: true, err: nil}, {skipped: true, err: nil}}},
+		{"testdata/book/force.yml", false, []*stepResult{{skipped: false, err: nil}, {skipped: false, err: errors.New("some error")}, {skipped: false, err: nil}}},
+		{"testdata/book/always_failure.yml", true, []*stepResult{{skipped: false, err: nil}, {skipped: false, err: errors.New("some error")}, {skipped: false, err: nil}}},
+		{"testdata/book/only_if_included.yml", true, []*stepResult{{skipped: true, err: nil}, {skipped: true, err: nil}}},
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
-			o, err := New(Book(tt.book))
+			o, err := New(Book(tt.book), Force(tt.force))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -897,19 +901,22 @@ func TestStepResult(t *testing.T) {
 
 func TestStepOutcome(t *testing.T) {
 	tests := []struct {
-		book string
-		want []result
+		book  string
+		force bool
+		want  []result
 	}{
-		{"testdata/book/always_success.yml", []result{resultSuccess, resultSuccess, resultSuccess}},
-		{"testdata/book/always_failure.yml", []result{resultSuccess, resultFailure, resultSkipped}},
-		{"testdata/book/skip_test.yml", []result{resultSkipped, resultSuccess}},
-		{"testdata/book/only_if_included.yml", []result{}},
+		{"testdata/book/always_success.yml", false, []result{resultSuccess, resultSuccess, resultSuccess}},
+		{"testdata/book/always_failure.yml", false, []result{resultSuccess, resultFailure, resultSkipped}},
+		{"testdata/book/skip_test.yml", false, []result{resultSkipped, resultSuccess}},
+		{"testdata/book/only_if_included.yml", false, []result{}},
+		{"testdata/book/always_failure.yml", true, []result{resultSuccess, resultFailure, resultSuccess}},
+		{"testdata/book/only_if_included.yml", true, []result{}},
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
-			o, err := New(Book(tt.book))
+			o, err := New(Book(tt.book), Force(tt.force))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/option.go
+++ b/option.go
@@ -599,6 +599,16 @@ func SkipTest(enable bool) Option {
 	}
 }
 
+// Force - Force all steps to run.
+func Force(enable bool) Option {
+	return func(bk *book) error {
+		if !bk.force {
+			bk.force = enable
+		}
+		return nil
+	}
+}
+
 // GRPCNoTLS - Disable TLS use in all gRPC runners.
 func GRPCNoTLS(noTLS bool) Option {
 	return func(bk *book) error {

--- a/parse.go
+++ b/parse.go
@@ -336,6 +336,13 @@ func parseIncludeConfig(v interface{}) (*includeConfig, error) {
 				return nil, fmt.Errorf("invalid include condig: %v", v)
 			}
 		}
+		force, ok := vv["force"]
+		if ok {
+			c.force, ok = force.(bool)
+			if !ok {
+				return nil, fmt.Errorf("invalid include condig: %v", v)
+			}
+		}
 		return c, nil
 	default:
 		return nil, fmt.Errorf("invalid include condig: %v", v)

--- a/runbook.go
+++ b/runbook.go
@@ -26,6 +26,7 @@ type runbook struct {
 	SkipTest    bool                   `yaml:"skipTest,omitempty"`
 	Loop        interface{}            `yaml:"loop,omitempty"`
 	Concurrency string                 `yaml:"concurrency,omitempty"`
+	Force       bool                   `yaml:"force,omitempty"`
 
 	useMap   bool
 	stepKeys []string
@@ -42,6 +43,7 @@ type runbookMapped struct {
 	SkipTest    bool                   `yaml:"skipTest,omitempty"`
 	Loop        interface{}            `yaml:"loop,omitempty"`
 	Concurrency string                 `yaml:"concurrency,omitempty"`
+	Force       bool                   `yaml:"force,omitempty"`
 }
 
 func NewRunbook(desc string) *runbook {
@@ -96,6 +98,7 @@ func parseRunbookMapped(b []byte, rb *runbook) error {
 	rb.Interval = m.Interval
 	rb.If = m.If
 	rb.SkipTest = m.SkipTest
+	rb.Force = m.Force
 
 	keys := map[string]struct{}{}
 	for _, s := range m.Steps {
@@ -156,6 +159,7 @@ func (rb *runbook) MarshalYAML() (interface{}, error) {
 	m.Interval = rb.Interval
 	m.If = rb.If
 	m.SkipTest = rb.SkipTest
+	m.Force = rb.Force
 	ms := yaml.MapSlice{}
 	for i, k := range rb.stepKeys {
 		ms = append(ms, yaml.MapItem{
@@ -343,6 +347,7 @@ func (rb *runbook) toBook() (*book, error) {
 	bk.intervalStr = rb.Interval
 	bk.ifCond = rb.If
 	bk.skipTest = rb.SkipTest
+	bk.force = rb.Force
 	if rb.Loop != nil {
 		bk.loop, err = newLoop(rb.Loop)
 		if err != nil {

--- a/testdata/book/force.yml
+++ b/testdata/book/force.yml
@@ -1,0 +1,9 @@
+desc: Always force run
+force: true
+steps:
+  -
+    test: 'true'
+  -
+    test: 'false'
+  -
+    test: 'true'


### PR DESCRIPTION
Add an option to run to the last step even if the intermediate step fails.

If even one step fails, it is considered a failure as a runbook.