### PR TITLE
Implicitly enable scope `run:parent` if `--and-run` is enabled

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -155,6 +155,7 @@ func runAndCapture(ctx context.Context, o *os.File, fn func(*os.File) error) err
 		runn.GRPCNoTLS(flgs.GRPCNoTLS),
 		runn.GRPCProtos(flgs.GRPCProtos),
 		runn.GRPCImportPaths(flgs.GRPCImportPaths),
+		runn.Scopes(runn.ScopeAllowReadParent),
 	}
 	oo, err := runn.New(opts...)
 	if err != nil {


### PR DESCRIPTION
ref: https://zenn.dev/link/comments/20c5b63af49c08