### PR TITLE
Support negative label condition

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -1325,7 +1325,7 @@ func Load(pathp string, opts ...Option) (*operators, error) {
 			o.Debugf(yellow("Skip %s because it is already included from another runbook\n"), p)
 			continue
 		}
-		// RUUN_LABEL, --label
+		// RUNN_LABEL, --label
 		tf, err := EvalCond(cond, labelEnv(o.labels))
 		if err != nil {
 			return nil, err
@@ -1334,7 +1334,7 @@ func Load(pathp string, opts ...Option) (*operators, error) {
 			o.Debugf(yellow("Skip %s because it does not match %s\n"), p, cond)
 			continue
 		}
-		// RUUN_ID, --id
+		// RUNN_ID, --id
 		for i, id := range bk.runIDs {
 			if strings.HasPrefix(o.id, id) {
 				idMatched = append(idMatched, o)
@@ -1752,9 +1752,13 @@ func labelCond(labels []string) string {
 			sb.WriteString(" or ")
 		}
 
+		label = strings.ReplaceAll(label, "!", "not ")
+
 		sb.WriteString("(")
 		for _, s := range strings.Split(label, " ") {
 			switch s {
+			case "not":
+				sb.WriteString("not ")
 			case "or":
 				sb.WriteString(" or ")
 			case "and":

--- a/operator_test.go
+++ b/operator_test.go
@@ -303,6 +303,8 @@ func TestLoad(t *testing.T) {
 		{"testdata/book/**/*", "", "", "http,openapi3", 12},
 		{"testdata/book/**/*", "", "", "http and openapi3", 8},
 		{"testdata/book/**/*", "", "", "http and nothing", 0},
+		{"testdata/book/**/*", "", "", "http or nothing", 12},
+		{"testdata/book/**/*", "", "", "http and not openapi3", 4},
 	}
 
 	t.Setenv("TEST_HTTP_HOST_RULE", "127.0.0.1")
@@ -1289,6 +1291,15 @@ func TestLabelCond(t *testing.T) {
 		{[]string{"http and openapi3"}, []string{"http"}, false},
 		{[]string{"user-login or user-logout"}, []string{"user-login"}, true},
 		{[]string{"user:login or user:logout"}, []string{"user:login"}, true},
+		{[]string{"not http"}, []string{"http"}, false},
+		{[]string{"not not http"}, []string{"http"}, true},
+		{[]string{"not not http"}, []string{"http"}, true},
+		{[]string{"not openapi3"}, []string{"http"}, true},
+		{[]string{"!http"}, []string{"http"}, false},
+		{[]string{"!!http"}, []string{"http"}, true},
+		{[]string{"!openapi3"}, []string{"http"}, true},
+		{[]string{"http and not openapi3"}, []string{"http"}, true},
+		{[]string{"http and !openapi3"}, []string{"http"}, true},
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%v", tt.runLabels), func(t *testing.T) {


### PR DESCRIPTION
Fix https://github.com/k1LoW/runn/issues/934

Support following

```
runn run path/to/**/*.yml --label '!foo'
runn run path/to/**/*.yml --label '!foo and !bar'
```