### PR TITLE
Use `--host-resolver-rules` instead of `--host-rules` in CDP Runner

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -24,7 +24,7 @@ func (rules hostRules) chromedpOpt() chromedp.ExecAllocatorOption {
 	for _, rule := range rules {
 		values = append(values, fmt.Sprintf("MAP %s %s", rule.host, rule.rule))
 	}
-	return chromedp.Flag("host-rules", strings.Join(values, ","))
+	return chromedp.Flag("host-resolver-rules", strings.Join(values, ","))
 }
 
 // dialContextFunc returns DialContext() for http.Transport.DialContext.


### PR DESCRIPTION
Fix net::ERR_CERT_COMMON_NAME_INVALID error