### PR TITLE
Set runnbook ID to result (STDOUT/JSON)

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -784,11 +784,13 @@ func (o *operator) DumpProfile(w io.Writer) error {
 
 // Result returns run result.
 func (o *operator) Result() *RunResult {
+	o.runResult.ID = o.id
 	return o.runResult
 }
 
 func (o *operator) clearResult() {
 	o.runResult = newRunResult(o.desc, o.bookPathOrID())
+	o.runResult.ID = o.id
 	for _, s := range o.steps {
 		s.clearResult()
 	}

--- a/operator_test.go
+++ b/operator_test.go
@@ -336,21 +336,25 @@ func TestRunN(t *testing.T) {
 	}{
 		{"testdata/book/runn_*", "", false, newRunNResult(t, 4, []*RunResult{
 			{
+				ID:          "84ff32ce475541124d3b28efcecb11268d79f2c6",
 				Path:        "testdata/book/runn_0_success.yml",
 				Err:         nil,
 				StepResults: []*StepResult{{Key: "0", Err: nil}},
 			},
 			{
+				ID:          "b6d90c331b04ab198ca95b13c5f656fd2522e53b",
 				Path:        "testdata/book/runn_1_fail.yml",
 				Err:         ErrDummy,
 				StepResults: []*StepResult{{Key: "0", Err: ErrDummy}},
 			},
 			{
+				ID:          "faeec884c284f9c2527f840372fc01ed8351a377",
 				Path:        "testdata/book/runn_2_success.yml",
 				Err:         nil,
 				StepResults: []*StepResult{{Key: "0", Err: nil}},
 			},
 			{
+				ID:          "15519f515b984b9b25dae1cfde43597cd035dc3d",
 				Path:        "testdata/book/runn_3.skip.yml",
 				Err:         nil,
 				Skipped:     true,
@@ -359,11 +363,13 @@ func TestRunN(t *testing.T) {
 		})},
 		{"testdata/book/runn_*", "", true, newRunNResult(t, 4, []*RunResult{
 			{
+				ID:          "84ff32ce475541124d3b28efcecb11268d79f2c6",
 				Path:        "testdata/book/runn_0_success.yml",
 				Err:         nil,
 				StepResults: []*StepResult{{Key: "0", Err: nil}},
 			},
 			{
+				ID:          "b6d90c331b04ab198ca95b13c5f656fd2522e53b",
 				Path:        "testdata/book/runn_1_fail.yml",
 				Err:         ErrDummy,
 				StepResults: []*StepResult{{Key: "0", Err: ErrDummy}},
@@ -371,6 +377,7 @@ func TestRunN(t *testing.T) {
 		})},
 		{"testdata/book/runn_*", "runn_0", false, newRunNResult(t, 1, []*RunResult{
 			{
+				ID:          "84ff32ce475541124d3b28efcecb11268d79f2c6",
 				Path:        "testdata/book/runn_0_success.yml",
 				Err:         nil,
 				StepResults: []*StepResult{{Key: "0", Err: nil}},

--- a/result.go
+++ b/result.go
@@ -20,6 +20,7 @@ const (
 )
 
 type RunResult struct {
+	ID          string
 	Desc        string
 	Path        string
 	Skipped     bool
@@ -50,6 +51,7 @@ type runNResultSimplified struct {
 }
 
 type runResultSimplified struct {
+	ID     string                 `json:"id"`
 	Path   string                 `json:"path"`
 	Result result                 `json:"result"`
 	Steps  []stepResultSimplified `json:"steps"`
@@ -85,6 +87,7 @@ func (r *runNResult) Simplify() runNResultSimplified {
 		case rr.Err != nil:
 			s.Failure += 1
 			s.Results = append(s.Results, runResultSimplified{
+				ID:     rr.ID,
 				Path:   rr.Path,
 				Result: resultFailure,
 				Steps:  simplifyStepResults(rr.StepResults),
@@ -92,6 +95,7 @@ func (r *runNResult) Simplify() runNResultSimplified {
 		case rr.Skipped:
 			s.Skipped += 1
 			s.Results = append(s.Results, runResultSimplified{
+				ID:     rr.ID,
 				Path:   rr.Path,
 				Result: resultSkipped,
 				Steps:  simplifyStepResults(rr.StepResults),
@@ -99,6 +103,7 @@ func (r *runNResult) Simplify() runNResultSimplified {
 		default:
 			s.Success += 1
 			s.Results = append(s.Results, runResultSimplified{
+				ID:     rr.ID,
 				Path:   rr.Path,
 				Result: resultSuccess,
 				Steps:  simplifyStepResults(rr.StepResults),
@@ -112,6 +117,7 @@ func (r *runNResult) Out(out io.Writer, verbose bool) error {
 	var ts, fs string
 	green := color.New(color.FgGreen).SprintFunc()
 	red := color.New(color.FgRed).SprintFunc()
+	cyan := color.New(color.FgCyan).SprintFunc()
 
 	_, _ = fmt.Fprintln(out, "")
 	if !verbose && r.HasFailure() {
@@ -121,7 +127,7 @@ func (r *runNResult) Out(out io.Writer, verbose bool) error {
 			if r.Err == nil {
 				continue
 			}
-			_, _ = fmt.Fprintf(out, "%d) %s\n", i, ShortenPath(r.Path))
+			_, _ = fmt.Fprintf(out, "%d) %s %s\n", i, ShortenPath(r.Path), cyan(r.ID))
 			for _, sr := range r.StepResults {
 				if sr.Err == nil {
 					continue

--- a/result_test.go
+++ b/result_test.go
@@ -16,60 +16,73 @@ func TestResultOut(t *testing.T) {
 	}{
 		{newRunNResult(t, 4, []*RunResult{
 			{
+				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path: "testdata/book/runn_0_success.yml",
 				Err:  nil,
 			},
 			{
+				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path: "testdata/book/runn_1_fail.yml",
 				Err:  ErrDummy,
 			},
 			{
+				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path: "testdata/book/runn_2_success.yml",
 				Err:  nil,
 			},
 			{
+				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path: "testdata/book/runn_3.skip.yml",
 				Err:  nil,
 			},
 		}), false},
 		{newRunNResult(t, 5, []*RunResult{
 			{
+				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path: "testdata/book/runn_0_success.yml",
 				Err:  nil,
 			},
 			{
+				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path: "testdata/book/runn_1_fail.yml",
 				Err:  ErrDummy,
 			},
 			{
+				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path: "testdata/book/runn_2_success.yml",
 				Err:  nil,
 			},
 			{
+				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path: "testdata/book/runn_3.skip.yml",
 				Err:  nil,
 			},
 			{
+				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path: "testdata/book/always_failure.yml",
 				Err:  nil,
 			},
 		}), false},
 		{newRunNResult(t, 2, []*RunResult{
 			{
+				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path: "testdata/book/runn_0_success.yml",
 				Err:  nil,
 			},
 			{
+				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path: "testdata/book/runn_1_fail.yml",
 				Err:  ErrDummy,
 			},
 		}), false},
 		{newRunNResult(t, 2, []*RunResult{
 			{
+				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path: "testdata/book/runn_0_success.yml",
 				Err:  nil,
 			},
 			{
+				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path: "testdata/book/runn_1_fail.yml",
 				Err:  ErrDummy,
 			},
@@ -99,21 +112,25 @@ func TestResultOutJSON(t *testing.T) {
 	}{
 		{newRunNResult(t, 4, []*RunResult{
 			{
+				ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path:        "testdata/book/runn_0_success.yml",
 				Err:         nil,
 				StepResults: []*StepResult{{Key: "0", Err: nil}},
 			},
 			{
+				ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path:        "testdata/book/runn_1_fail.yml",
 				Err:         ErrDummy,
 				StepResults: []*StepResult{{Key: "0", Err: ErrDummy}},
 			},
 			{
+				ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path:        "testdata/book/runn_2_success.yml",
 				Err:         nil,
 				StepResults: []*StepResult{{Key: "0", Err: nil}},
 			},
 			{
+				ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path:        "testdata/book/runn_3.skip.yml",
 				Err:         nil,
 				StepResults: []*StepResult{{Key: "0", Err: nil, Skipped: true}},
@@ -121,26 +138,31 @@ func TestResultOutJSON(t *testing.T) {
 		})},
 		{newRunNResult(t, 5, []*RunResult{
 			{
+				ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path:        "testdata/book/runn_0_success.yml",
 				Err:         nil,
 				StepResults: []*StepResult{{Key: "0", Err: nil}},
 			},
 			{
+				ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path:        "testdata/book/runn_1_fail.yml",
 				Err:         ErrDummy,
 				StepResults: []*StepResult{{Key: "0", Err: ErrDummy}},
 			},
 			{
+				ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path:        "testdata/book/runn_2_success.yml",
 				Err:         nil,
 				StepResults: []*StepResult{{Key: "0", Err: nil}},
 			},
 			{
+				ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path:        "testdata/book/runn_3.skip.yml",
 				Err:         nil,
 				StepResults: []*StepResult{{Key: "0", Err: nil, Skipped: true}},
 			},
 			{
+				ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path:        "testdata/book/always_failure.yml",
 				Err:         ErrDummy,
 				StepResults: []*StepResult{{Key: "0", Err: ErrDummy}},
@@ -148,11 +170,13 @@ func TestResultOutJSON(t *testing.T) {
 		})},
 		{newRunNResult(t, 2, []*RunResult{
 			{
+				ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path:        "testdata/book/runn_0_success.yml",
 				Err:         nil,
 				StepResults: []*StepResult{{Key: "0", Err: nil}},
 			},
 			{
+				ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path:        "testdata/book/runn_1_fail.yml",
 				Err:         ErrDummy,
 				StepResults: []*StepResult{{Key: "0", Err: ErrDummy}},

--- a/testdata/result_out_0.golden
+++ b/testdata/result_out_0.golden
@@ -1,5 +1,5 @@
 
 
-1) t/b/runn_1_fail.yml
+1) t/b/runn_1_fail.yml ab13ba1e546838ceafa17f91ab3220102f397b2e
 
 4 scenarios, 0 skipped, 1 failure

--- a/testdata/result_out_1.golden
+++ b/testdata/result_out_1.golden
@@ -1,5 +1,5 @@
 
 
-1) t/b/runn_1_fail.yml
+1) t/b/runn_1_fail.yml ab13ba1e546838ceafa17f91ab3220102f397b2e
 
 5 scenarios, 0 skipped, 1 failure

--- a/testdata/result_out_2.golden
+++ b/testdata/result_out_2.golden
@@ -1,5 +1,5 @@
 
 
-1) t/b/runn_1_fail.yml
+1) t/b/runn_1_fail.yml ab13ba1e546838ceafa17f91ab3220102f397b2e
 
 2 scenarios, 0 skipped, 1 failure

--- a/testdata/result_out_json_0.golden
+++ b/testdata/result_out_json_0.golden
@@ -5,6 +5,7 @@
   "skipped": 0,
   "results": [
     {
+      "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e",
       "path": "testdata/book/runn_0_success.yml",
       "result": "success",
       "steps": [
@@ -15,6 +16,7 @@
       ]
     },
     {
+      "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e",
       "path": "testdata/book/runn_1_fail.yml",
       "result": "failure",
       "steps": [
@@ -25,6 +27,7 @@
       ]
     },
     {
+      "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e",
       "path": "testdata/book/runn_2_success.yml",
       "result": "success",
       "steps": [
@@ -35,6 +38,7 @@
       ]
     },
     {
+      "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e",
       "path": "testdata/book/runn_3.skip.yml",
       "result": "success",
       "steps": [

--- a/testdata/result_out_json_1.golden
+++ b/testdata/result_out_json_1.golden
@@ -5,6 +5,7 @@
   "skipped": 0,
   "results": [
     {
+      "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e",
       "path": "testdata/book/runn_0_success.yml",
       "result": "success",
       "steps": [
@@ -15,6 +16,7 @@
       ]
     },
     {
+      "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e",
       "path": "testdata/book/runn_1_fail.yml",
       "result": "failure",
       "steps": [
@@ -25,6 +27,7 @@
       ]
     },
     {
+      "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e",
       "path": "testdata/book/runn_2_success.yml",
       "result": "success",
       "steps": [
@@ -35,6 +38,7 @@
       ]
     },
     {
+      "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e",
       "path": "testdata/book/runn_3.skip.yml",
       "result": "success",
       "steps": [
@@ -45,6 +49,7 @@
       ]
     },
     {
+      "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e",
       "path": "testdata/book/always_failure.yml",
       "result": "failure",
       "steps": [

--- a/testdata/result_out_json_2.golden
+++ b/testdata/result_out_json_2.golden
@@ -5,6 +5,7 @@
   "skipped": 0,
   "results": [
     {
+      "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e",
       "path": "testdata/book/runn_0_success.yml",
       "result": "success",
       "steps": [
@@ -15,6 +16,7 @@
       ]
     },
     {
+      "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e",
       "path": "testdata/book/runn_1_fail.yml",
       "result": "failure",
       "steps": [


### PR DESCRIPTION
Set runnbook ID to result.

RunResult is not configured to save the results of steps included by Include runners, which needs to be corrected in the future.

```console
$ runn run *.yml
F

1) tmp.yml 6a5d63a3c2c505fbc67b941937ee79c16113fc0e
  Failure/Error: test failed on 'Test desc'.steps.one 'Test desc one': (current.stdout == "Hello World") is not true
  current.stdout == "Hello World"
  ├── current.stdout => "Hello World
  │   "
  └── "Hello World" => "Hello World"

1 scenario, 0 skipped, 1 failure
exit status 1
$ runn run *.yml --id 6a5d63
F

1) tmp.yml 6a5d63a3c2c505fbc67b941937ee79c16113fc0e
  Failure/Error: test failed on 'Test desc'.steps.one 'Test desc one': (current.stdout == "Hello World") is not true
  current.stdout == "Hello World"
  ├── current.stdout => "Hello World
  │   "
  └── "Hello World" => "Hello World"

1 scenario, 0 skipped, 1 failure
exit status 1
```