### PR TITLE
Fixed a bug with subdomain enabled cookies

### DIFF
--- a/http.go
+++ b/http.go
@@ -288,7 +288,13 @@ func (r *httpRequest) setCookieHeader(req *http.Request, cookies map[string]map[
 				if l, err := isLocalhost(domain); !l || err != nil {
 					continue
 				}
-			} else if !strings.HasSuffix(domain, host) {
+			} else if strings.HasPrefix(host, ".") {
+				// Subdomain did not match
+				if !strings.HasSuffix(domain, host) && domain != host[1:] {
+					continue
+				}
+			} else if domain != host {
+				// Domain did not match exactly
 				continue
 			}
 

--- a/http_test.go
+++ b/http_test.go
@@ -737,6 +737,24 @@ func TestSetCookieHeader(t *testing.T) {
 		},
 		{
 			&use,
+			"https://gist.github.com/k1low",
+			map[string]map[string]*http.Cookie{".github.com": {"key": &http.Cookie{Name: "key", Value: "value9", Path: "/"}}},
+			"key=value9",
+		},
+		{
+			&use,
+			"https://github.com/k1low",
+			map[string]map[string]*http.Cookie{".github.com": {"key": &http.Cookie{Name: "key", Value: "value9", Path: "/"}}},
+			"key=value9",
+		},
+		{
+			&use,
+			"https://gist.github.com/k1low",
+			map[string]map[string]*http.Cookie{"github.com": {"key": &http.Cookie{Name: "key", Value: "value9", Path: "/"}}},
+			"",
+		},
+		{
+			&use,
 			"https://127.0.0.1/k1low",
 			map[string]map[string]*http.Cookie{"localhost": {"key": &http.Cookie{Name: "key", Value: "value10", Path: "/"}}},
 			"key=value10",

--- a/http_test.go
+++ b/http_test.go
@@ -726,13 +726,13 @@ func TestSetCookieHeader(t *testing.T) {
 		{
 			&use,
 			"https://gist.github.com/k1low",
-			map[string]map[string]*http.Cookie{"github.com": {"key": &http.Cookie{Name: "key", Value: "value8", Path: "/"}}},
+			map[string]map[string]*http.Cookie{"gist.github.com": {"key": &http.Cookie{Name: "key", Value: "value8", Path: "/"}}},
 			"key=value8",
 		},
 		{
 			&use,
 			"https://gist.github.com/k1low",
-			map[string]map[string]*http.Cookie{"github.com": {"key": &http.Cookie{Name: "key", Value: "value9", Path: "/", Expires: time.Now()}}},
+			map[string]map[string]*http.Cookie{"gist.github.com": {"key": &http.Cookie{Name: "key", Value: "value9", Path: "/", Expires: time.Now()}}},
 			"",
 		},
 		{


### PR DESCRIPTION
The domain of a cookie can be either a domain that starts with a dot or a domain that does not start with a dot.
A domain that starts with a dot is limited to the domain and its subdomains.
For example, a cookie set on the domain .github.com will be sent to subdomains such as gist.github.com and api.github.com.
On the other hand, a domain that does not start with a dot is limited to the domain itself.
For example, a cookie set on the domain github.com will only be sent to zenn.dev