### PR TITLE
Revert "Fix logic to skip validation using `servers:` section in OpenAPI v3 spec"

### DIFF
--- a/http_validator.go
+++ b/http_validator.go
@@ -96,10 +96,6 @@ func newOpenApi3Validator(c *httpRunnerConfig) (*openApi3Validator, error) {
 	if c.openApi3Doc == nil {
 		return nil, errors.New("cannot load openapi3 document")
 	}
-
-	// skip scheme://host:port validation
-	c.openApi3Doc.Servers = nil
-
 	return &openApi3Validator{
 		skipValidateRequest:  c.SkipValidateRequest,
 		skipValidateResponse: c.SkipValidateResponse,
@@ -138,6 +134,17 @@ func (v *openApi3Validator) ValidateRequest(ctx context.Context, req *http.Reque
 }
 
 func (v *openApi3Validator) requestInput(req *http.Request) (*openapi3filter.RequestValidationInput, error) {
+	// skip scheme://host:port validation
+	for _, server := range v.doc.Servers {
+		su, err := url.Parse(server.URL)
+		if err != nil {
+			return nil, err
+		}
+		su.Host = req.URL.Host
+		su.Opaque = req.URL.Opaque
+		su.Scheme = req.URL.Scheme
+		server.URL = su.String()
+	}
 	router, err := legacyrouter.NewRouter(v.doc)
 	if err != nil {
 		return nil, err

--- a/testdata/openapi3.yml
+++ b/testdata/openapi3.yml
@@ -2,9 +2,6 @@ openapi: 3.0.3
 info:
   title: test spec
   version: 0.0.1
-servers:
-  - url: http://api.example.com
-  - url: https://api.example.com
 paths:
   /users:
     get:


### PR DESCRIPTION
Reverts k1LoW/runn#533