### PR TITLE
Support `exec.shell:` for specifying the shell to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -1432,13 +1432,20 @@ The response to the run command is always `stdout` and `stderr`.
 
 The `exec` runner is a built-in runner, so there is no need to specify it in the `runners:` section.
 
-It execute command using `command:` and `stdin:`
+It execute command using `command:` and `stdin:` and `shell:`.
 
 ``` yaml
 -
   exec:
     command: grep hello
     stdin: '{{ steps[3].res.rawBody }}'
+```
+
+``` yaml
+-
+  exec:
+    command: echo $0
+    shell: bash
 ```
 
 See [testdata/book/exec.yml](testdata/book/exec.yml).

--- a/capture/runbook.go
+++ b/capture/runbook.go
@@ -389,7 +389,7 @@ func (c *cRunbook) CaptureDBResponse(name string, res *runn.DBResponse) {
 	r.replaceLatestStep(step)
 }
 
-func (c *cRunbook) CaptureExecCommand(command string) {
+func (c *cRunbook) CaptureExecCommand(command, shell string) {
 	r := c.currentRunbook()
 	if r == nil {
 		return
@@ -397,6 +397,7 @@ func (c *cRunbook) CaptureExecCommand(command string) {
 	step := yaml.MapSlice{
 		{Key: "exec", Value: yaml.MapSlice{
 			{Key: "command", Value: command},
+			{Key: "shell", Value: shell},
 		}},
 	}
 	r.Steps = append(r.Steps, step)

--- a/capturer.go
+++ b/capturer.go
@@ -37,7 +37,7 @@ type Capturer interface {
 	CaptureDBStatement(name string, stmt string)
 	CaptureDBResponse(name string, res *DBResponse)
 
-	CaptureExecCommand(command string)
+	CaptureExecCommand(command, shell string)
 	CaptureExecStdin(stdin string)
 	CaptureExecStdout(stdout string)
 	CaptureExecStderr(stderr string)
@@ -185,9 +185,9 @@ func (cs capturers) captureDBResponse(name string, res *DBResponse) { //nostyle:
 	}
 }
 
-func (cs capturers) captureExecCommand(command string) { //nostyle:recvtype
+func (cs capturers) captureExecCommand(command, shell string) { //nostyle:recvtype
 	for _, c := range cs {
-		c.CaptureExecCommand(command)
+		c.CaptureExecCommand(command, shell)
 	}
 }
 

--- a/cmdout.go
+++ b/cmdout.go
@@ -62,7 +62,7 @@ func (d *cmdOut) CaptureSSHStdout(stdout string)                                
 func (d *cmdOut) CaptureSSHStderr(stderr string)                                     {}
 func (d *cmdOut) CaptureDBStatement(name string, stmt string)                        {}
 func (d *cmdOut) CaptureDBResponse(name string, res *DBResponse)                     {}
-func (d *cmdOut) CaptureExecCommand(command string)                                  {}
+func (d *cmdOut) CaptureExecCommand(command, shell string)                           {}
 func (d *cmdOut) CaptureExecStdin(stdin string)                                      {}
 func (d *cmdOut) CaptureExecStdout(stdout string)                                    {}
 func (d *cmdOut) CaptureExecStderr(stderr string)                                    {}

--- a/debugger.go
+++ b/debugger.go
@@ -140,7 +140,7 @@ func (d *debugger) CaptureDBResponse(name string, res *DBResponse) {
 	}
 }
 
-func (d *debugger) CaptureExecCommand(command string) {
+func (d *debugger) CaptureExecCommand(command, shell string) {
 	_, _ = fmt.Fprintf(d.out, "-----START COMMAND-----\n%s\n-----END COMMAND-----\n", command)
 }
 

--- a/exec.go
+++ b/exec.go
@@ -17,12 +17,15 @@ const (
 	execStoreExitCodeKey = "exit_code"
 )
 
+const execDefaultShell = "sh"
+
 type execRunner struct {
 	operator *operator
 }
 
 type execCommand struct {
 	command string
+	shell   string
 	stdin   string
 }
 
@@ -35,10 +38,12 @@ func newExecRunner(o *operator) (*execRunner, error) {
 func (rnr *execRunner) Run(ctx context.Context, c *execCommand) error {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
+	if c.shell == "" {
+		c.shell = execDefaultShell
+	}
+	rnr.operator.capturers.captureExecCommand(c.command, c.shell)
 
-	rnr.operator.capturers.captureExecCommand(c.command)
-
-	sh, err := safeexec.LookPath("sh")
+	sh, err := safeexec.LookPath(c.shell)
 	if err != nil {
 		return err
 	}

--- a/exec_test.go
+++ b/exec_test.go
@@ -83,7 +83,10 @@ func TestExecShell(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			got := o.store.steps[0]["stdout"].(string)
+			got, ok := o.store.steps[0]["stdout"].(string)
+			if !ok {
+				t.Fatal("stdout is not string")
+			}
 			if !strings.HasPrefix(got, want) {
 				t.Errorf("got %s, want %s", got, want)
 			}

--- a/parse.go
+++ b/parse.go
@@ -333,7 +333,7 @@ func parseExecCommand(v map[string]any) (*execCommand, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(v) != 1 && len(v) != 2 {
+	if len(v) < 1 && len(v) > 3 {
 		return nil, fmt.Errorf("invalid command: %s", string(part))
 	}
 	cs, ok := v["command"]
@@ -345,15 +345,22 @@ func parseExecCommand(v map[string]any) (*execCommand, error) {
 		return nil, fmt.Errorf("invalid command: %s", string(part))
 	}
 	c.command = strings.Trim(command, " \n")
-	ss, ok := v["stdin"]
-	if !ok {
-		return c, nil
+	is, ok := v["stdin"]
+	if ok {
+		stdin, ok := is.(string)
+		if !ok {
+			return nil, fmt.Errorf("invalid stdin: %s", string(part))
+		}
+		c.stdin = stdin
 	}
-	stdin, ok := ss.(string)
-	if !ok {
-		return nil, fmt.Errorf("invalid stdin: %s", string(part))
+	ss, ok := v["shell"]
+	if ok {
+		sh, ok := ss.(string)
+		if !ok {
+			return nil, fmt.Errorf("invalid shell: %s", string(part))
+		}
+		c.shell = sh
 	}
-	c.stdin = stdin
 	return c, nil
 }
 

--- a/testdata/book/exec.yml
+++ b/testdata/book/exec.yml
@@ -11,6 +11,6 @@ steps:
     test: 'current.stdout contains "hello"'
   -
     exec:
-      command: echo $0
+      command: basename `echo $0`
       shell: bash
-    test: 'current.stdout contains "bash"'
+    test: 'current.stdout == "bash\n"'

--- a/testdata/book/exec.yml
+++ b/testdata/book/exec.yml
@@ -3,11 +3,14 @@ steps:
   -
     exec:
       command: echo hello world!!
-  -
-    test: 'steps[0].stdout contains "hello"'
+    test: 'current.stdout contains "hello"'
   -
     exec:
       command: cat
-      stdin: '{{ steps[0].stdout }}'
+      stdin: '{{ previous.stdout }}'
+    test: 'current.stdout contains "hello"'
   -
-    test: 'steps[2].stdout contains "hello"'
+    exec:
+      command: echo $0
+      shell: bash
+    test: 'current.stdout contains "bash"'

--- a/testdata/exec.yml.debugger.golden
+++ b/testdata/exec.yml.debugger.golden
@@ -23,10 +23,10 @@ hello world!!
 
 -----END STDERR-----
 -----START COMMAND-----
-echo $0
+basename `echo $0`
 -----END COMMAND-----
 -----START STDOUT-----
-/bin/bash
+bash
 
 -----END STDOUT-----
 -----START STDERR-----

--- a/testdata/exec.yml.debugger.golden
+++ b/testdata/exec.yml.debugger.golden
@@ -22,3 +22,13 @@ hello world!!
 -----START STDERR-----
 
 -----END STDERR-----
+-----START COMMAND-----
+echo $0
+-----END COMMAND-----
+-----START STDOUT-----
+/bin/bash
+
+-----END STDOUT-----
+-----START STDERR-----
+
+-----END STDERR-----

--- a/testdata/exec.yml.runbook.golden
+++ b/testdata/exec.yml.runbook.golden
@@ -3,13 +3,21 @@ desc: Captured of exec.yml run
 steps:
 - exec:
     command: echo hello world!!
+    shell: sh
   test: |
     current.stdout == "hello world!!\n"
     && current.stderr == ""
 - exec:
     command: cat
+    shell: sh
     stdin: |
       hello world!!
   test: |
     current.stdout == "hello world!!\n"
+    && current.stderr == ""
+- exec:
+    command: echo $0
+    shell: bash
+  test: |
+    current.stdout == "/bin/bash\n"
     && current.stderr == ""

--- a/testdata/exec.yml.runbook.golden
+++ b/testdata/exec.yml.runbook.golden
@@ -16,8 +16,8 @@ steps:
     current.stdout == "hello world!!\n"
     && current.stderr == ""
 - exec:
-    command: echo $0
+    command: basename `echo $0`
     shell: bash
   test: |
-    current.stdout == "/bin/bash\n"
+    current.stdout == "bash\n"
     && current.stderr == ""

--- a/testdata/include_main.yml.runbook.golden
+++ b/testdata/include_main.yml.runbook.golden
@@ -3,6 +3,7 @@ desc: Captured of include_main.yml run
 steps:
 - exec:
     command: echo 'hello a'
+    shell: sh
   test: |
     current.stdout == "hello a\n"
     && current.stderr == ""


### PR DESCRIPTION
Support `exec.shell:` for specifying the shell to use.

```yaml
- exec:
    command: hello 
    shell: bash
```