### PR TITLE
Revert inexplicable Unmarshal

### DIFF
--- a/result_test.go
+++ b/result_test.go
@@ -2,6 +2,7 @@ package runn
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -215,6 +216,30 @@ func TestResultOutJSON(t *testing.T) {
 			}
 			if diff := golden.Diff(t, "testdata", key, got); diff != "" {
 				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestResultElasped(t *testing.T) {
+	tests := []struct {
+		book string
+	}{
+		{"testdata/book/always_success.yml"},
+		{"testdata/book/always_failure.yml"},
+	}
+	ctx := context.Background()
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.book, func(t *testing.T) {
+			o, err := New(Book(tt.book))
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = o.Run(ctx)
+			result := o.Result()
+			if result.Elapsed == 0 {
+				t.Error("cannot measure elapsed time")
 			}
 		})
 	}


### PR DESCRIPTION
Elasped was not recorded in result.json due to an inexplicable Unmarshal.

ref: https://github.com/k1LoW/runn/commit/abc3ac308bf48c39c3dea0e46e48edec14ce4393#diff-5063501a84242fcc60e366cd9998632d2f48cd7838a1c58d6b7167c965986600L1514-R1518