### PR TITLE
Support wildcards in `json://` and `yaml://` so that values can be retrieved with slice

### DIFF
--- a/vars_test.go
+++ b/vars_test.go
@@ -63,6 +63,13 @@ func TestEvaluateSchema(t *testing.T) {
 			"",
 			true,
 		},
+		{"json://testdata/vars*.json", nil, []any{
+			map[string]any{"foo": "test", "bar": float64(1)},
+			[]any{
+				map[string]any{"foo": "test1", "bar": float64(1)},
+				map[string]any{"foo": "test2", "bar": float64(2)},
+			},
+		}, false},
 	}
 	for i, tt := range tests {
 		tt := tt


### PR DESCRIPTION
ref: #534 

## Proposal

Support wildcards in `json://` and `yaml://` so that values can be retrieved with slice.

Only when a wildcard ( `*` ) is used, the expanded values become a slice.

