### PR TITLE
Fix a problem that functions with uint type arguments can't be used

### DIFF
--- a/builtin/faker.go
+++ b/builtin/faker.go
@@ -77,9 +77,9 @@ func (f *Faker) RandomInt(i []int) int               { return f.engine.RandomInt
 // https://github.com/brianvoe/gofakeit#string
 
 func (f *Faker) Digit() string                  { return f.engine.Digit() }
-func (f *Faker) DigitN(n uint) string           { return f.engine.DigitN(n) }
+func (f *Faker) DigitN(n int) string            { return f.engine.DigitN(uint(n)) }
 func (f *Faker) Letter() string                 { return f.engine.Letter() }
-func (f *Faker) LetterN(n uint) string          { return f.engine.LetterN(n) }
+func (f *Faker) LetterN(n int) string           { return f.engine.LetterN(uint(n)) }
 func (f *Faker) Lexify(str string) string       { return f.engine.Lexify(str) }
 func (f *Faker) Numerify(str string) string     { return f.engine.Numerify(str) }
 func (f *Faker) RandomString(a []string) string { return f.engine.RandomString(a) }

--- a/builtin/faker.go
+++ b/builtin/faker.go
@@ -76,10 +76,20 @@ func (f *Faker) RandomInt(i []int) int               { return f.engine.RandomInt
 
 // https://github.com/brianvoe/gofakeit#string
 
-func (f *Faker) Digit() string                  { return f.engine.Digit() }
-func (f *Faker) DigitN(n int) string            { return f.engine.DigitN(uint(n)) }
-func (f *Faker) Letter() string                 { return f.engine.Letter() }
-func (f *Faker) LetterN(n int) string           { return f.engine.LetterN(uint(n)) }
+func (f *Faker) Digit() string { return f.engine.Digit() }
+func (f *Faker) DigitN(n int) string {
+	if n < 0 {
+		return ""
+	}
+	return f.engine.DigitN(uint(n))
+}
+func (f *Faker) Letter() string { return f.engine.Letter() }
+func (f *Faker) LetterN(n int) string {
+	if n < 0 {
+		return ""
+	}
+	return f.engine.LetterN(uint(n))
+}
 func (f *Faker) Lexify(str string) string       { return f.engine.Lexify(str) }
 func (f *Faker) Numerify(str string) string     { return f.engine.Numerify(str) }
 func (f *Faker) RandomString(a []string) string { return f.engine.RandomString(a) }

--- a/builtin/faker_test.go
+++ b/builtin/faker_test.go
@@ -1,0 +1,44 @@
+package builtin
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestDigitN(t *testing.T) {
+	tests := []struct {
+		n          int
+		wantLength int
+	}{
+		{10, 10},
+		{-1, 0},
+	}
+	faker := NewFaker()
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("n=%d", tt.n), func(t *testing.T) {
+			got := faker.DigitN(tt.n)
+			if len(got) != tt.wantLength {
+				t.Errorf("got=%d, want=%d", len(got), tt.wantLength)
+			}
+		})
+	}
+}
+
+func TestLetterN(t *testing.T) {
+	tests := []struct {
+		n          int
+		wantLength int
+	}{
+		{10, 10},
+		{-1, 0},
+	}
+	faker := NewFaker()
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("n=%d", tt.n), func(t *testing.T) {
+			got := faker.LetterN(tt.n)
+			if len(got) != tt.wantLength {
+				t.Errorf("got=%d, want=%d", len(got), tt.wantLength)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* make the functions argument type int because int type can be used in runbook
* return `""` when less than 0 is passed to the argument
* add test because logics is added