### PR TITLE
Add prefix to random ID to make it clear that it is randomly generated

### DIFF
--- a/id.go
+++ b/id.go
@@ -85,11 +85,12 @@ func generateID(p string) (string, error) {
 }
 
 func generateRandomID() (string, error) {
+	const prefix = "r-"
 	h := sha1.New() //#nosec G401
 	if _, err := io.WriteString(h, xid.New().String()); err != nil {
 		return "", err
 	}
-	return hex.EncodeToString(h.Sum(nil)), nil
+	return prefix + hex.EncodeToString(h.Sum(nil)), nil
 }
 
 func reversePath(p string) []string {

--- a/operator.go
+++ b/operator.go
@@ -386,7 +386,7 @@ func New(opts ...Option) (*operator, error) {
 	if err := bk.applyOptions(opts...); err != nil {
 		return nil, err
 	}
-	id, err := generateID(bk.path)
+	id, err := generateRandomID()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The initial ID of the operator is to be a random ID.