### PR TITLE
Add `--force-color` option for forcing colorized output

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -29,6 +29,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/k1LoW/donegroup"
 	"github.com/k1LoW/runn"
 	"github.com/spf13/cobra"
@@ -63,6 +64,11 @@ var runCmd = &cobra.Command{
 				_ = runn.RemoveCacheDir()
 			}
 		}()
+
+		// force colorized output
+		if flgs.ForceColor {
+			color.NoColor = false
+		}
 
 		o, err := runn.Load(pathp, opts...)
 		if err != nil {
@@ -149,4 +155,5 @@ func init() {
 	}
 	runCmd.Flags().BoolVarP(&flgs.Verbose, "verbose", "", false, flgs.Usage("Verbose"))
 	runCmd.Flags().BoolVarP(&flgs.Attach, "attach", "", false, flgs.Usage("Attach"))
+	runCmd.Flags().BoolVarP(&flgs.ForceColor, "force-color", "", false, flgs.Usage("ForceColor"))
 }

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -72,6 +72,7 @@ type Flags struct {
 	HostRules       []string `usage:"host rules for runn. (\"host rule,host rule,...\")"`
 	WaitTimeout     string   `usage:"timeout for waiting for cleanup process after running runbooks"`
 	EnvFile         string   `usage:"load environment variables from a file"`
+	ForceColor      bool     `usage:"force colorized output even in non-tty output streams"`
 	Verbose         bool     `usage:"verbose"`
 }
 


### PR DESCRIPTION
Added an option to enable colorized output in non-tty output streams like GitHub Actions. When specifying this option, bypass the check for non-tty output streams by the [fatih/color](https://github.com/fatih/color) package.

Output without option:
```bash
$ runn run testdata/book/runn_0_success.yml | less
.

1 scenario, 0 skipped, 0 failures
```

Output with `--force-color` option:
```bash
$ runn run testdata/book/runn_0_success.yml --force-color | less
[32m.[0m

[32m1 scenario, 0 skipped, 0 failures
[0m
```