### PR TITLE
Fix detectRunbookAreas() failure when the runbook has only 1 step in maps format

### DIFF
--- a/runbook.go
+++ b/runbook.go
@@ -500,6 +500,8 @@ func detectRunbookAreas(in string) *areas {
 			a.Runners = detectAreaFromNode(s)
 		case "steps":
 			switch steps := s.Value.(type) {
+			case *ast.MappingValueNode:
+				a.Steps = append(a.Steps, detectAreaFromNode(steps.Value))
 			case *ast.MappingNode:
 				for _, v := range steps.Values {
 					a.Steps = append(a.Steps, detectAreaFromNode(v))

--- a/runbook_test.go
+++ b/runbook_test.go
@@ -218,6 +218,8 @@ func TestPickStepYAML(t *testing.T) {
 		{"testdata/book/github.yml", 3},
 		{"testdata/book/github_map.yml", 0},
 		{"testdata/book/github_map.yml", 3},
+		{"testdata/book/single_step.yml", 0},
+		{"testdata/book/single_step_map.yml", 0},
 	}
 	for _, tt := range tests {
 		key := fmt.Sprintf("%s.%d", tt.runbook, tt.idx)

--- a/testdata/book/single_step.yml
+++ b/testdata/book/single_step.yml
@@ -1,0 +1,8 @@
+desc: Testing the step is mapped as ast.MappingValueNode when parsed
+
+vars:
+  hello: hello
+
+steps:
+  - test: |
+      vars.hello == "hello"

--- a/testdata/book/single_step_map.yml
+++ b/testdata/book/single_step_map.yml
@@ -1,0 +1,9 @@
+desc: Testing the step is mapped as ast.MappingValueNode when parsed
+
+vars:
+  hello: hello
+
+steps:
+  the_only_step:
+    test: |
+      vars.hello == "hello"

--- a/testdata/pick_step.single_step.yml.0.golden
+++ b/testdata/pick_step.single_step.yml.0.golden
@@ -1,0 +1,2 @@
+7   - test: |
+8       vars.hello == "hello"

--- a/testdata/pick_step.single_step_map.yml.0.golden
+++ b/testdata/pick_step.single_step_map.yml.0.golden
@@ -1,0 +1,2 @@
+8     test: |
+9       vars.hello == "hello"


### PR DESCRIPTION
I noticed that `detectRunbookAreas()` function fails to parse the `steps` section in a specific situation.

When a runbook only has **single step with map-style**, the step will be parsed as `ast.MappingValueNode` which is not currently handled by runn.