### PR TITLE
Guarantee sequential run for each operator

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -73,6 +73,8 @@ type operator struct {
 	sw            *stopw.Span
 	capturers     capturers
 	runResult     *RunResult
+
+	mu sync.Mutex
 }
 
 // Desc returns `desc:` of runbook.
@@ -899,6 +901,8 @@ func (o *operator) runLoop(ctx context.Context) error {
 }
 
 func (o *operator) runInternal(ctx context.Context) (rerr error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
 	if o.t != nil {
 		o.t.Helper()
 	}

--- a/operator_test.go
+++ b/operator_test.go
@@ -567,6 +567,7 @@ func TestShard(t *testing.T) {
 				cmpopts.IgnoreFields(stopw.Span{}, "ID"),
 				cmpopts.IgnoreFields(operator{}, "id"),
 				cmpopts.IgnoreFields(operator{}, "concurrency"),
+				cmpopts.IgnoreFields(operator{}, "mu"),
 				cmpopts.IgnoreFields(cdpRunner{}, "ctx"),
 				cmpopts.IgnoreFields(cdpRunner{}, "cancel"),
 				cmpopts.IgnoreFields(cdpRunner{}, "opts"),


### PR DESCRIPTION
ref: #513 