### PR TITLE
Introduce pick() expr built-in function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1672,6 +1672,7 @@ See [Language Definition](https://github.com/antonmedv/expr/blob/master/docs/Lan
 - `bool` ... [cast.ToBool](https://pkg.go.dev/github.com/spf13/cast#ToBool)
 - `compare` ... Compare two values ( `func(x, y any, ignoreKeys ...string) bool` ).
 - `diff` ... Difference between two values ( `func(x, y any, ignoreKeys ...string) string` ).
+- `pick` ... Returns same map type filtered by given keys left [lo.PickByKeys](https://github.com/samber/lo?tab=readme-ov-file#pickbykeys).
 - `input` ... [prompter.Prompt](https://pkg.go.dev/github.com/Songmu/prompter#Prompt)
 - `intersect` ... Find the intersection of two iterable values ( `func(x, y any) any` ).
 - `secret` ... [prompter.Password](https://pkg.go.dev/github.com/Songmu/prompter#Password)

--- a/builtin/pick.go
+++ b/builtin/pick.go
@@ -1,0 +1,24 @@
+package builtin
+
+import (
+	"fmt"
+
+	"github.com/samber/lo"
+)
+
+func Pick(x any, keys ...string) any {
+	d, err := pick(x, keys...)
+	if err != nil {
+		panic(err)
+	}
+
+	return d
+}
+
+func pick(x any, keys ...string) (any, error) {
+	if t, ok := x.(map[string]any); ok {
+		return lo.PickByKeys(t, keys), nil
+	} else {
+		return nil, fmt.Errorf("unsupported type: %T", x)
+	}
+}

--- a/builtin/pick_test.go
+++ b/builtin/pick_test.go
@@ -1,0 +1,36 @@
+package builtin
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestPick(t *testing.T) {
+	tests := []struct {
+		x    any
+		keys []string
+		want any
+	}{
+		{map[string]any{"a": int(1), "b": int(2), "c": int(3)}, []string{"a", "c"}, map[string]any{"a": int(1), "c": int(3)}},
+		{map[string]any{"a": "foo", "b": "bar", "c": "baz"}, []string{"a", "c"}, map[string]any{"a": "foo", "c": "baz"}},
+		{map[string]any{"a": true, "b": true, "c": false}, []string{"a", "c"}, map[string]any{"a": true, "c": false}},
+		{map[string]any{"a": 1.0, "b": 2.0, "c": 3.0}, []string{"a", "c"}, map[string]any{"a": 1.0, "c": 3.0}},
+		{map[string]any{"a": []string{"foo"}, "b": []string{"bar"}, "c": []string{"baz"}}, []string{"a", "c"}, map[string]any{"a": []string{"foo"}, "c": []string{"baz"}}},
+		{map[string]any{"a": map[string]any{"a": 1}, "b": map[string]any{"b": 2}, "c": map[string]any{"c": 3}}, []string{"a", "c"}, map[string]any{"a": map[string]any{"a": 1}, "c": map[string]any{"c": 3}}},
+		{map[string]any{"a": int(1), "b": int(2)}, []string{"a", "not_existing_key"}, map[string]any{"a": int(1)}},
+		{map[string]any{}, []string{"not_existing_key"}, map[string]any{}},
+		{map[string]any{}, []string{}, map[string]any{}},
+		{
+			map[string]any{"a": int(1), "b": 2.0, "c": "3", "d": true, "e": nil, "f": []int{6}, "g": map[string]any{"h": 7}, "i": nil},
+			[]string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "not_existing_key"},
+			map[string]any{"a": int(1), "b": 2.0, "c": "3", "d": true, "e": nil, "f": []int{6}, "g": map[string]any{"h": 7}, "i": nil},
+		},
+	}
+	for _, tt := range tests {
+		got := Pick(tt.x, tt.keys...)
+		if diff := cmp.Diff(got, tt.want); diff != "" {
+			t.Error(diff)
+		}
+	}
+}

--- a/option.go
+++ b/option.go
@@ -1045,6 +1045,7 @@ func setupBuiltinFunctions(opts ...Option) []Option {
 		Func("compare", builtin.Compare),
 		Func("diff", builtin.Diff),
 		Func("intersect", builtin.Intersect),
+		Func("pick", builtin.Pick),
 		Func("input", func(msg, defaultMsg any) string {
 			return prompter.Prompt(cast.ToString(msg), cast.ToString(defaultMsg))
 		}),

--- a/option_test.go
+++ b/option_test.go
@@ -1,6 +1,7 @@
 package runn
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"net/http"
@@ -910,6 +911,7 @@ func TestSetupBuiltinFunctions(t *testing.T) {
 		{"time"},
 		{"compare"},
 		{"diff"},
+		{"pick"},
 		{"intersect"},
 		{"sprintf"},
 		{"basename"},
@@ -1005,6 +1007,35 @@ func TestOptionRunID(t *testing.T) {
 			}
 			if diff := cmp.Diff(tt.want, bk.runIDs); diff != "" {
 				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestBuiltinFunctionBooks(t *testing.T) {
+	tests := []struct {
+		book    string
+		wantErr bool
+	}{
+		{"testdata/book/builtin_pick.yml", false},
+	}
+	ctx := context.Background()
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.book, func(t *testing.T) {
+			t.Parallel()
+			o, err := New(Book(tt.book))
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("got %v", err)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Errorf("want err")
+			}
+			if err := o.Run(ctx); err != nil {
+				t.Error(err)
 			}
 		})
 	}

--- a/testdata/book/builtin_pick.yml
+++ b/testdata/book/builtin_pick.yml
@@ -1,0 +1,8 @@
+desc: For pick() built-in function
+steps:
+  pick:
+    test: |
+      compare(
+        pick({"a": 1, "b": 2, "c": 3}, "a", "c"),
+        {"a": 1, "c": 3}
+      )


### PR DESCRIPTION
This pull request adds `pick()` built-in expr function which is equivalent to the samber/lo's [`PickByKeys()`](https://github.com/samber/lo?tab=readme-ov-file#pickbykeys) function.

### example

```yaml
test: |
  compare(
    pick({"a": 1, "b": 2, "c": 3}, "a", "c"),
    {"a": 1, "c": 3}
  )
```

---

FYI: This PR is the 1st one that I implemented today. 

1.  https://github.com/h6ah4i/runn/tree/feature/add-built-in-function-pick 👈  This pull request
2. https://github.com/h6ah4i/runn/tree/feature/add-built-in-function-omit
3. https://github.com/h6ah4i/runn/tree/feature/add-built-in-function-merge
4. https://github.com/h6ah4i/runn/tree/feature/support-yaml-anchor-alias-handling