### PR TITLE
Remove `steps[*].run` `steps.<key>.run` from store

### DIFF
--- a/bind_test.go
+++ b/bind_test.go
@@ -25,14 +25,14 @@ func TestBindRunnerRun(t *testing.T) {
 			map[string]any{},
 			store{
 				steps: []map[string]any{
-					{"run": true},
+					{},
 				},
 				vars:     map[string]any{},
 				bindVars: map[string]any{},
 			},
 			map[string]any{
 				"steps": []map[string]any{
-					{"run": true},
+					{},
 				},
 				"vars":   map[string]any{},
 				"parent": nil,
@@ -52,7 +52,7 @@ func TestBindRunnerRun(t *testing.T) {
 			},
 			store{
 				steps: []map[string]any{
-					{"run": true},
+					{},
 				},
 				vars: map[string]any{
 					"key": "value",
@@ -63,7 +63,7 @@ func TestBindRunnerRun(t *testing.T) {
 			},
 			map[string]any{
 				"steps": []map[string]any{
-					{"run": true},
+					{},
 				},
 				"vars": map[string]any{
 					"key": "value",
@@ -86,7 +86,7 @@ func TestBindRunnerRun(t *testing.T) {
 			},
 			store{
 				steps: []map[string]any{
-					{"run": true},
+					{},
 				},
 				vars: map[string]any{
 					"key": "value",
@@ -97,7 +97,7 @@ func TestBindRunnerRun(t *testing.T) {
 			},
 			map[string]any{
 				"steps": []map[string]any{
-					{"run": true},
+					{},
 				},
 				"vars": map[string]any{
 					"key": "value",
@@ -120,7 +120,7 @@ func TestBindRunnerRun(t *testing.T) {
 			},
 			store{
 				steps: []map[string]any{
-					{"run": true},
+					{},
 				},
 				vars: map[string]any{
 					"key": "value",
@@ -131,7 +131,7 @@ func TestBindRunnerRun(t *testing.T) {
 			},
 			map[string]any{
 				"steps": []map[string]any{
-					{"run": true},
+					{},
 				},
 				"vars": map[string]any{
 					"key": "value",
@@ -157,7 +157,7 @@ func TestBindRunnerRun(t *testing.T) {
 			},
 			store{
 				steps: []map[string]any{
-					{"run": true},
+					{},
 				},
 				vars: map[string]any{
 					"key": "value",
@@ -171,7 +171,7 @@ func TestBindRunnerRun(t *testing.T) {
 			},
 			map[string]any{
 				"steps": []map[string]any{
-					{"run": true},
+					{},
 				},
 				"vars": map[string]any{
 					"key": "value",
@@ -201,7 +201,7 @@ func TestBindRunnerRun(t *testing.T) {
 			},
 			store{
 				steps: []map[string]any{
-					{"run": true},
+					{},
 				},
 				vars: map[string]any{
 					"key": "value",
@@ -219,7 +219,7 @@ func TestBindRunnerRun(t *testing.T) {
 			},
 			map[string]any{
 				"steps": []map[string]any{
-					{"run": true},
+					{},
 				},
 				"vars": map[string]any{
 					"key": "value",
@@ -251,7 +251,7 @@ func TestBindRunnerRun(t *testing.T) {
 			},
 			store{
 				steps: []map[string]any{
-					{"run": true},
+					{},
 				},
 				vars: map[string]any{
 					"key": "value",
@@ -262,7 +262,7 @@ func TestBindRunnerRun(t *testing.T) {
 			},
 			map[string]any{
 				"steps": []map[string]any{
-					{"run": true},
+					{},
 				},
 				"vars": map[string]any{
 					"key": "value",

--- a/db_test.go
+++ b/db_test.go
@@ -22,7 +22,6 @@ func TestDBRunner(t *testing.T) {
 				"rows": []map[string]any{
 					{"1": int64(1)},
 				},
-				"run": true,
 			},
 		},
 		{
@@ -31,7 +30,6 @@ func TestDBRunner(t *testing.T) {
 				"rows": []map[string]any{
 					{"2": int64(2)},
 				},
-				"run": true,
 			},
 		},
 		{
@@ -47,7 +45,6 @@ INSERT INTO users (username, password, email, created) VALUES ('alice', 'passw0r
 			map[string]any{
 				"last_insert_id": int64(1),
 				"rows_affected":  int64(1),
-				"run":            true,
 			},
 		},
 		{
@@ -66,7 +63,6 @@ SELECT COUNT(*) AS count FROM users;
 				"rows": []map[string]any{
 					{"count": int64(1)},
 				},
-				"run": true,
 			},
 		},
 		{
@@ -106,7 +102,6 @@ SELECT * FROM users;
 						},
 					},
 				},
-				"run": true,
 			},
 		},
 	}

--- a/exec_test.go
+++ b/exec_test.go
@@ -29,13 +29,11 @@ func TestExecRun(t *testing.T) {
 			"stdout":    "hello!!\n",
 			"stderr":    "",
 			"exit_code": 0,
-			"run":       true,
 		}},
 		{"cat", "hello!!", "", map[string]any{
 			"stdout":    "hello!!",
 			"stderr":    "",
 			"exit_code": 0,
-			"run":       true,
 		}},
 	}
 	ctx := context.Background()

--- a/operator.go
+++ b/operator.go
@@ -337,7 +337,6 @@ func (o *operator) recordNotRun(i int) {
 		return
 	}
 	v := map[string]any{}
-	v[storeStepKeyRun] = false
 	if o.useMap {
 		o.recordAsMapped(v)
 		return
@@ -349,7 +348,6 @@ func (o *operator) record(v map[string]any) {
 	if v == nil {
 		v = map[string]any{}
 	}
-	v[storeStepKeyRun] = true
 	if o.useMap {
 		o.recordAsMapped(v)
 		return

--- a/operator_test.go
+++ b/operator_test.go
@@ -1142,20 +1142,19 @@ func TestStepResult(t *testing.T) {
 	}
 }
 
-func TestStepOutcomeAndRun(t *testing.T) {
+func TestStepOutcome(t *testing.T) {
 	tests := []struct {
-		book        string
-		force       bool
-		wantOutcome []result
-		wantRun     []bool
+		book  string
+		force bool
+		want  []result
 	}{
-		{"testdata/book/always_success.yml", false, []result{resultSuccess, resultSuccess, resultSuccess}, []bool{true, true, true}},
-		{"testdata/book/always_failure.yml", false, []result{resultSuccess, resultFailure, resultSkipped}, []bool{true, false, false}},
-		{"testdata/book/skip_test.yml", false, []result{resultSkipped, resultSuccess}, []bool{false, true}},
-		{"testdata/book/only_if_included.yml", false, []result{resultSkipped, resultSkipped}, []bool{false, false}},
-		{"testdata/book/always_failure.yml", true, []result{resultSuccess, resultFailure, resultSuccess}, []bool{true, false, true}},
-		{"testdata/book/only_if_included.yml", true, []result{resultSkipped, resultSkipped}, []bool{false, false}},
-		{"testdata/book/always_success_loop.yml", false, []result{resultSuccess, resultSuccess, resultSuccess}, []bool{true, true, true}},
+		{"testdata/book/always_success.yml", false, []result{resultSuccess, resultSuccess, resultSuccess}},
+		{"testdata/book/always_failure.yml", false, []result{resultSuccess, resultFailure, resultSkipped}},
+		{"testdata/book/skip_test.yml", false, []result{resultSkipped, resultSuccess}},
+		{"testdata/book/only_if_included.yml", false, []result{resultSkipped, resultSkipped}},
+		{"testdata/book/always_failure.yml", true, []result{resultSuccess, resultFailure, resultSuccess}},
+		{"testdata/book/only_if_included.yml", true, []result{resultSkipped, resultSkipped}},
+		{"testdata/book/always_success_loop.yml", false, []result{resultSuccess, resultSuccess, resultSuccess}},
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
@@ -1167,8 +1166,8 @@ func TestStepOutcomeAndRun(t *testing.T) {
 			}
 			_ = o.Run(ctx)
 			if o.useMap {
-				if len(o.store.stepMapKeys) != len(tt.wantOutcome) {
-					t.Errorf("got %v\nwant %v", len(o.store.stepMapKeys), len(tt.wantOutcome))
+				if len(o.store.stepMapKeys) != len(tt.want) {
+					t.Errorf("got %v\nwant %v", len(o.store.stepMapKeys), len(tt.want))
 				}
 				i := 0
 				for _, k := range o.store.stepMapKeys {
@@ -1177,26 +1176,15 @@ func TestStepOutcomeAndRun(t *testing.T) {
 						t.Error("want outcome")
 						continue
 					}
-					want := tt.wantOutcome[i]
+					want := tt.want[i]
 					if got != want {
 						t.Errorf("step[%d] got %v\nwant %v", i, got, want)
-					}
-					{
-						got, ok := o.store.stepMap[k][storeStepKeyRun]
-						if !ok {
-							t.Error("want run result")
-							continue
-						}
-						want := tt.wantRun[i]
-						if got != want {
-							t.Errorf("step[%d] got %v\nwant %v", i, got, want)
-						}
 					}
 					i++
 				}
 			} else {
-				if len(o.store.steps) != len(tt.wantOutcome) {
-					t.Errorf("got %v\nwant %v", len(o.store.steps), len(tt.wantOutcome))
+				if len(o.store.steps) != len(tt.want) {
+					t.Errorf("got %v\nwant %v", len(o.store.steps), len(tt.want))
 				}
 				for i, s := range o.store.steps {
 					got, ok := s[storeStepKeyOutcome]
@@ -1204,20 +1192,9 @@ func TestStepOutcomeAndRun(t *testing.T) {
 						t.Error("want outcome")
 						continue
 					}
-					want := tt.wantOutcome[i]
+					want := tt.want[i]
 					if got != want {
 						t.Errorf("step[%d] got %v\nwant %v", i, got, want)
-					}
-					{
-						got, ok := s[storeStepKeyRun]
-						if !ok {
-							t.Error("want run result")
-							continue
-						}
-						want := tt.wantRun[i]
-						if got != want {
-							t.Errorf("step[%d] got %v\nwant %v", i, got, want)
-						}
 					}
 				}
 			}

--- a/store.go
+++ b/store.go
@@ -23,7 +23,6 @@ const (
 )
 
 const (
-	storeStepKeyRun     = "run"
 	storeStepKeyOutcome = "outcome"
 )
 


### PR DESCRIPTION
Use `steps[*].outcome` `steps.<key>.outcome` instead.