### PR TITLE
Add show ids in `runn list` command

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -41,7 +41,7 @@ var listCmd = &cobra.Command{
 	Args:    cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		table := tablewriter.NewWriter(os.Stdout)
-		table.SetHeader([]string{"desc:", "if:", "steps:", "path"})
+		table.SetHeader([]string{"id:", "desc:", "if:", "steps:", "path"})
 		table.SetAutoWrapText(false)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 		table.SetAutoFormatHeaders(false)
@@ -77,11 +77,18 @@ var listCmd = &cobra.Command{
 			return err
 		}
 		for _, oo := range selected {
+			id := oo.ID()
+			if !flgs.Long {
+				id = id[:7]
+			}
 			desc := oo.Desc()
-			p := runn.ShortenPath(oo.BookPath())
+			p := oo.BookPath()
+			if !flgs.Long {
+				p = runn.ShortenPath(p)
+			}
 			c := strconv.Itoa(oo.NumberOfSteps())
 			ifCond := oo.If()
-			table.Append([]string{desc, ifCond, c, p})
+			table.Append([]string{id, desc, ifCond, c, p})
 		}
 
 		table.Render()
@@ -92,6 +99,7 @@ var listCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(listCmd)
+	listCmd.Flags().BoolVarP(&flgs.Long, "long", "l", false, flgs.Usage("Long"))
 	listCmd.Flags().BoolVarP(&flgs.SkipIncluded, "skip-included", "", false, flgs.Usage("SkipIncluded"))
 	listCmd.Flags().StringSliceVarP(&flgs.Vars, "var", "", []string{}, flgs.Usage("Vars"))
 	listCmd.Flags().StringSliceVarP(&flgs.Runners, "runner", "", []string{}, flgs.Usage("Runners"))

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -22,6 +22,7 @@ var floatRe = regexp.MustCompile(`^\-?[0-9.]+$`)
 
 type Flags struct {
 	Debug           bool     `usage:"debug"`
+	Long            bool     `usage:"long format"`
 	FailFast        bool     `usage:"fail fast"`
 	SkipTest        bool     `usage:"skip \"test:\" section"`
 	SkipIncluded    bool     `usage:"skip running the included runbook by itself"`

--- a/operator.go
+++ b/operator.go
@@ -77,6 +77,11 @@ type operator struct {
 	mu sync.Mutex
 }
 
+// ID returns id of runbook.
+func (o *operator) ID() string {
+	return o.id
+}
+
 // Desc returns `desc:` of runbook.
 func (o *operator) Desc() string {
 	return o.desc


### PR DESCRIPTION
- Defaults to short trimmed ID, `--long` option to show the entire ID.
- `--long` option to show the full path.

```console
$ go run cmd/runn/main.go list testdata/book/*.yml | head
  id:      desc:                                      if:       steps:  path
------------------------------------------------------------------------------------------------------------------
  8150b83  Always failure scenario                                   3  t/b/always_failure.yml
  8750a8e  Always success scenario                                   3  t/b/always_success.yml
  fd8d83d  Login and get projects.                                   6  t/b/book.yml
  b9f7be5  Test for json.*                                           3  t/b/builtin-json.yml
  06c1f13  Test using CDP                                            6  t/b/cdp.yml
  e8dc026  Loop test using CDP                                       1  t/b/cdploop.yml
  1f8a149  Inherit cookies Example                                   3  t/b/cookie.yml
  9087c93  Cookie in requests automatically                          4  t/b/cookie_in_requests_automatically.yml
```