### PR TITLE
Output results step by step when the `--verbose` option is enabled (Update `runn.Capturer` interface)

### DIFF
--- a/capture/runbook.go
+++ b/capture/runbook.go
@@ -110,6 +110,8 @@ func (c *cRunbook) CaptureResult(trs runn.Trails, result *runn.RunResult) {
 
 func (c *cRunbook) CaptureEnd(trs runn.Trails, bookPath, desc string) {}
 
+func (c *cRunbook) CaptureResultByStep(trs runn.Trails, result *runn.RunResult) {}
+
 func (c *cRunbook) CaptureHTTPRequest(name string, req *http.Request) {
 	const dummyDsn = "[THIS IS HTTP RUNNER]"
 	if v, ok := c.runners[name]; ok {

--- a/capturer.go
+++ b/capturer.go
@@ -12,6 +12,8 @@ type Capturer interface {
 	CaptureResult(trs Trails, result *RunResult)
 	CaptureEnd(trs Trails, bookPath, desc string)
 
+	CaptureResultByStep(trs Trails, result *RunResult)
+
 	CaptureHTTPRequest(name string, req *http.Request)
 	CaptureHTTPResponse(name string, res *http.Response)
 
@@ -63,6 +65,12 @@ func (cs capturers) captureResult(trs Trails, result *RunResult) { //nostyle:rec
 func (cs capturers) captureEnd(trs Trails, bookPath, desc string) { //nostyle:recvtype
 	for _, c := range cs {
 		c.CaptureEnd(trs, bookPath, desc)
+	}
+}
+
+func (cs capturers) captureResultByStep(trs Trails, result *RunResult) { //nostyle:recvtype
+	for _, c := range cs {
+		c.CaptureResultByStep(trs, result)
 	}
 }
 

--- a/cmdout_test.go
+++ b/cmdout_test.go
@@ -61,3 +61,56 @@ func TestCmdOutCaptureResult(t *testing.T) {
 		})
 	}
 }
+
+func TestCmdOutCaptureResultByStep(t *testing.T) {
+	noColor(t)
+	tests := []struct {
+		result  *RunResult
+		verbose bool
+	}{
+		{
+			&RunResult{
+				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
+				Path: "testdata/book/runn_1_fail.yml",
+				Err:  ErrDummy,
+				StepResults: []*StepResult{{Key: "0", Err: ErrDummy, IncludedRunResult: &RunResult{
+					ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
+					Path:        "testdata/book/runn_included_0_fail.yml",
+					Err:         ErrDummy,
+					StepResults: []*StepResult{{Key: "0", Err: ErrDummy}},
+				}}},
+			},
+			false,
+		},
+		{
+			&RunResult{
+				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
+				Path: "testdata/book/runn_1_fail.yml",
+				Err:  ErrDummy,
+				StepResults: []*StepResult{{Key: "0", Err: ErrDummy, IncludedRunResult: &RunResult{
+					ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
+					Path:        "testdata/book/runn_included_0_fail.yml",
+					Err:         ErrDummy,
+					StepResults: []*StepResult{{Key: "0", Err: ErrDummy}},
+				}}},
+			},
+			true,
+		},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			out := new(bytes.Buffer)
+			o := NewCmdOut(out, tt.verbose)
+			o.CaptureResultByStep(nil, tt.result)
+			f := fmt.Sprintf("runn_cmdout_by_step%d", i)
+			got := out.String()
+			if os.Getenv("UPDATE_GOLDEN") != "" {
+				golden.Update(t, "testdata", f, got)
+				return
+			}
+			if diff := golden.Diff(t, "testdata", f, got); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/debugger.go
+++ b/debugger.go
@@ -32,6 +32,8 @@ func (d *debugger) CaptureStart(trs Trails, bookPath, desc string) {}
 func (d *debugger) CaptureResult(trs Trails, result *RunResult)    {}
 func (d *debugger) CaptureEnd(trs Trails, bookPath, desc string)   {}
 
+func (d *debugger) CaptureResultByStep(trs Trails, result *RunResult) {}
+
 func (d *debugger) CaptureHTTPRequest(name string, req *http.Request) {
 	b, _ := httputil.DumpRequest(req, true)
 	_, _ = fmt.Fprintf(d.out, "-----START HTTP REQUEST-----\n%s\n-----END HTTP REQUEST-----\n", string(b))

--- a/operator.go
+++ b/operator.go
@@ -362,6 +362,9 @@ func (o *operator) recordAsMapped(v map[string]any) {
 }
 
 func (o *operator) recordToLatest(key string, value any) error {
+	r := o.Result()
+	r.StepResults = o.StepResults()
+	o.capturers.captureResultByStep(o.trails(), r)
 	return o.store.recordToLatest(key, value)
 }
 

--- a/testdata/runn_cmdout_1.golden
+++ b/testdata/runn_cmdout_1.golden
@@ -1,5 +1,0 @@
-===  (testdata/book/runn_1_fail.yml) ... fail
-    --- (0) ... fail
-        ===  (testdata/book/runn_included_0_fail.yml) ... fail
-            --- (0) ... fail
-                Failure/Error: dummy

--- a/testdata/runn_cmdout_by_step1.golden
+++ b/testdata/runn_cmdout_by_step1.golden
@@ -1,0 +1,3 @@
+    --- (0) ... fail
+            --- (0) ... fail
+                Failure/Error: dummy


### PR DESCRIPTION
SSIA.