### PR TITLE
Support for `hostRules:` (control of hostname/IP mapping) in HTTP runner, gRPC runner and CDP runner

### DIFF
--- a/book.go
+++ b/book.go
@@ -26,6 +26,7 @@ type book struct {
 	runners              map[string]any
 	vars                 map[string]any
 	rawSteps             []map[string]any
+	hostRules            hostRules
 	debug                bool
 	ifCond               string
 	skipTest             bool
@@ -539,6 +540,7 @@ func (bk *book) merge(loaded *book) error {
 	}
 	bk.runnerErrs = loaded.runnerErrs
 	bk.rawSteps = loaded.rawSteps
+	bk.hostRules = loaded.hostRules
 	bk.stepKeys = loaded.stepKeys
 	if !bk.debug {
 		bk.debug = loaded.debug

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/lestrrat-go/backoff/v2 v2.0.8
 	github.com/lib/pq v1.10.7
 	github.com/mattn/go-isatty v0.0.19
+	github.com/minio/pkg v1.7.5
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/ory/dockertest/v3 v3.9.1
@@ -129,7 +130,6 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mattn/go-shellwords v1.0.12 // indirect
-	github.com/minio/pkg v1.7.5 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 // indirect

--- a/hosts.go
+++ b/hosts.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/chromedp/chromedp"
+	"github.com/minio/pkg/wildcard"
 )
 
 type hostRule struct {
@@ -38,7 +39,7 @@ func (rules hostRules) dialContextFunc() func(ctx context.Context, network, addr
 			return nil, err
 		}
 		for _, rule := range rules {
-			if rule.host == host {
+			if wildcard.MatchSimple(rule.host, host) {
 				var rhost, rport string
 				if strings.Contains(rule.rule, ":") {
 					rhost, rport, err = net.SplitHostPort(rule.rule)
@@ -66,7 +67,7 @@ func (rules hostRules) contextDialerFunc() func(ctx context.Context, address str
 		}
 		var network string
 		for _, rule := range rules {
-			if rule.host == host {
+			if wildcard.MatchSimple(rule.host, host) {
 				var rhost, rport string
 				if strings.Contains(rule.rule, ":") {
 					rhost, rport, err = net.SplitHostPort(rule.rule)

--- a/hosts.go
+++ b/hosts.go
@@ -1,0 +1,117 @@
+package runn
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/chromedp/chromedp"
+)
+
+type hostRule struct {
+	host string
+	rule string
+}
+
+type hostRules []hostRule
+
+func (rules hostRules) chromedpOpt() chromedp.ExecAllocatorOption {
+	var values []string
+	for _, rule := range rules {
+		values = append(values, fmt.Sprintf("MAP %s %s", rule.host, rule.rule))
+	}
+	return chromedp.Flag("host-rules", strings.Join(values, ","))
+}
+
+// dialContextFunc returns DialContext() for http.Transport.DialContext
+func (rules hostRules) dialContextFunc() func(ctx context.Context, network, addr string) (net.Conn, error) {
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		for _, rule := range rules {
+			if rule.host == host {
+				var rhost, rport string
+				if strings.Contains(rule.rule, ":") {
+					rhost, rport, err = net.SplitHostPort(rule.rule)
+					if err != nil {
+						return nil, err
+					}
+				} else {
+					rhost = rule.rule
+					rport = port
+				}
+				return dialer.DialContext(ctx, network, net.JoinHostPort(rhost, rport))
+			}
+		}
+		return dialer.DialContext(ctx, network, addr)
+	}
+}
+
+// contextDialerFunc returns Dialer() for grpc.WithContextDialer
+func (rules hostRules) contextDialerFunc() func(ctx context.Context, address string) (net.Conn, error) {
+	dialer := &net.Dialer{} // Same as google.golang.org/grpc@v1.58.3/internal/transport.dial()
+	return func(ctx context.Context, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		var network string
+		for _, rule := range rules {
+			if rule.host == host {
+				var rhost, rport string
+				if strings.Contains(rule.rule, ":") {
+					rhost, rport, err = net.SplitHostPort(rule.rule)
+					if err != nil {
+						return nil, err
+					}
+				} else {
+					rhost = rule.rule
+					rport = port
+				}
+				address = net.JoinHostPort(rhost, rport)
+				network, address = parseDialTarget(address)
+				return dialer.DialContext(ctx, network, address)
+			}
+		}
+		network, address = parseDialTarget(address)
+		return dialer.DialContext(ctx, network, address)
+	}
+}
+
+// parseDialTarget returns the network and address to pass to dialer.
+// Copy from google.golang.org/grpc@v1.58.3/internal/transport/http_util.go
+func parseDialTarget(target string) (string, string) {
+	net := "tcp"
+	m1 := strings.Index(target, ":")
+	m2 := strings.Index(target, ":/")
+	// handle unix:addr which will fail with url.Parse
+	if m1 >= 0 && m2 < 0 {
+		if n := target[0:m1]; n == "unix" {
+			return n, target[m1+1:]
+		}
+	}
+	if m2 >= 0 {
+		t, err := url.Parse(target)
+		if err != nil {
+			return net, target
+		}
+		scheme := t.Scheme
+		addr := t.Path
+		if scheme == "unix" {
+			if addr == "" {
+				addr = t.Host
+			}
+			return scheme, addr
+		}
+	}
+	return net, target
+}

--- a/hosts.go
+++ b/hosts.go
@@ -26,7 +26,7 @@ func (rules hostRules) chromedpOpt() chromedp.ExecAllocatorOption {
 	return chromedp.Flag("host-rules", strings.Join(values, ","))
 }
 
-// dialContextFunc returns DialContext() for http.Transport.DialContext
+// dialContextFunc returns DialContext() for http.Transport.DialContext.
 func (rules hostRules) dialContextFunc() func(ctx context.Context, network, addr string) (net.Conn, error) {
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
@@ -56,7 +56,7 @@ func (rules hostRules) dialContextFunc() func(ctx context.Context, network, addr
 	}
 }
 
-// contextDialerFunc returns Dialer() for grpc.WithContextDialer
+// contextDialerFunc returns Dialer() for grpc.WithContextDialer.
 func (rules hostRules) contextDialerFunc() func(ctx context.Context, address string) (net.Conn, error) {
 	dialer := &net.Dialer{} // Same as google.golang.org/grpc@v1.58.3/internal/transport.dial()
 	return func(ctx context.Context, address string) (net.Conn, error) {
@@ -88,7 +88,7 @@ func (rules hostRules) contextDialerFunc() func(ctx context.Context, address str
 }
 
 // parseDialTarget returns the network and address to pass to dialer.
-// Copy from google.golang.org/grpc@v1.58.3/internal/transport/http_util.go
+// Copy from google.golang.org/grpc@v1.58.3/internal/transport/http_util.go.
 func parseDialTarget(target string) (string, string) {
 	net := "tcp"
 	m1 := strings.Index(target, ":")

--- a/hosts_test.go
+++ b/hosts_test.go
@@ -11,49 +11,82 @@ import (
 func TestHostRules(t *testing.T) {
 	ctx := context.Background()
 	t.Run("HTTP", func(t *testing.T) {
-		book := "testdata/book/http_with_host_rules.yml"
+		tests := []struct {
+			book string
+		}{
+			{"testdata/book/http_with_host_rules.yml"},
+			{"testdata/book/http_with_host_rules_wildcard.yml"},
+		}
 		ts, tr := testutil.HTTPServerAndRouter(t)
 		t.Setenv("TEST_HTTP_HOST_RULE", strings.TrimPrefix(ts.URL, "http://"))
-		o, err := New(Book(book))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := o.Run(ctx); err != nil {
-			t.Error(err)
-		}
-		want := "example.com"
-		if tr.Requests()[0].Host != "example.com" {
-			t.Errorf("got %s want %s", tr.Requests()[0].Host, want)
+		for _, tt := range tests {
+			t.Run(tt.book, func(t *testing.T) {
+				tr.ClearRequests()
+				o, err := New(Book(tt.book))
+				if err != nil {
+					t.Fatal(err)
+					return
+				}
+				if err := o.Run(ctx); err != nil {
+					t.Error(err)
+					return
+				}
+				want := "app.example.com"
+				if tr.Requests()[0].Host != "app.example.com" {
+					t.Errorf("got %s want %s", tr.Requests()[0].Host, want)
+				}
+			})
 		}
 	})
 
 	t.Run("gRPC", func(t *testing.T) {
-		book := "testdata/book/grpc_with_host_rules.yml"
+		tests := []struct {
+			book string
+		}{
+			{"testdata/book/grpc_with_host_rules.yml"},
+			{"testdata/book/grpc_with_host_rules_wildcard.yml"},
+		}
 		ts := testutil.GRPCServer(t, true, false)
 		t.Setenv("TEST_GRPC_HOST_RULE", ts.Addr())
-		o, err := New(Book(book))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := o.Run(ctx); err != nil {
-			t.Error(err)
+		for _, tt := range tests {
+			t.Run(tt.book, func(t *testing.T) {
+				o, err := New(Book(tt.book))
+				if err != nil {
+					t.Fatal(err)
+					return
+				}
+				if err := o.Run(ctx); err != nil {
+					t.Error(err)
+				}
+			})
 		}
 	})
 
 	t.Run("CDP", func(t *testing.T) {
-		book := "testdata/book/cdp_with_host_rules.yml"
+		tests := []struct {
+			book string
+		}{
+			{"testdata/book/cdp_with_host_rules.yml"},
+			{"testdata/book/cdp_with_host_rules_wildcard.yml"},
+		}
 		ts, tr := testutil.HTTPServerAndRouter(t)
 		t.Setenv("TEST_HTTP_HOST_RULE", strings.TrimPrefix(ts.URL, "http://"))
-		o, err := New(Book(book))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := o.Run(ctx); err != nil {
-			t.Error(err)
-		}
-		want := "example.com"
-		if tr.Requests()[0].Host != "example.com" {
-			t.Errorf("got %s want %s", tr.Requests()[0].Host, want)
+		for _, tt := range tests {
+			t.Run(tt.book, func(t *testing.T) {
+				o, err := New(Book(tt.book))
+				if err != nil {
+					t.Fatal(err)
+					return
+				}
+				if err := o.Run(ctx); err != nil {
+					t.Error(err)
+					return
+				}
+				want := "blog.example.com"
+				if tr.Requests()[0].Host != "blog.example.com" {
+					t.Errorf("got %s want %s", tr.Requests()[0].Host, want)
+				}
+			})
 		}
 	})
 }

--- a/hosts_test.go
+++ b/hosts_test.go
@@ -13,7 +13,7 @@ func TestHostRules(t *testing.T) {
 	t.Run("HTTP", func(t *testing.T) {
 		book := "testdata/book/http_with_host_rules.yml"
 		ts, tr := testutil.HTTPServerAndRouter(t)
-		t.Setenv("TEST_HTTP_HOST_RULE", strings.TrimLeft(ts.URL, "http://"))
+		t.Setenv("TEST_HTTP_HOST_RULE", strings.TrimPrefix(ts.URL, "http://"))
 		o, err := New(Book(book))
 		if err != nil {
 			t.Fatal(err)
@@ -43,7 +43,7 @@ func TestHostRules(t *testing.T) {
 	t.Run("CDP", func(t *testing.T) {
 		book := "testdata/book/cdp_with_host_rules.yml"
 		ts, tr := testutil.HTTPServerAndRouter(t)
-		t.Setenv("TEST_HTTP_HOST_RULE", strings.TrimLeft(ts.URL, "http://"))
+		t.Setenv("TEST_HTTP_HOST_RULE", strings.TrimPrefix(ts.URL, "http://"))
 		o, err := New(Book(book))
 		if err != nil {
 			t.Fatal(err)

--- a/hosts_test.go
+++ b/hosts_test.go
@@ -1,0 +1,59 @@
+package runn
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/k1LoW/runn/testutil"
+)
+
+func TestHostRules(t *testing.T) {
+	ctx := context.Background()
+	t.Run("HTTP", func(t *testing.T) {
+		book := "testdata/book/http_with_host_rules.yml"
+		ts, tr := testutil.HTTPServerAndRouter(t)
+		t.Setenv("TEST_HTTP_HOST_RULE", strings.TrimLeft(ts.URL, "http://"))
+		o, err := New(Book(book))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := o.Run(ctx); err != nil {
+			t.Error(err)
+		}
+		want := "example.com"
+		if tr.Requests()[0].Host != "example.com" {
+			t.Errorf("got %s want %s", tr.Requests()[0].Host, want)
+		}
+	})
+
+	t.Run("gRPC", func(t *testing.T) {
+		book := "testdata/book/grpc_with_host_rules.yml"
+		ts := testutil.GRPCServer(t, true, false)
+		t.Setenv("TEST_GRPC_HOST_RULE", ts.Addr())
+		o, err := New(Book(book))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := o.Run(ctx); err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("CDP", func(t *testing.T) {
+		book := "testdata/book/cdp_with_host_rules.yml"
+		ts, tr := testutil.HTTPServerAndRouter(t)
+		t.Setenv("TEST_HTTP_HOST_RULE", strings.TrimLeft(ts.URL, "http://"))
+		o, err := New(Book(book))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := o.Run(ctx); err != nil {
+			t.Error(err)
+		}
+		want := "example.com"
+		if tr.Requests()[0].Host != "example.com" {
+			t.Errorf("got %s want %s", tr.Requests()[0].Host, want)
+		}
+	})
+}

--- a/operator_test.go
+++ b/operator_test.go
@@ -297,9 +297,9 @@ func TestLoad(t *testing.T) {
 		{"testdata/book/**/*", "nonexistent", "", "", 0},
 		{"testdata/book/**/*", "", "eb33c9aed04a7f1e03c1a1246b5d7bdaefd903d3", "", 1},
 		{"testdata/book/**/*", "", "eb33c9a", "", 1},
-		{"testdata/book/**/*", "", "", "http", 10},
+		{"testdata/book/**/*", "", "", "http", 11},
 		{"testdata/book/**/*", "", "", "openapi3", 7},
-		{"testdata/book/**/*", "", "", "http,openapi3", 10},
+		{"testdata/book/**/*", "", "", "http,openapi3", 11},
 		{"testdata/book/**/*", "", "", "http and openapi3", 7},
 		{"testdata/book/**/*", "", "", "http and nothing", 0},
 	}

--- a/runbook.go
+++ b/runbook.go
@@ -44,6 +44,7 @@ type runbook struct {
 	Runners     map[string]any  `yaml:"runners,omitempty"`
 	Vars        map[string]any  `yaml:"vars,omitempty"`
 	Steps       []yaml.MapSlice `yaml:"steps"`
+	HostRules   yaml.MapSlice   `yaml:"hostRules,omitempty"`
 	Debug       bool            `yaml:"debug,omitempty"`
 	Interval    string          `yaml:"interval,omitempty"`
 	If          string          `yaml:"if,omitempty"`
@@ -63,6 +64,7 @@ type runbookMapped struct {
 	Runners     map[string]any `yaml:"runners,omitempty"`
 	Vars        map[string]any `yaml:"vars,omitempty"`
 	Steps       yaml.MapSlice  `yaml:"steps,omitempty"`
+	HostRules   yaml.MapSlice  `yaml:"hostRules,omitempty"`
 	Debug       bool           `yaml:"debug,omitempty"`
 	Interval    string         `yaml:"interval,omitempty"`
 	If          string         `yaml:"if,omitempty"`
@@ -159,6 +161,7 @@ func parseRunbookMapped(b []byte, rb *runbook) error {
 	rb.Labels = m.Labels
 	rb.Runners = m.Runners
 	rb.Vars = m.Vars
+	rb.HostRules = m.HostRules
 	rb.Debug = m.Debug
 	rb.Interval = m.Interval
 	rb.If = m.If
@@ -222,6 +225,7 @@ func (rb *runbook) MarshalYAML() (any, error) {
 	m.Labels = rb.Labels
 	m.Runners = rb.Runners
 	m.Vars = rb.Vars
+	m.HostRules = rb.HostRules
 	m.Debug = rb.Debug
 	m.Interval = rb.Interval
 	m.If = rb.If
@@ -428,6 +432,17 @@ func (rb *runbook) toBook() (*book, error) {
 			return nil, fmt.Errorf("failed to normalize step values: %v", s)
 		}
 		bk.rawSteps = append(bk.rawSteps, v)
+	}
+	for _, r := range rb.HostRules {
+		host, ok := r.Key.(string)
+		if !ok {
+			return nil, fmt.Errorf("invalid host rule: %v", r)
+		}
+		rule, ok := r.Value.(string)
+		if !ok {
+			return nil, fmt.Errorf("invalid host rule: %v", r)
+		}
+		bk.hostRules = append(bk.hostRules, hostRule{host, rule})
 	}
 	bk.debug = rb.Debug
 	bk.intervalStr = rb.Interval

--- a/testdata/book/cdp_with_host_rules.yml
+++ b/testdata/book/cdp_with_host_rules.yml
@@ -1,0 +1,13 @@
+desc: Test using CDP with host rules
+runners:
+  cc: chrome://new
+hostRules:
+  example.com: ${TEST_HTTP_HOST_RULE}
+steps:
+  -
+    cc:
+      actions:
+        - navigate: 'http://example.com/hello'
+        - html
+    test: |
+      current.html contains 'Hello'

--- a/testdata/book/cdp_with_host_rules_wildcard.yml
+++ b/testdata/book/cdp_with_host_rules_wildcard.yml
@@ -1,8 +1,8 @@
-desc: Test using CDP with host rules
+desc: Test using CDP with host rules (wildcard)
 runners:
   cc: chrome://new
 hostRules:
-  blog.example.com: ${TEST_HTTP_HOST_RULE}
+  '*.example.com': ${TEST_HTTP_HOST_RULE}
 steps:
   -
     cc:

--- a/testdata/book/grpc_with_host_rules.yml
+++ b/testdata/book/grpc_with_host_rules.yml
@@ -1,0 +1,97 @@
+desc: Test using gRPC with host rules
+runners:
+  greq:
+    addr: grpc.example.com:443
+    protos:
+      - ../grpctest.proto
+    tls: true
+    cacert: ../cacert.pem
+    cert: ../cert.pem
+    key: ../key.pem
+hostRules:
+  grpc.example.com: ${TEST_GRPC_HOST_RULE}      
+vars:
+  names:
+    - alice
+    - bob
+    - charlie      
+steps:
+  unary:
+    desc: Request using Unary RPC
+    greq:
+      grpctest.GrpcTestService/Hello:
+        headers:
+          authentication: tokenhello
+          multivalues:
+            - a
+            - b
+        message:
+          name: "{{ vars.names[0] }}"
+          num: 3
+          request_time: 2022-06-25T05:24:43.861872Z
+    test: |
+      steps.unary.res.status == 0 && steps.unary.res.message.message == 'hello'
+  error_message:
+    desc: Get gRPC error message
+    greq:
+      grpctest.GrpcTestService/Hello:
+        headers:
+          error: 'error'
+        message:
+          name: "{{ vars.names[0] }}"
+          num: 3
+          request_time: 2022-06-25T05:24:43.861872Z
+    test: |
+      current.res.status == 1 && current.res.message == 'request canceled'
+  server_streaming:
+    desc: Request using Server streaming RPC
+    greq:
+      grpctest.GrpcTestService/ListHello:
+        headers:
+          authentication: tokenlisthello
+        message:
+          name: "{{ vars.names[1] }}"
+          num: 4
+          request_time: 2022-06-25T05:24:43.861872Z
+    test: |
+      steps.server_streaming.res.status == 0 && len(steps.server_streaming.res.messages) == 2 && steps.server_streaming.res.messages[1].num == 34
+  client_streaming:
+    desc: Request using Client streaming RPC
+    greq:
+      grpctest.GrpcTestService/MultiHello:
+        headers:
+          authentication: tokenmultihello
+        messages:
+          -
+            name: "{{ vars.names[0] }}"
+            num: 5
+            request_time: 2022-06-25T05:24:43.861872Z
+          -
+            name: "{{ vars.names[1] }}"
+            num: 6
+            request_time: 2022-06-25T05:24:43.861872Z
+    test: |
+      steps.client_streaming.res.status == 0 && steps.client_streaming.res.message.num == 35
+  bidirectional_streaming:
+    desc: Request using Bidirectional streaming RPC
+    greq:
+      grpctest.GrpcTestService/HelloChat:
+        headers:
+          authentication: tokenhellochat
+        messages:
+          -
+            name: "{{ vars.names[0] }}"
+            num: 7
+            request_time: 2022-06-25T05:24:43.861872Z
+          - receive # receive server message
+          -
+            name: "{{ vars.names[1] }}"
+            num: 8
+            request_time: 2022-06-25T05:24:43.861872Z
+          -
+            name: "{{ vars.names[2] }}"
+            num: 9
+            request_time: 2022-06-25T05:24:43.861872Z
+          - close # close connection
+    test: |
+      steps.bidirectional_streaming.res.status == 0 && steps.bidirectional_streaming.res.message.num == 34 && len(steps.bidirectional_streaming.res.messages) == 1

--- a/testdata/book/grpc_with_host_rules_wildcard.yml
+++ b/testdata/book/grpc_with_host_rules_wildcard.yml
@@ -1,0 +1,97 @@
+desc: Test using gRPC with host rules (wildcard)
+runners:
+  greq:
+    addr: grpc.example.com:443
+    protos:
+      - ../grpctest.proto
+    tls: true
+    cacert: ../cacert.pem
+    cert: ../cert.pem
+    key: ../key.pem
+hostRules:
+  '*.example.com': ${TEST_GRPC_HOST_RULE}      
+vars:
+  names:
+    - alice
+    - bob
+    - charlie      
+steps:
+  unary:
+    desc: Request using Unary RPC
+    greq:
+      grpctest.GrpcTestService/Hello:
+        headers:
+          authentication: tokenhello
+          multivalues:
+            - a
+            - b
+        message:
+          name: "{{ vars.names[0] }}"
+          num: 3
+          request_time: 2022-06-25T05:24:43.861872Z
+    test: |
+      steps.unary.res.status == 0 && steps.unary.res.message.message == 'hello'
+  error_message:
+    desc: Get gRPC error message
+    greq:
+      grpctest.GrpcTestService/Hello:
+        headers:
+          error: 'error'
+        message:
+          name: "{{ vars.names[0] }}"
+          num: 3
+          request_time: 2022-06-25T05:24:43.861872Z
+    test: |
+      current.res.status == 1 && current.res.message == 'request canceled'
+  server_streaming:
+    desc: Request using Server streaming RPC
+    greq:
+      grpctest.GrpcTestService/ListHello:
+        headers:
+          authentication: tokenlisthello
+        message:
+          name: "{{ vars.names[1] }}"
+          num: 4
+          request_time: 2022-06-25T05:24:43.861872Z
+    test: |
+      steps.server_streaming.res.status == 0 && len(steps.server_streaming.res.messages) == 2 && steps.server_streaming.res.messages[1].num == 34
+  client_streaming:
+    desc: Request using Client streaming RPC
+    greq:
+      grpctest.GrpcTestService/MultiHello:
+        headers:
+          authentication: tokenmultihello
+        messages:
+          -
+            name: "{{ vars.names[0] }}"
+            num: 5
+            request_time: 2022-06-25T05:24:43.861872Z
+          -
+            name: "{{ vars.names[1] }}"
+            num: 6
+            request_time: 2022-06-25T05:24:43.861872Z
+    test: |
+      steps.client_streaming.res.status == 0 && steps.client_streaming.res.message.num == 35
+  bidirectional_streaming:
+    desc: Request using Bidirectional streaming RPC
+    greq:
+      grpctest.GrpcTestService/HelloChat:
+        headers:
+          authentication: tokenhellochat
+        messages:
+          -
+            name: "{{ vars.names[0] }}"
+            num: 7
+            request_time: 2022-06-25T05:24:43.861872Z
+          - receive # receive server message
+          -
+            name: "{{ vars.names[1] }}"
+            num: 8
+            request_time: 2022-06-25T05:24:43.861872Z
+          -
+            name: "{{ vars.names[2] }}"
+            num: 9
+            request_time: 2022-06-25T05:24:43.861872Z
+          - close # close connection
+    test: |
+      steps.bidirectional_streaming.res.status == 0 && steps.bidirectional_streaming.res.message.num == 34 && len(steps.bidirectional_streaming.res.messages) == 1

--- a/testdata/book/http_with_host_rules.yml
+++ b/testdata/book/http_with_host_rules.yml
@@ -1,0 +1,123 @@
+desc: Test using HTTP with host rules
+labels:
+  - http
+  - host_rules
+runners:
+  req: http://example.com
+hostRules:
+  example.com: ${TEST_HTTP_HOST_RULE}
+steps:
+  getusers:
+    req:
+      /users:
+        get:
+          body: null
+    test: |
+      'bob' in map(current.res.body, {#.username})
+  postusers:
+    desc: Post /users
+    req:
+      /users:
+        post:
+          body:
+            application/json:
+              username: alice
+              password: passw0rd
+    test: |
+      current.res.status == 201
+  helpform:
+    desc: Post /help
+    req:
+      /help:
+        post:
+          body:
+            application/x-www-form-urlencoded:
+              name: bob
+              content: help me
+    test: |
+      current.res.status == 201
+  notfound:
+    desc: Get /notfound
+    req:
+      /notfound:
+        get:
+          body:
+            application/json:
+              nil
+    test: |
+      current.res.status == 404
+  getuser:
+    desc: Get /users/1
+    req:
+      /users/1:
+        get:
+          body:
+            application/json:
+              null
+    test: |
+      current.res.status == 200 && current.res.body.data.username == 'alice'
+  forbidden:
+    desc: Get /private
+    req:
+      /private?token=xxxxx:
+        get:
+          body:
+            application/json:
+              null
+    test: |
+      current.res.status == 403 && current.res.body.error == 'Forbidden'
+  getprivate:
+    desc: Get /private with token
+    req:
+      /private:
+        get:
+          headers:
+            Authorization: 'Bearer xxxxx'
+            Multivalues:
+              - a
+              - b
+          body:
+            application/json:
+              null
+    test: |
+      current.res.status == 200
+  redirect:
+    desc: Get /redirect and redirect
+    req:
+      /redirect:
+        get:
+          body:
+            application/json:
+              null
+    test: |
+      current.res.status == 404
+  fileupload:
+    desc: Post /upload with single file
+    req:
+      /upload:
+        post:
+          body:
+            multipart/form-data:
+              upload0: ../dummy.png
+    test: |
+      current.res.status == 201
+  dataupload:
+    desc: Post /upload with octet-stream
+    req:
+      /upload:
+        post:
+          body:
+            application/octet-stream:
+              filename: ../dummy.jpg
+    test: |
+      current.res.status == 201
+  severalvalues:
+    desc: Get several values
+    req:
+      /ping:
+        get:
+          body:
+            application/json:
+              null
+    test: |
+      current.res.body.url == 'http://localhost:8080/ping'

--- a/testdata/book/http_with_host_rules_wildcard.yml
+++ b/testdata/book/http_with_host_rules_wildcard.yml
@@ -1,11 +1,11 @@
-desc: Test using HTTP with host rules
+desc: Test using HTTP with host rules (wildcard)
 labels:
   - http
   - host_rules
 runners:
   req: http://app.example.com
 hostRules:
-  app.example.com: ${TEST_HTTP_HOST_RULE}
+  '*.example.com': ${TEST_HTTP_HOST_RULE}
 steps:
   getusers:
     req:


### PR DESCRIPTION
Allows control of hostname/IP address mapping without modifying /etc/hosts ( like `curl --resolve` ).