### PR TITLE
Set default output for Dump runner

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/k1LoW/stopw"
 	"github.com/ryo-yamaoka/otchkiss"
 	"github.com/samber/lo"
+	"github.com/spf13/cast"
 	"go.uber.org/multierr"
 )
 
@@ -661,11 +662,11 @@ func (o *operator) AppendStep(idx int, key string, s map[string]any) error {
 			}
 			out, ok := vv["out"]
 			if !ok {
-				return fmt.Errorf("invalid dump request: %v", vv)
+				out = "" // default: o.stdout
 			}
 			step.dumpRequest = &dumpRequest{
-				expr: expr.(string),
-				out:  out.(string),
+				expr: cast.ToString(expr),
+				out:  cast.ToString(out),
 			}
 		default:
 			return fmt.Errorf("invalid dump request: %v", vv)

--- a/testdata/book/dump.yml
+++ b/testdata/book/dump.yml
@@ -22,3 +22,12 @@ steps:
   dump_run_func:
     desc: dump runner should execute built-in func
     dump: toBase64("hello")
+  dump_expr:
+    desc: dump runner use only expr
+    dump:
+      expr: 3
+  dump_out:
+    desc: dump runner use only expr
+    dump:
+      expr: 3
+      out: '{{ vars.out }}'


### PR DESCRIPTION
Allow no `dump.out:`

```yaml
dump:
  expr: vars.some + 'hello'
  # no out:
```