### PR TITLE
Add `dump.disableTrailingNewline:` for disabling trailing newline in dump output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1645,6 +1645,7 @@ or
   dump:
     expr: steps[4].rows
     out: path/to/dump.out
+    disableTrailingNewline: true
 ```
 
 The `dump` runner can run in the same steps as the other runners.

--- a/operator.go
+++ b/operator.go
@@ -696,9 +696,14 @@ func (o *operator) appendStep(idx int, key string, s map[string]any) error {
 			if !ok {
 				out = "" // default: o.stdout
 			}
+			disableNL, ok := vv["disableTrailingNewline"]
+			if !ok {
+				disableNL = false
+			}
 			step.dumpRequest = &dumpRequest{
-				expr: cast.ToString(expr),
-				out:  cast.ToString(out),
+				expr:                   cast.ToString(expr),
+				out:                    cast.ToString(out),
+				disableTrailingNewline: cast.ToBool(disableNL),
 			}
 		default:
 			return fmt.Errorf("invalid dump request: %v", vv)


### PR DESCRIPTION
Also fully unified normal and file output content.