### PR TITLE
fix: Fix potential panic

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -659,8 +659,8 @@ func (o *operator) AppendStep(idx int, key string, s map[string]any) error {
 			if !ok {
 				return fmt.Errorf("invalid dump request: %v", vv)
 			}
-			out := vv["out"]
-			if out == nil {
+			out, ok := vv["out"]
+			if !ok {
 				return fmt.Errorf("invalid dump request: %v", vv)
 			}
 			step.dumpRequest = &dumpRequest{

--- a/operator.go
+++ b/operator.go
@@ -660,6 +660,9 @@ func (o *operator) AppendStep(idx int, key string, s map[string]any) error {
 				return fmt.Errorf("invalid dump request: %v", vv)
 			}
 			out := vv["out"]
+			if out == nil {
+				return fmt.Errorf("invalid dump request: %v", vv)
+			}
 			step.dumpRequest = &dumpRequest{
 				expr: expr.(string),
 				out:  out.(string),


### PR DESCRIPTION
Thank you for creating the fantastic tool runn. During usage, I encountered a potential panic scenario. I've addressed this in the attached pull request to contribute to the stability and reliability of runn. I hope this is helpful.

This PR addresses a potential panic issue in the handling of the dump action when the expr field is specified without providing an out field. If the expr field was used in a dump action without an accompanying out, the system would encounter a panic. The issue can be illustrated with the following configuration:

```yaml
desc: "hello world!"
steps:
  say_hello:
    desc: "echo hello"
    exec:
      command: echo hello
    test:
      current.exit_code == 0
    dump:
      expr: current.stdout
```

```
runn run --scopes run:exec hello.yml
panic: interface conversion: interface {} is nil, not string

goroutine 1 [running]:
github.com/k1LoW/runn.(*operator).AppendStep(0x140000dab40, 0x0, {0x14000e0ed40, 0x9}, 0x1?)
	/Users/runner/work/runn/runn/operator.go:665 +0xfac
github.com/k1LoW/runn.New({0x140000cf320, 0x12, 0x12})
	/Users/runner/work/runn/runn/operator.go:590 +0x1828
github.com/k1LoW/runn.Load({0x16ae0b7cb, 0x9}, {0x14000e18160, 0xd, 0x0?})
	/Users/runner/work/runn/runn/operator.go:1226 +0x818
github.com/k1LoW/runn/cmd.glob..func6(0x14000159300?, {0x14000c08960?, 0x4?, 0x1062d47cc?})
	/Users/runner/work/runn/runn/cmd/run.go:59 +0xb8
github.com/spf13/cobra.(*Command).execute(0x107c114c0, {0x1400054ff80, 0x3, 0x3})
	/Users/runner/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:916 +0x66c
github.com/spf13/cobra.(*Command).ExecuteC(0x107c10f00)
	/Users/runner/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x320
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/runner/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
github.com/k1LoW/runn/cmd.Execute()
	/Users/runner/work/runn/runn/cmd/root.go:44 +0x24
main.main()
	/Users/runner/work/runn/runn/cmd/runn/main.go:27 +0x1c
```

