### PR TITLE
Introduce merge() expr built-in function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1674,6 +1674,7 @@ See [Language Definition](https://github.com/antonmedv/expr/blob/master/docs/Lan
 - `diff` ... Difference between two values ( `func(x, y any, ignoreKeys ...string) string` ).
 - `pick` ... Returns same map type filtered by given keys left [lo.PickByKeys](https://github.com/samber/lo?tab=readme-ov-file#pickbykeys).
 - `omit` ... Returns same map type filtered by given keys excluded [lo.OmitByKeys](https://github.com/samber/lo?tab=readme-ov-file#omitbykeys).
+- `merge` ... Merges multiple maps from left to right [lo.Assign](https://github.com/samber/lo?tab=readme-ov-file#assign).
 - `input` ... [prompter.Prompt](https://pkg.go.dev/github.com/Songmu/prompter#Prompt)
 - `intersect` ... Find the intersection of two iterable values ( `func(x, y any) any` ).
 - `secret` ... [prompter.Password](https://pkg.go.dev/github.com/Songmu/prompter#Password)

--- a/builtin/merge.go
+++ b/builtin/merge.go
@@ -1,0 +1,28 @@
+package builtin
+
+import (
+	"fmt"
+
+	"github.com/samber/lo"
+)
+
+func Merge(x ...any) any {
+	d, err := merge(x...)
+	if err != nil {
+		panic(err)
+	}
+
+	return d
+}
+
+func merge(x ...any) (any, error) {
+	y := make([]map[string]any, len(x))
+	for _, t := range x {
+		if t, ok := t.(map[string]any); ok {
+			y = append(y, t)
+		} else {
+			return nil, fmt.Errorf("unsupported type: %T", x)
+		}
+	}
+	return lo.Assign(y...), nil
+}

--- a/builtin/merge_test.go
+++ b/builtin/merge_test.go
@@ -1,0 +1,69 @@
+package builtin
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMerge(t *testing.T) {
+	tests := []struct {
+		x    []any
+		want map[string]any
+	}{
+		{
+			[]any{},
+			map[string]any{},
+		},
+		{
+			[]any{map[string]any{"a": 1}},
+			map[string]any{"a": 1},
+		},
+		{
+			[]any{map[string]any{"a": 1}, map[string]any{"b": 2}},
+			map[string]any{"a": 1, "b": 2},
+		},
+		{
+			[]any{map[string]any{"a": 1, "b": 2}, map[string]any{"b": 3, "c": 4}},
+			map[string]any{"a": 1, "b": 3, "c": 4},
+		},
+		{
+			[]any{map[string]any{"a": 1, "b": 2}, map[string]any{"b": 3, "c": 4}, map[string]any{"a": 5}},
+			map[string]any{"a": 5, "b": 3, "c": 4},
+		},
+		{
+			[]any{map[string]any{"a": "foo"}, map[string]any{"b": "bar"}},
+			map[string]any{"a": "foo", "b": "bar"},
+		},
+		{
+			[]any{map[string]any{"a": true}, map[string]any{"b": false}},
+			map[string]any{"a": true, "b": false},
+		},
+		{
+			[]any{map[string]any{"a": int(1)}, map[string]any{"b": int(2)}},
+			map[string]any{"a": int(1), "b": int(2)},
+		},
+		{
+			[]any{map[string]any{"a": 1.0}, map[string]any{"b": 2.0}},
+			map[string]any{"a": 1.0, "b": 2.0},
+		},
+		{
+			[]any{map[string]any{"a": nil}, map[string]any{"b": nil}},
+			map[string]any{"a": nil, "b": nil},
+		},
+		{
+			[]any{map[string]any{"a": []string{"foo"}}, map[string]any{"b": []string{"bar"}}},
+			map[string]any{"a": []string{"foo"}, "b": []string{"bar"}},
+		},
+		{
+			[]any{map[string]any{"a": map[string]string{"foo": "bar"}}, map[string]any{"baz": map[string]string{"baz": "qux"}}},
+			map[string]any{"a": map[string]string{"foo": "bar"}, "baz": map[string]string{"baz": "qux"}},
+		},
+	}
+	for _, tt := range tests {
+		got := Merge(tt.x...)
+		if diff := cmp.Diff(got, tt.want); diff != "" {
+			t.Error(diff)
+		}
+	}
+}

--- a/option.go
+++ b/option.go
@@ -1047,6 +1047,7 @@ func setupBuiltinFunctions(opts ...Option) []Option {
 		Func("intersect", builtin.Intersect),
 		Func("pick", builtin.Pick),
 		Func("omit", builtin.Omit),
+		Func("merge", builtin.Merge),
 		Func("input", func(msg, defaultMsg any) string {
 			return prompter.Prompt(cast.ToString(msg), cast.ToString(defaultMsg))
 		}),

--- a/option_test.go
+++ b/option_test.go
@@ -1019,6 +1019,7 @@ func TestBuiltinFunctionBooks(t *testing.T) {
 	}{
 		{"testdata/book/builtin_pick.yml", false},
 		{"testdata/book/builtin_omit.yml", false},
+		{"testdata/book/builtin_merge.yml", false},
 	}
 	ctx := context.Background()
 	for _, tt := range tests {

--- a/testdata/book/builtin_merge.yml
+++ b/testdata/book/builtin_merge.yml
@@ -1,0 +1,8 @@
+desc: For merge() built-in function
+steps:
+  merge:
+    test: |
+      compare(
+        merge({"a": 1, "b": 2}, {"b": 3, "c": 4}),
+        {"a": 1, "b": 3, "c": 4}
+      )


### PR DESCRIPTION
This pull request adds `merge()` built-in expr function which is equivalent to the samber/lo's [`Assign()`](https://github.com/samber/lo?tab=readme-ov-file#assign) function.

### example

```yaml
test: |
  compare(
    merge({"a": 1, "b": 2}, {"b": 3, "c": 4}),
    {"a": 1, "b": 3, "c": 4}
  )
```

---

FYI: This PR is the 3rd one that I implemented yesterday. 

1.  ~~https://github.com/h6ah4i/runn/tree/feature/add-built-in-function-pick~~ (Thx, already merged :pray:)
2. ~~https://github.com/h6ah4i/runn/tree/feature/add-built-in-function-omit~~ (Thx, already merged :pray:)
3. https://github.com/h6ah4i/runn/tree/feature/add-built-in-function-merge 👈  This pull request
4. https://github.com/h6ah4i/runn/tree/feature/support-yaml-anchor-alias-handling