### PR TITLE
Support using YAML's anchors and aliases in runbooks

### DIFF
--- a/http.go
+++ b/http.go
@@ -166,6 +166,21 @@ func (r *httpRequest) encodeBody() (io.Reader, error) {
 			return strings.NewReader(v), nil
 		case []byte:
 			return bytes.NewBuffer(r.body.([]byte)), nil
+		case []any:
+			// NOTE: flattenYamlAliases converts !!binary base64 data into array
+			arr, ok := r.body.([]any)
+			if !ok {
+				return nil, fmt.Errorf("invalid body: %v", r.body)
+			}
+			b := make([]byte, len(arr))
+			for i := range arr {
+				u64, ok := arr[i].(uint64)
+				if !ok {
+					return nil, fmt.Errorf("invalid body: %v", r.body)
+				}
+				b[i] = (uint8)(u64 & 0xff)
+			}
+			return bytes.NewBuffer(b), nil
 		}
 		return nil, fmt.Errorf("invalid body: %v", r.body)
 	case MediaTypeTextPlain:

--- a/runbook_test.go
+++ b/runbook_test.go
@@ -2,6 +2,7 @@ package runn
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -260,6 +261,35 @@ func TestRunbookValidate(t *testing.T) {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			if err := tt.rb.validate(); (err != nil) != tt.wantErr {
 				t.Errorf("runbook.validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRunbookYamlAnchorAndAlias(t *testing.T) {
+	tests := []struct {
+		book    string
+		wantErr bool
+	}{
+		{"testdata/book/yaml_anchor_alias.yml", false},
+	}
+	ctx := context.Background()
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.book, func(t *testing.T) {
+			t.Parallel()
+			o, err := New(Book(tt.book))
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("got %v", err)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Errorf("want err")
+			}
+			if err := o.Run(ctx); err != nil {
+				t.Error(err)
 			}
 		})
 	}

--- a/runbook_test.go
+++ b/runbook_test.go
@@ -221,6 +221,10 @@ func TestPickStepYAML(t *testing.T) {
 		{"testdata/book/github_map.yml", 3},
 		{"testdata/book/single_step.yml", 0},
 		{"testdata/book/single_step_map.yml", 0},
+		{"testdata/book/yaml_anchor_alias.yml", 0},
+		{"testdata/book/yaml_anchor_alias.yml", 7},
+		{"testdata/book/yaml_anchor_alias_always_failure.yml", 0},
+		{"testdata/book/yaml_anchor_alias_always_failure.yml", 1},
 	}
 	for _, tt := range tests {
 		key := fmt.Sprintf("%s.%d", tt.runbook, tt.idx)
@@ -268,10 +272,11 @@ func TestRunbookValidate(t *testing.T) {
 
 func TestRunbookYamlAnchorAndAlias(t *testing.T) {
 	tests := []struct {
-		book    string
-		wantErr bool
+		book       string
+		wantRunErr bool
 	}{
 		{"testdata/book/yaml_anchor_alias.yml", false},
+		{"testdata/book/yaml_anchor_alias_always_failure.yml", true},
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
@@ -280,16 +285,19 @@ func TestRunbookYamlAnchorAndAlias(t *testing.T) {
 			t.Parallel()
 			o, err := New(Book(tt.book))
 			if err != nil {
-				if !tt.wantErr {
-					t.Errorf("got %v", err)
-				}
+				t.Errorf("got %v", err)
 				return
 			}
-			if tt.wantErr {
-				t.Errorf("want err")
-			}
-			if err := o.Run(ctx); err != nil {
-				t.Error(err)
+
+			err = o.Run(ctx)
+			if err != nil {
+				if !tt.wantRunErr {
+					t.Errorf("got %v", err)
+				}
+			} else {
+				if tt.wantRunErr {
+					t.Errorf("want err")
+				}
 			}
 		})
 	}

--- a/testdata/book/yaml_anchor_alias.yml
+++ b/testdata/book/yaml_anchor_alias.yml
@@ -1,0 +1,64 @@
+desc: YAML's anchor & alias check
+
+my_aliases: # NOTE: this field name is not reserved by runn
+  my_string: &my_string_anchor "ABCDEFG"
+  my_array: &my_array_anchor
+    - 'A'
+    - 'B'
+  my_hash: &my_hash_anchor
+    a: 1
+    b: 2
+
+vars:
+  string: &str_anchor "abcdefg"
+  string_alias: *str_anchor
+  array: &arr_anchor
+    - 1
+    - 2
+  array_alias: *arr_anchor
+  hash: &hash_anchor
+    foo: 1
+    bar: 2
+  hash_alias: *hash_anchor
+  hash_alias_with_merged:
+    <<: *hash_anchor
+    baz: 3
+  my_string: *my_string_anchor
+  my_array: *my_array_anchor
+  my_hash: *my_hash_anchor
+  my_hash_with_merged:
+    <<: *my_hash_anchor
+    c: 3
+
+steps:
+  check_string_alias_in_vars:
+    test: |
+      vars.string_alias == "abcdefg"
+
+  check_array_alias_in_vars:
+    test: |
+      compare(vars.array_alias, [1, 2])
+
+  check_hash_alias_in_vars:
+    test: |
+      compare(vars.hash_alias, { foo: 1, bar: 2 })
+
+  check_hash_alias_with_merged_in_vars:
+    test: |
+      compare(vars.hash_alias_with_merged, { foo: 1, bar: 2, baz: 3 })
+
+  check_my_string:
+    test: |
+      compare(vars.my_string, "ABCDEFG")
+
+  check_my_array:
+    test: |
+      compare(vars.my_array, ["A", "B"])
+
+  check_my_hash:
+    test: |
+      compare(vars.my_hash, {a: 1, b: 2})
+
+  check_my_hash_with_merged:
+    test: |
+      compare(vars.my_hash_with_merged, {a: 1, b: 2, c: 3})

--- a/testdata/book/yaml_anchor_alias_always_failure.yml
+++ b/testdata/book/yaml_anchor_alias_always_failure.yml
@@ -1,0 +1,37 @@
+desc: YAML's anchor & alias check
+
+my_aliases: # NOTE: this field name is not reserved by runn
+  my_hash: &my_hash_anchor
+    a: 1
+    b: 2
+
+runners:
+  httpbin:
+    endpoint: https://httpbin.org/
+
+vars:
+  my_hash_anchor_merged:
+    <<: *my_hash_anchor
+    c: 3
+    d: 4
+  common_req_headers: &common_req_headers
+    accept: application/json
+    accept-language: en-US,en;q=0.9
+
+force: true
+
+steps:
+  check_1:
+    desc: 'with anchor & alias'
+    test: |
+      compare(vars.my_hash_anchor_merged, {a: 1, b: 2, c: 3, d: 100})
+
+  check_2:
+    desc: 'merging in HTTP header part'
+    httpbin:
+      /status/418:
+        get:
+          headers:
+            <<: *common_req_headers
+    test:
+      current.res.status != 418

--- a/testdata/pick_step.yaml_anchor_alias.yml.0.golden
+++ b/testdata/pick_step.yaml_anchor_alias.yml.0.golden
@@ -1,0 +1,4 @@
+34   check_string_alias_in_vars:
+35     test: |
+36       vars.string_alias == "abcdefg"
+37 

--- a/testdata/pick_step.yaml_anchor_alias.yml.7.golden
+++ b/testdata/pick_step.yaml_anchor_alias.yml.7.golden
@@ -1,0 +1,3 @@
+62   check_my_hash_with_merged:
+63     test: |
+64       compare(vars.my_hash_with_merged, {a: 1, b: 2, c: 3})

--- a/testdata/pick_step.yaml_anchor_alias_always_failure.yml.0.golden
+++ b/testdata/pick_step.yaml_anchor_alias_always_failure.yml.0.golden
@@ -1,0 +1,5 @@
+24   check_1:
+25     desc: 'with anchor & alias'
+26     test: |
+27       compare(vars.my_hash_anchor_merged, {a: 1, b: 2, c: 3, d: 100})
+28 

--- a/testdata/pick_step.yaml_anchor_alias_always_failure.yml.1.golden
+++ b/testdata/pick_step.yaml_anchor_alias_always_failure.yml.1.golden
@@ -1,0 +1,9 @@
+29   check_2:
+30     desc: 'merging in HTTP header part'
+31     httpbin:
+32       /status/418:
+33         get:
+34           headers:
+35             <<: *common_req_headers
+36     test:
+37       current.res.status != 418


### PR DESCRIPTION
This pull request introduces [YAML's anchors & aliases](https://medium.com/codex/yaml-aliases-32a9cc496a28) support in runbooks.

### example

The aliases are very useful if you want to re-use same fields multiple times.

```yaml
my_aliases:
  common_request_headers: &common_request_headers
    authorization: 'Bearer **********'
    accept: 'application/json'

steps:
  - req:
      /api-foo:
        get:
          headers:
            <<: *common_request_headers
            additionnal-header: foo
          body:
            application/json: null

  - req:
      /api-bar:
        get:
          headers:
            <<: *common_request_headers
            additionnal-header: bar
          body:
            application/json: null
```



---

FYI: This PR is the 4th one that I implemented yesterday. 

1.  ~~https://github.com/h6ah4i/runn/tree/feature/add-built-in-function-pick~~ (Thx, already merged :pray:)
2. ~~https://github.com/h6ah4i/runn/tree/feature/add-built-in-function-omit~~ (Thx, already merged :pray:)
3. ~~https://github.com/h6ah4i/runn/tree/feature/add-built-in-function-merge~~ (Thx, already merged :pray:)
4. https://github.com/h6ah4i/runn/tree/feature/support-yaml-anchor-alias-handling 👈  This pull request