### PR TITLE
Introduce omit() expr built-in function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1673,6 +1673,7 @@ See [Language Definition](https://github.com/antonmedv/expr/blob/master/docs/Lan
 - `compare` ... Compare two values ( `func(x, y any, ignoreKeys ...string) bool` ).
 - `diff` ... Difference between two values ( `func(x, y any, ignoreKeys ...string) string` ).
 - `pick` ... Returns same map type filtered by given keys left [lo.PickByKeys](https://github.com/samber/lo?tab=readme-ov-file#pickbykeys).
+- `omit` ... Returns same map type filtered by given keys excluded [lo.OmitByKeys](https://github.com/samber/lo?tab=readme-ov-file#omitbykeys).
 - `input` ... [prompter.Prompt](https://pkg.go.dev/github.com/Songmu/prompter#Prompt)
 - `intersect` ... Find the intersection of two iterable values ( `func(x, y any) any` ).
 - `secret` ... [prompter.Password](https://pkg.go.dev/github.com/Songmu/prompter#Password)

--- a/builtin/omit.go
+++ b/builtin/omit.go
@@ -1,0 +1,24 @@
+package builtin
+
+import (
+	"fmt"
+
+	"github.com/samber/lo"
+)
+
+func Omit(x any, keys ...string) any {
+	d, err := omit(x, keys...)
+	if err != nil {
+		panic(err)
+	}
+
+	return d
+}
+
+func omit(x any, keys ...string) (any, error) {
+	if t, ok := x.(map[string]any); ok {
+		return lo.OmitByKeys(t, keys), nil
+	} else {
+		return nil, fmt.Errorf("unsupported type: %T", x)
+	}
+}

--- a/builtin/omit_test.go
+++ b/builtin/omit_test.go
@@ -1,0 +1,36 @@
+package builtin
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestOmit(t *testing.T) {
+	tests := []struct {
+		x    any
+		keys []string
+		want any
+	}{
+		{map[string]any{"a": int(1), "b": int(2), "c": int(3)}, []string{"b"}, map[string]any{"a": int(1), "c": int(3)}},
+		{map[string]any{"a": "foo", "b": "bar", "c": "baz"}, []string{"b"}, map[string]any{"a": "foo", "c": "baz"}},
+		{map[string]any{"a": true, "b": true, "c": false}, []string{"b"}, map[string]any{"a": true, "c": false}},
+		{map[string]any{"a": 1.0, "b": 2.0, "c": 3.0}, []string{"b"}, map[string]any{"a": 1.0, "c": 3.0}},
+		{map[string]any{"a": []string{"foo"}, "b": []string{"bar"}, "c": []string{"baz"}}, []string{"b"}, map[string]any{"a": []string{"foo"}, "c": []string{"baz"}}},
+		{map[string]any{"a": map[string]any{"a": 1}, "b": map[string]any{"b": 2}, "c": map[string]any{"c": 3}}, []string{"b"}, map[string]any{"a": map[string]any{"a": 1}, "c": map[string]any{"c": 3}}},
+		{map[string]any{"a": int(1), "b": int(2)}, []string{"b", "not_existing_key"}, map[string]any{"a": int(1)}},
+		{map[string]any{}, []string{"not_existing_key"}, map[string]any{}},
+		{map[string]any{}, []string{}, map[string]any{}},
+		{
+			map[string]any{"a": int(1), "b": 2.0, "c": "3", "d": true, "e": nil, "f": []int{6}, "g": map[string]any{"h": 7}, "i": nil},
+			[]string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "not_existing_key"},
+			map[string]any{},
+		},
+	}
+	for _, tt := range tests {
+		got := Omit(tt.x, tt.keys...)
+		if diff := cmp.Diff(got, tt.want); diff != "" {
+			t.Error(diff)
+		}
+	}
+}

--- a/option.go
+++ b/option.go
@@ -1046,6 +1046,7 @@ func setupBuiltinFunctions(opts ...Option) []Option {
 		Func("diff", builtin.Diff),
 		Func("intersect", builtin.Intersect),
 		Func("pick", builtin.Pick),
+		Func("omit", builtin.Omit),
 		Func("input", func(msg, defaultMsg any) string {
 			return prompter.Prompt(cast.ToString(msg), cast.ToString(defaultMsg))
 		}),

--- a/option_test.go
+++ b/option_test.go
@@ -1018,6 +1018,7 @@ func TestBuiltinFunctionBooks(t *testing.T) {
 		wantErr bool
 	}{
 		{"testdata/book/builtin_pick.yml", false},
+		{"testdata/book/builtin_omit.yml", false},
 	}
 	ctx := context.Background()
 	for _, tt := range tests {

--- a/testdata/book/builtin_omit.yml
+++ b/testdata/book/builtin_omit.yml
@@ -1,0 +1,8 @@
+desc: For omit() built-in function
+steps:
+  omit:
+    test: |
+      compare(
+        omit({"a": 1, "b": 2, "c": 3}, "b"),
+        {"a": 1, "c": 3}
+      )


### PR DESCRIPTION
This pull request adds `omit()` built-in expr function which is equivalent to the samber/lo's [`OmitByKeys()`](https://github.com/samber/lo?tab=readme-ov-file#omitbykeys) function.

### example

```yaml
test: |
  compare(
    omit({"a": 1, "b": 2, "c": 3}, "b"),
    {"a": 1, "c": 3}
  )
```
※ I know that the `compare()` function has the same behavior included, but this new function is still useful for composing JSON object in other places.

---

FYI: This PR is the 1st one that I implemented yesterday. 

1.  ~~https://github.com/h6ah4i/runn/tree/feature/add-built-in-function-pick~~ (Thx, already merged :pray:)
2. https://github.com/h6ah4i/runn/tree/feature/add-built-in-function-omit 👈  This pull request
3. https://github.com/h6ah4i/runn/tree/feature/add-built-in-function-merge
4. https://github.com/h6ah4i/runn/tree/feature/support-yaml-anchor-alias-handling