### PR TITLE
String containing vars number expanded by include is interpreted as a numerical value

### DIFF
--- a/include_test.go
+++ b/include_test.go
@@ -18,6 +18,15 @@ func TestIncludeRunnerRun(t *testing.T) {
 		{"testdata/book/db.yml", map[string]any{}, 8},
 		{"testdata/book/db.yml", map[string]any{"foo": "bar"}, 8},
 		{"testdata/book/db.yml", map[string]any{"json": "json://../vars.json"}, 8},
+		{
+			"testdata/book/include_str_int.yml",
+			map[string]any{
+				"a":   "010000000{{ vars.int }}",
+				"b":   "1601{{ vars.int }}",
+				"int": 1,
+			},
+			1,
+		},
 	}
 	ctx := context.Background()
 	for _, tt := range tests {

--- a/operator_test.go
+++ b/operator_test.go
@@ -259,6 +259,7 @@ func TestRunUsingLoop(t *testing.T) {
 		book string
 	}{
 		{"testdata/book/loop.yml"},
+		{"testdata/book/include_loop.yml"},
 	}
 	ctx := context.Background()
 	for _, tt := range tests {

--- a/testdata/book/include_loop.yml
+++ b/testdata/book/include_loop.yml
@@ -1,14 +1,14 @@
-desc: Test include loop
+desc: Test include loop(include was not involved.)
 vars:
   lists:
     - 1
     - 2
     - 3 
+  int: 1
 steps:
-  include_loop:
-    loop: len(vars.lists)
+  include_not_loop:
     include:
       path: include_str_int.yml
       vars:
-        a: '010000000{{ i }}'
-        b: '1601{{ i }}'
+        a: '010000000{{ vars.int }}'
+        b: '1601{{ vars.int }}'

--- a/testdata/book/include_loop.yml
+++ b/testdata/book/include_loop.yml
@@ -1,0 +1,14 @@
+desc: Test include loop
+vars:
+  lists:
+    - 1
+    - 2
+    - 3 
+steps:
+  include_loop:
+    loop: len(vars.lists)
+    include:
+      path: include_str_int.yml
+      vars:
+        a: '010000000{{ i }}'
+        b: '1601{{ i }}'

--- a/testdata/book/include_str_int.yml
+++ b/testdata/book/include_str_int.yml
@@ -1,0 +1,9 @@
+desc: For include loop test
+vars:
+  a: null
+  b: null
+steps:
+  t_main:
+    test: |
+      vars.a == "0100000001"
+      && vars.b == "16011"


### PR DESCRIPTION
Created a verification test that fails. It fails as follows
```
        Condition:
          vars.a == "0100000001"
          && vars.b == "16011"
          │
          ├── vars.a => 16777216
          ├── "0100000001" => "0100000001"
          ├── vars.b => 16010
          └── "16011" => "16011"
```