### PR TITLE
Enable to specify OpenAPI3 documents for each HTTP runner.

### DIFF
--- a/book.go
+++ b/book.go
@@ -21,52 +21,52 @@ const noDesc = "[No Description]"
 
 // book - Aggregated settings. runbook settings and run settings are aggregated.
 type book struct {
-	desc                string
-	runners             map[string]any
-	vars                map[string]any
-	rawSteps            []map[string]any
-	debug               bool
-	ifCond              string
-	skipTest            bool
-	funcs               map[string]any
-	stepKeys            []string
-	path                string // runbook file path
-	httpRunners         map[string]*httpRunner
-	dbRunners           map[string]*dbRunner
-	grpcRunners         map[string]*grpcRunner
-	cdpRunners          map[string]*cdpRunner
-	sshRunners          map[string]*sshRunner
-	profile             bool
-	intervalStr         string
-	interval            time.Duration
-	loop                *Loop
-	concurrency         string
-	useMap              bool
-	t                   *testing.T
-	included            bool
-	force               bool
-	failFast            bool
-	skipIncluded        bool
-	openApi3DocLocation string
-	grpcNoTLS           bool
-	grpcProtos          []string
-	grpcImportPaths     []string
-	runID               string
-	runMatch            *regexp.Regexp
-	runSample           int
-	runShardIndex       int
-	runShardN           int
-	runShuffle          bool
-	runShuffleSeed      int64
-	runConcurrent       bool
-	runConcurrentMax    int
-	runRandom           int
-	runnerErrs          map[string]error
-	beforeFuncs         []func(*RunResult) error
-	afterFuncs          []func(*RunResult) error
-	capturers           capturers
-	stdout              io.Writer
-	stderr              io.Writer
+	desc                 string
+	runners              map[string]any
+	vars                 map[string]any
+	rawSteps             []map[string]any
+	debug                bool
+	ifCond               string
+	skipTest             bool
+	funcs                map[string]any
+	stepKeys             []string
+	path                 string // runbook file path
+	httpRunners          map[string]*httpRunner
+	dbRunners            map[string]*dbRunner
+	grpcRunners          map[string]*grpcRunner
+	cdpRunners           map[string]*cdpRunner
+	sshRunners           map[string]*sshRunner
+	profile              bool
+	intervalStr          string
+	interval             time.Duration
+	loop                 *Loop
+	concurrency          string
+	useMap               bool
+	t                    *testing.T
+	included             bool
+	force                bool
+	failFast             bool
+	skipIncluded         bool
+	openApi3DocLocations []string
+	grpcNoTLS            bool
+	grpcProtos           []string
+	grpcImportPaths      []string
+	runID                string
+	runMatch             *regexp.Regexp
+	runSample            int
+	runShardIndex        int
+	runShardN            int
+	runShuffle           bool
+	runShuffleSeed       int64
+	runConcurrent        bool
+	runConcurrentMax     int
+	runRandom            int
+	runnerErrs           map[string]error
+	beforeFuncs          []func(*RunResult) error
+	afterFuncs           []func(*RunResult) error
+	capturers            capturers
+	stdout               io.Writer
+	stderr               io.Writer
 	// skip some errors for `runn list`
 	loadOnly bool
 }
@@ -512,7 +512,7 @@ func (bk *book) merge(loaded *book) error {
 		bk.force = loaded.force
 	}
 	bk.loop = loaded.loop
-	bk.openApi3DocLocation = loaded.openApi3DocLocation
+	bk.openApi3DocLocations = loaded.openApi3DocLocations
 	bk.grpcNoTLS = loaded.grpcNoTLS
 	bk.grpcProtos = loaded.grpcProtos
 	bk.grpcImportPaths = loaded.grpcImportPaths
@@ -545,6 +545,7 @@ func detectSSHRunner(v any) bool {
 	return false
 }
 
+// fp returns the absolute path of root+p.
 func fp(p, root string) string {
 	if strings.HasPrefix(p, "/") {
 		return p

--- a/cmd/coverage.go
+++ b/cmd/coverage.go
@@ -182,7 +182,7 @@ func init() {
 	coverageCmd.Flags().StringVarP(&flgs.RunMatch, "run", "", "", flgs.Usage("RunMatch"))
 	coverageCmd.Flags().StringVarP(&flgs.RunID, "id", "", "", flgs.Usage("RunID"))
 	coverageCmd.Flags().BoolVarP(&flgs.SkipIncluded, "skip-included", "", false, flgs.Usage("SkipIncluded"))
-	coverageCmd.Flags().StringVarP(&flgs.HTTPOpenApi3, "http-openapi3", "", "", flgs.Usage("HTTPOpenApi3"))
+	coverageCmd.Flags().StringSliceVarP(&flgs.HTTPOpenApi3s, "http-openapi3", "", []string{}, flgs.Usage("HTTPOpenApi3s"))
 	coverageCmd.Flags().BoolVarP(&flgs.GRPCNoTLS, "grpc-no-tls", "", false, flgs.Usage("GRPCNoTLS"))
 	coverageCmd.Flags().StringSliceVarP(&flgs.GRPCProtos, "grpc-proto", "", []string{}, flgs.Usage("GRPCProtos"))
 	coverageCmd.Flags().StringSliceVarP(&flgs.GRPCImportPaths, "grpc-import-path", "", []string{}, flgs.Usage("GRPCImportPaths"))

--- a/cmd/coverage.go
+++ b/cmd/coverage.go
@@ -51,7 +51,7 @@ var sortByMethod = []string{
 	http.MethodTrace,
 }
 
-// coverageCmd represents the coverage command
+// coverageCmd represents the coverage command.
 var coverageCmd = &cobra.Command{
 	Use:   "coverage [PATH_PATTERN ...]",
 	Short: "show coverage for paths/operations of OpenAPI spec and methods of protocol buffers",

--- a/cmd/loadt.go
+++ b/cmd/loadt.go
@@ -105,7 +105,7 @@ func init() {
 	loadtCmd.Flags().BoolVarP(&flgs.FailFast, "fail-fast", "", false, flgs.Usage("FailFast"))
 	loadtCmd.Flags().BoolVarP(&flgs.SkipTest, "skip-test", "", false, flgs.Usage("SkipTest"))
 	loadtCmd.Flags().BoolVarP(&flgs.SkipIncluded, "skip-included", "", false, flgs.Usage("SkipIncluded"))
-	loadtCmd.Flags().StringVarP(&flgs.HTTPOpenApi3, "http-openapi3", "", "", flgs.Usage("HTTPOpenApi3"))
+	loadtCmd.Flags().StringSliceVarP(&flgs.HTTPOpenApi3s, "http-openapi3", "", []string{}, flgs.Usage("HTTPOpenApi3s"))
 	loadtCmd.Flags().BoolVarP(&flgs.GRPCNoTLS, "grpc-no-tls", "", false, flgs.Usage("GRPCNoTLS"))
 	loadtCmd.Flags().StringVarP(&flgs.CaptureDir, "capture", "", "", flgs.Usage("CaptureDir"))
 	loadtCmd.Flags().StringSliceVarP(&flgs.Vars, "var", "", []string{}, flgs.Usage("Vars"))

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -108,7 +108,7 @@ func init() {
 	runCmd.Flags().BoolVarP(&flgs.FailFast, "fail-fast", "", false, flgs.Usage("FailFast"))
 	runCmd.Flags().BoolVarP(&flgs.SkipTest, "skip-test", "", false, flgs.Usage("SkipTest"))
 	runCmd.Flags().BoolVarP(&flgs.SkipIncluded, "skip-included", "", false, flgs.Usage("SkipIncluded"))
-	runCmd.Flags().StringVarP(&flgs.HTTPOpenApi3, "http-openapi3", "", "", flgs.Usage("HTTPOpenApi3"))
+	runCmd.Flags().StringSliceVarP(&flgs.HTTPOpenApi3s, "http-openapi3", "", []string{}, flgs.Usage("HTTPOpenApi3s"))
 	runCmd.Flags().BoolVarP(&flgs.GRPCNoTLS, "grpc-no-tls", "", false, flgs.Usage("GRPCNoTLS"))
 	runCmd.Flags().StringSliceVarP(&flgs.GRPCProtos, "grpc-proto", "", []string{}, flgs.Usage("GRPCProtos"))
 	runCmd.Flags().StringSliceVarP(&flgs.GRPCImportPaths, "grpc-import-path", "", []string{}, flgs.Usage("GRPCImportPaths"))

--- a/coverage.go
+++ b/coverage.go
@@ -16,12 +16,12 @@ import (
 var varRep = regexp.MustCompile(`\{\{([^}]+)\}\}`)
 var qRep = regexp.MustCompile(`\?.+$`)
 
-// Coverage is a coverage of runbooks
+// Coverage is a coverage of runbooks.
 type Coverage struct {
 	Specs []*SpecCoverage `json:"specs"`
 }
 
-// SpecCoverage is a coverage of spec (e.g. OpenAPI Document, servive of protocol buffers)
+// SpecCoverage is a coverage of spec (e.g. OpenAPI Document, servive of protocol buffers).
 type SpecCoverage struct {
 	Key       string         `json:"key"`
 	Coverages map[string]int `json:"coverages"`
@@ -61,7 +61,10 @@ func (o *operator) collectCoverage(ctx context.Context) (*Coverage, error) {
 			}
 		L:
 			for p, m := range s.httpRequest {
-				mm := m.(map[string]any)
+				mm, ok := m.(map[string]any)
+				if !ok {
+					continue
+				}
 				for mmm := range mm {
 					method := strings.ToUpper(mmm)
 					// Find path using openapi3 spec document (e.g. /v1/users/{id})

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -28,7 +28,7 @@ type Flags struct {
 	SkipIncluded    bool     `usage:"skip running the included runbook by itself"`
 	RunMatch        string   `usage:"run all runbooks with a matching file path, treating the value passed to the option as an unanchored regular expression"`
 	RunID           string   `usage:"run the matching runbook if there is only one runbook with a forward matching ID"`
-	HTTPOpenApi3    string   `usage:"set the path to the OpenAPI v3 document for all HTTP runners"`
+	HTTPOpenApi3s   []string `usage:"set the path to the OpenAPI v3 document for HTTP runners (\"path/to/spec.yml\" or \"key:path/to/spec.yml\")"`
 	GRPCNoTLS       bool     `usage:"disable TLS use in all gRPC runners"`
 	GRPCProtos      []string `usage:"set the name of proto source for all gRPC runners"`
 	GRPCImportPaths []string `usage:"set the path to the directory where proto sources can be imported for all gRPC runners"`
@@ -73,7 +73,7 @@ func (f *Flags) ToOpts() ([]runn.Option, error) {
 		runn.Debug(f.Debug),
 		runn.SkipTest(f.SkipTest),
 		runn.SkipIncluded(f.SkipIncluded),
-		runn.HTTPOpenApi3(f.HTTPOpenApi3),
+		runn.HTTPOpenApi3s(f.HTTPOpenApi3s),
 		runn.GRPCNoTLS(f.GRPCNoTLS),
 		runn.GRPCProtos(f.GRPCProtos),
 		runn.GRPCImportPaths(f.GRPCImportPaths),

--- a/operator.go
+++ b/operator.go
@@ -484,13 +484,20 @@ func New(opts ...Option) (*operator, error) {
 	for k, v := range bk.httpRunners {
 		v.operator = o
 		if _, ok := v.validator.(*nopValidator); ok {
-			val, err := newHttpValidator(&httpRunnerConfig{
-				OpenApi3DocLocation: bk.openApi3DocLocation,
-			})
-			if err != nil {
-				return nil, err
+			for _, l := range bk.openApi3DocLocations {
+				key, p := splitKeyAndPath(l)
+				if key != "" && key != k {
+					continue
+				}
+				val, err := newHttpValidator(&httpRunnerConfig{
+					OpenApi3DocLocation: p,
+				})
+				if err != nil {
+					return nil, err
+				}
+				v.validator = val
+				break
 			}
-			v.validator = val
 		}
 		o.httpRunners[k] = v
 	}

--- a/option.go
+++ b/option.go
@@ -631,10 +631,19 @@ func Force(enable bool) Option {
 	}
 }
 
-// HTTPOpenApi3 - Set the path of OpenAPI Document for all HTTP runners.
+// HTTPOpenApi3 - Set the path of OpenAPI Document for HTTP runners.
+// Deprecated: Use HTTPOpenApi3s instead.
 func HTTPOpenApi3(l string) Option {
 	return func(bk *book) error {
-		bk.openApi3DocLocation = l
+		bk.openApi3DocLocations = []string{l}
+		return nil
+	}
+}
+
+// HTTPOpenApi3s - Set the path of OpenAPI Document for HTTP runners.
+func HTTPOpenApi3s(locations []string) Option {
+	return func(bk *book) error {
+		bk.openApi3DocLocations = locations
 		return nil
 	}
 }

--- a/path.go
+++ b/path.go
@@ -320,6 +320,15 @@ func splitList(pathp string) []string {
 	return listp
 }
 
+func splitKeyAndPath(kp string) (string, string) {
+	const sep = ":"
+	if !strings.Contains(kp, sep) || strings.HasPrefix(kp, prefixHttps) || strings.HasPrefix(kp, prefixGitHub) {
+		return "", kp
+	}
+	pair := strings.SplitN(kp, sep, 2)
+	return pair[0], pair[1]
+}
+
 func repKey(in string) string {
 	return fmt.Sprintf("RUNN_%s_SCHEME", strings.TrimSuffix(strings.ToUpper(in), "://"))
 }


### PR DESCRIPTION
```console
$ runn run *.yml \
--runner req:https://example.test \
--runner req2:https://other.test \
--http-openapi3 req:path/to/openapi3.yaml \
--http-openapi3 req2:path/to/other.yaml
```