### PR TITLE
Add a cleanup operation because connections were left behind when defining a DB/gRPC/SSH/CDP Runner in Include runner.

### DIFF
--- a/cdp.go
+++ b/cdp.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/chromedp/chromedp"
+	"github.com/k1LoW/donegroup"
 )
 
 const cdpNewKey = "new"
@@ -98,12 +99,12 @@ func (rnr *cdpRunner) Run(ctx context.Context, s *step) error {
 func (rnr *cdpRunner) run(ctx context.Context, cas CDPActions, s *step) error {
 	if rnr.ctx == nil {
 		allocCtx, cancel := chromedp.NewExecAllocator(context.Background(), rnr.opts...)
-		ctx, _ := chromedp.NewContext(allocCtx)
-		rnr.ctx = ctx
+		ctxx, _ := chromedp.NewContext(allocCtx)
+		rnr.ctx = ctxx
 		rnr.cancel = cancel
 		// Merge run() function context and runner (chrome) context
-		context.AfterFunc(ctx, func() {
-			_ = rnr.Close()
+		donegroup.Cleanup(ctx, func() error {
+			return rnr.Renew()
 		})
 	}
 	o := s.parent

--- a/cdp.go
+++ b/cdp.go
@@ -103,9 +103,15 @@ func (rnr *cdpRunner) run(ctx context.Context, cas CDPActions, s *step) error {
 		rnr.ctx = ctxx
 		rnr.cancel = cancel
 		// Merge run() function context and runner (chrome) context
-		donegroup.Cleanup(ctx, func() error {
-			return rnr.Renew()
+		context.AfterFunc(ctxx, func() {
+			_ = rnr.Close()
 		})
+
+		if err := donegroup.Cleanup(ctx, func() error {
+			return rnr.Renew()
+		}); err != nil {
+			return err
+		}
 	}
 	o := s.parent
 	o.capturers.captureCDPStart(rnr.name)

--- a/cdp.go
+++ b/cdp.go
@@ -30,6 +30,8 @@ type cdpRunner struct {
 	opts          []chromedp.ExecAllocatorOption
 	timeoutByStep time.Duration
 	mu            sync.Mutex
+	// operatorID - The id of the operator for which the runner is defined.
+	operatorID string
 }
 
 type CDPActions []CDPAction
@@ -97,6 +99,7 @@ func (rnr *cdpRunner) Run(ctx context.Context, s *step) error {
 }
 
 func (rnr *cdpRunner) run(ctx context.Context, cas CDPActions, s *step) error {
+	o := s.parent
 	if rnr.ctx == nil {
 		allocCtx, cancel := chromedp.NewExecAllocator(context.Background(), rnr.opts...)
 		ctxx, _ := chromedp.NewContext(allocCtx)
@@ -106,14 +109,16 @@ func (rnr *cdpRunner) run(ctx context.Context, cas CDPActions, s *step) error {
 		context.AfterFunc(ctxx, func() {
 			_ = rnr.Close()
 		})
-
 		if err := donegroup.Cleanup(ctx, func() error {
+			// In the case of Reused runners, leave the cleanup to the main cleanup
+			if o.id != rnr.operatorID {
+				return nil
+			}
 			return rnr.Renew()
 		}); err != nil {
 			return err
 		}
 	}
-	o := s.parent
 	o.capturers.captureCDPStart(rnr.name)
 	defer o.capturers.captureCDPEnd(rnr.name)
 

--- a/cdp_test.go
+++ b/cdp_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/k1LoW/donegroup"
 	"github.com/k1LoW/runn/testutil"
 )
 
@@ -195,6 +196,9 @@ func TestCDPRunner(t *testing.T) {
 	}
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("%d/%s", i, tt.actions[0].Fn), func(t *testing.T) {
+			ctx, cancel := donegroup.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
 			r, err := newCDPRunner("cc", cdpNewKey)
 			if err != nil {
 				t.Fatal(err)
@@ -208,7 +212,7 @@ func TestCDPRunner(t *testing.T) {
 				o.store.steps = []map[string]any{}
 			})
 			s := newStep(0, "stepKey", o, nil)
-			if err := r.run(context.Background(), tt.actions, s); err != nil {
+			if err := r.run(ctx, tt.actions, s); err != nil {
 				t.Fatal(err)
 			}
 			got, ok := o.store.steps[0][tt.wantKey]
@@ -223,6 +227,8 @@ func TestCDPRunner(t *testing.T) {
 }
 
 func TestSetUploadFile(t *testing.T) {
+	ctx, cancel := donegroup.WithCancel(context.Background())
+	t.Cleanup(cancel)
 	if testutil.SkipCDPTest(t) {
 		t.Skip("chrome not found")
 	}
@@ -268,7 +274,7 @@ func TestSetUploadFile(t *testing.T) {
 		}
 	})
 	s := newStep(0, "stepKey", o, nil)
-	if err := r.run(context.Background(), as, s); err != nil {
+	if err := r.run(ctx, as, s); err != nil {
 		t.Error(err)
 	}
 	{

--- a/db.go
+++ b/db.go
@@ -138,9 +138,11 @@ func (rnr *dbRunner) run(ctx context.Context, q *dbQuery, s *step) error {
 			return err
 		}
 		rnr.client = nx
-		donegroup.Cleanup(ctx, func() error {
+		if err := donegroup.Cleanup(ctx, func() error {
 			return rnr.Renew()
-		})
+		}); err != nil {
+			return err
+		}
 	}
 	stmts := separateStmt(q.stmt)
 	out := map[string]any{}

--- a/db.go
+++ b/db.go
@@ -114,6 +114,10 @@ func (rnr *dbRunner) Close() error {
 }
 
 func (rnr *dbRunner) Renew() error {
+	// If the DSN is in-memory, keep connection ( do not renew )
+	if rnr.dsn == "sqlite3://:memory:" {
+		return nil
+	}
 	if rnr.client != nil && rnr.dsn == "" {
 		return errors.New("DB runners created with the runn.DBRunner option cannot be renewed") //nostyle:errorstrings
 	}

--- a/db.go
+++ b/db.go
@@ -18,6 +18,7 @@ import (
 	"github.com/golang-sql/sqlexp"
 	"github.com/golang-sql/sqlexp/nest"
 	_ "github.com/googleapis/go-sql-spanner"
+	"github.com/k1LoW/donegroup"
 	_ "github.com/lib/pq"
 	"github.com/xo/dburl"
 	"modernc.org/sqlite"
@@ -133,6 +134,9 @@ func (rnr *dbRunner) run(ctx context.Context, q *dbQuery, s *step) error {
 			return err
 		}
 		rnr.client = nx
+		donegroup.Cleanup(ctx, func() error {
+			return rnr.Renew()
+		})
 	}
 	stmts := separateStmt(q.stmt)
 	out := map[string]any{}

--- a/db_test.go
+++ b/db_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/k1LoW/donegroup"
 	"github.com/k1LoW/runn/testutil"
 )
 
@@ -105,9 +106,10 @@ SELECT * FROM users;
 			},
 		},
 	}
-	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.stmt, func(t *testing.T) {
+			ctx, cancel := donegroup.WithCancel(context.Background())
+			t.Cleanup(cancel)
 			_, dsn := testutil.SQLite(t)
 			o, err := New()
 			if err != nil {
@@ -130,6 +132,8 @@ SELECT * FROM users;
 		})
 
 		t.Run(fmt.Sprintf("%s with Tx", tt.stmt), func(t *testing.T) {
+			ctx, cancel := donegroup.WithCancel(context.Background())
+			t.Cleanup(cancel)
 			db, dsn := testutil.SQLite(t)
 			o, err := New()
 			if err != nil {
@@ -309,10 +313,11 @@ func TestTraceStmtComment(t *testing.T) {
 INSERT INTO users (username, password, email, created) VALUES ('alice', 'passw0rd', 'alice@example.com', datetime('2017-12-05'));`,
 		},
 	}
-	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.stmt, func(t *testing.T) {
 			t.Run("runner with trace", func(t *testing.T) {
+				ctx, cancel := donegroup.WithCancel(context.Background())
+				t.Cleanup(cancel)
 				_, dsn := testutil.SQLite(t)
 				buf := new(bytes.Buffer)
 				o, err := New(Capture(NewDebugger(buf)))
@@ -337,6 +342,8 @@ INSERT INTO users (username, password, email, created) VALUES ('alice', 'passw0r
 			})
 
 			t.Run("query with trace", func(t *testing.T) {
+				ctx, cancel := donegroup.WithCancel(context.Background())
+				t.Cleanup(cancel)
 				_, dsn := testutil.SQLite(t)
 				buf := new(bytes.Buffer)
 				o, err := New(Capture(NewDebugger(buf)))

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/k1LoW/bufresolv v0.6.3
 	github.com/k1LoW/concgroup v1.1.0
 	github.com/k1LoW/curlreq v0.3.3
-	github.com/k1LoW/donegroup v1.8.1
+	github.com/k1LoW/donegroup v1.10.2
 	github.com/k1LoW/duration v1.2.0
 	github.com/k1LoW/exec v0.3.0
 	github.com/k1LoW/expand v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -1000,8 +1000,8 @@ github.com/k1LoW/concgroup v1.1.0 h1:yf7JEnvXPNlRdBw184mFaLz6w/anJMpe8fg4nJ8s4II
 github.com/k1LoW/concgroup v1.1.0/go.mod h1:cD18DUBcac9rl5mf8aK5MwITLeSoodExDG4dI7vp79k=
 github.com/k1LoW/curlreq v0.3.3 h1:ycHRTnphAq3vWZU49EdmXYYuF1AGkJBY5MQADvE7Ezo=
 github.com/k1LoW/curlreq v0.3.3/go.mod h1:kh0wTrg3kahGoGnAREXK5gYOcTXW7W/TnL8qbHe5Ppc=
-github.com/k1LoW/donegroup v1.8.1 h1:6eF6peh1l3KEdIkHq8lkDTLLVGgdJjhnO8ep+IGZnQg=
-github.com/k1LoW/donegroup v1.8.1/go.mod h1:I/s+pK8/noQoE7lY3ecYwhXOBvcKGYOBeKtSBlM6IXk=
+github.com/k1LoW/donegroup v1.10.2 h1:T3XWToJqsT9Gr+WBnxKV8FupE6x7LL0UsfMiYJrD8WA=
+github.com/k1LoW/donegroup v1.10.2/go.mod h1:I/s+pK8/noQoE7lY3ecYwhXOBvcKGYOBeKtSBlM6IXk=
 github.com/k1LoW/duration v1.2.0 h1:qq1gWtPh7YROFyerBufVP+ATR11mOOHDInrcC/Xe/6A=
 github.com/k1LoW/duration v1.2.0/go.mod h1:qUa0NptIiUl5EUsCc8wIiSaHuNjS4wmpYNMHp0l6pos=
 github.com/k1LoW/exec v0.3.0 h1:lNUqhF5IXhm2aDKcaWxhGwYC/WLcCbLOqoe97oxW1XQ=

--- a/grpc.go
+++ b/grpc.go
@@ -236,9 +236,11 @@ func (rnr *grpcRunner) connectAndResolve(ctx context.Context) error {
 			return err
 		}
 		rnr.cc = cc
-		donegroup.Cleanup(ctx, func() error {
+		if err := donegroup.Cleanup(ctx, func() error {
 			return rnr.Renew()
-		})
+		}); err != nil {
+			return err
+		}
 	}
 	if len(rnr.importPaths) > 0 || len(rnr.protos) > 0 || len(rnr.bufDirs) > 0 || len(rnr.bufLocks) > 0 || len(rnr.bufConfigs) > 0 || len(rnr.bufModules) > 0 {
 		if err := rnr.resolveAllMethodsUsingProtos(ctx); err != nil {

--- a/grpc.go
+++ b/grpc.go
@@ -190,7 +190,7 @@ func (rnr *grpcRunner) run(ctx context.Context, r *grpcRequest, s *step) error {
 func (rnr *grpcRunner) connectAndResolve(ctx context.Context, o *operator) error {
 	if rnr.cc == nil {
 		opts := []grpc.DialOption{
-			grpc.WithReturnConnectionError(),
+			grpc.WithReturnConnectionError(), //nolint:staticcheck
 			grpc.WithUserAgent(fmt.Sprintf("runn/%s", version.Version)),
 		}
 		if len(rnr.hostRules) > 0 {
@@ -233,7 +233,7 @@ func (rnr *grpcRunner) connectAndResolve(ctx context.Context, o *operator) error
 		}
 		cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
-		cc, err := grpc.DialContext(cctx, rnr.target, opts...)
+		cc, err := grpc.DialContext(cctx, rnr.target, opts...) //nolint:staticcheck
 		if err != nil {
 			return err
 		}

--- a/grpc.go
+++ b/grpc.go
@@ -18,6 +18,7 @@ import (
 	"github.com/goccy/go-json"
 	"github.com/jhump/protoreflect/v2/grpcreflect"
 	"github.com/k1LoW/bufresolv"
+	"github.com/k1LoW/donegroup"
 	"github.com/k1LoW/protoresolv"
 	"github.com/k1LoW/runn/version"
 	"github.com/mitchellh/copystructure"
@@ -235,6 +236,9 @@ func (rnr *grpcRunner) connectAndResolve(ctx context.Context) error {
 			return err
 		}
 		rnr.cc = cc
+		donegroup.Cleanup(ctx, func() error {
+			return rnr.Renew()
+		})
 	}
 	if len(rnr.importPaths) > 0 || len(rnr.protos) > 0 || len(rnr.bufDirs) > 0 || len(rnr.bufLocks) > 0 || len(rnr.bufConfigs) > 0 || len(rnr.bufModules) > 0 {
 		if err := rnr.resolveAllMethodsUsingProtos(ctx); err != nil {

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/k1LoW/donegroup"
 	"github.com/k1LoW/grpcstub"
 	"github.com/k1LoW/runn/testutil"
 	"github.com/k1LoW/runn/version"
@@ -245,7 +246,6 @@ func TestGrpcRunner(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
 	for _, useTLS := range []bool{true, false} {
 		useTLS := useTLS
 		for _, disableReflection := range []bool{true, false} {
@@ -254,6 +254,8 @@ func TestGrpcRunner(t *testing.T) {
 				tt := tt
 				t.Run(fmt.Sprintf("%s (useTLS: %v, disableReflection: %v)", tt.name, useTLS, disableReflection), func(t *testing.T) {
 					t.Parallel()
+					ctx, cancel := donegroup.WithCancel(context.Background())
+					t.Cleanup(cancel)
 					ts := testutil.GRPCServer(t, useTLS, disableReflection)
 					o, err := New()
 					if err != nil {
@@ -422,12 +424,13 @@ func TestGrpcRunnerWithTimeout(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
 	useTLS := false
 	ts := testutil.GRPCServer(t, useTLS, false)
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := donegroup.WithCancel(context.Background())
+			t.Cleanup(cancel)
 			o, err := New()
 			if err != nil {
 				t.Fatal(err)
@@ -563,11 +566,12 @@ func TestGrpcTraceHeader(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			ctx, cancel := donegroup.WithCancel(context.Background())
+			t.Cleanup(cancel)
 			ts := testutil.GRPCServer(t, false, false)
 			o, err := New()
 			if err != nil {

--- a/include.go
+++ b/include.go
@@ -176,16 +176,16 @@ func (o *operator) newNestedOperator(parent *step, opts ...Option) (*operator, e
 
 	// Set parent runners for re-use
 	for k, r := range o.httpRunners {
-		popts = append(popts, runnHTTPRunner(k, r))
+		popts = append(popts, reuseHTTPRunner(k, r))
 	}
 	for k, r := range o.dbRunners {
-		popts = append(popts, runnDBRunner(k, r))
+		popts = append(popts, reuseDBRunner(k, r))
 	}
 	for k, r := range o.grpcRunners {
-		popts = append(popts, runnGrpcRunner(k, r))
+		popts = append(popts, reuseGrpcRunner(k, r))
 	}
 	for k, r := range o.sshRunners {
-		popts = append(popts, runnSSHRunner(k, r))
+		popts = append(popts, reuseSSHRunner(k, r))
 	}
 
 	popts = append(popts, Debug(o.debug))

--- a/include.go
+++ b/include.go
@@ -196,7 +196,9 @@ func (o *operator) newNestedOperator(parent *step, opts ...Option) (*operator, e
 	for k, f := range o.store.funcs {
 		popts = append(popts, Func(k, f))
 	}
+
 	// Prefer child runbook opts
+	// For example, if a runner with the same name is defined in the child runbook to be included, it takes precedence.
 	opts = append(popts, opts...)
 	oo, err := New(opts...)
 	if err != nil {

--- a/integration_test.go
+++ b/integration_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/k1LoW/donegroup"
 	"github.com/k1LoW/runn/testutil"
 	"github.com/xo/dburl"
 )
@@ -67,16 +68,20 @@ func TestRunUsingHTTPBin(t *testing.T) {
 }
 
 func TestRunUsingMySQL(t *testing.T) {
-	db, _ := testutil.CreateMySQLContainer(t)
+	_, dsn := testutil.CreateMySQLContainer(t)
+	t.Setenv("TEST_DB", dsn)
 	tests := []struct {
 		book string
 	}{
 		{"testdata/book/mysql.yml"},
+		{"testdata/book/db_connection.yml"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.book, func(t *testing.T) {
-			ctx := context.Background()
-			f, err := New(Book(tt.book), DBRunner("db", db))
+			t.Parallel()
+			ctx, cancel := donegroup.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			f, err := New(Book(tt.book))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/operator.go
+++ b/operator.go
@@ -514,6 +514,9 @@ func New(opts ...Option) (*operator, error) {
 				return nil, err
 			}
 		}
+		if v.operatorID == "" {
+			v.operatorID = o.id
+		}
 		o.dbRunners[k] = v
 	}
 	for k, v := range bk.grpcRunners {
@@ -545,6 +548,9 @@ func New(opts ...Option) (*operator, error) {
 				return nil, err
 			}
 		}
+		if v.operatorID == "" {
+			v.operatorID = o.id
+		}
 		o.grpcRunners[k] = v
 	}
 	for k, v := range bk.cdpRunners {
@@ -554,6 +560,9 @@ func New(opts ...Option) (*operator, error) {
 		if err := v.Renew(); err != nil {
 			return nil, err
 		}
+		if v.operatorID == "" {
+			v.operatorID = o.id
+		}
 		o.cdpRunners[k] = v
 	}
 	for k, v := range bk.sshRunners {
@@ -562,6 +571,9 @@ func New(opts ...Option) (*operator, error) {
 			if err := v.Renew(); err != nil {
 				return nil, err
 			}
+		}
+		if v.operatorID == "" {
+			v.operatorID = o.id
 		}
 		o.sshRunners[k] = v
 	}

--- a/option.go
+++ b/option.go
@@ -1256,7 +1256,7 @@ func Books(pathp string) ([]Option, error) {
 	return opts, nil
 }
 
-func runnHTTPRunner(name string, r *httpRunner) Option {
+func reuseHTTPRunner(name string, r *httpRunner) Option {
 	return func(bk *book) error {
 		if bk == nil {
 			return ErrNilBook
@@ -1266,7 +1266,7 @@ func runnHTTPRunner(name string, r *httpRunner) Option {
 	}
 }
 
-func runnDBRunner(name string, r *dbRunner) Option {
+func reuseDBRunner(name string, r *dbRunner) Option {
 	return func(bk *book) error {
 		if bk == nil {
 			return ErrNilBook
@@ -1276,7 +1276,7 @@ func runnDBRunner(name string, r *dbRunner) Option {
 	}
 }
 
-func runnGrpcRunner(name string, r *grpcRunner) Option {
+func reuseGrpcRunner(name string, r *grpcRunner) Option {
 	return func(bk *book) error {
 		if bk == nil {
 			return ErrNilBook
@@ -1286,7 +1286,7 @@ func runnGrpcRunner(name string, r *grpcRunner) Option {
 	}
 }
 
-func runnSSHRunner(name string, r *sshRunner) Option {
+func reuseSSHRunner(name string, r *sshRunner) Option {
 	return func(bk *book) error {
 		if bk == nil {
 			return ErrNilBook

--- a/path.go
+++ b/path.go
@@ -247,7 +247,7 @@ func readFile(p string) ([]byte, error) {
 			return nil, err
 		}
 		// Write cache
-		if err := os.WriteFile(p, b, os.ModePerm); err != nil {
+		if err := os.WriteFile(p, b, os.ModePerm); err != nil { //nolint:gosec
 			return nil, err
 		}
 		return b, err

--- a/ssh.go
+++ b/ssh.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/Songmu/prompter"
+	"github.com/k1LoW/donegroup"
 	"github.com/k1LoW/sshc/v4"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/sync/errgroup"
@@ -227,6 +228,9 @@ func (rnr *sshRunner) run(ctx context.Context, c *sshCommand, s *step) error {
 				return err
 			}
 		}
+		donegroup.Cleanup(ctx, func() error {
+			return rnr.Renew()
+		})
 	}
 
 	if !rnr.keepSession {

--- a/ssh.go
+++ b/ssh.go
@@ -228,9 +228,11 @@ func (rnr *sshRunner) run(ctx context.Context, c *sshCommand, s *step) error {
 				return err
 			}
 		}
-		donegroup.Cleanup(ctx, func() error {
+		if err := donegroup.Cleanup(ctx, func() error {
 			return rnr.Renew()
-		})
+		}); err != nil {
+			return err
+		}
 	}
 
 	if !rnr.keepSession {

--- a/testdata/book/db_connection.yml
+++ b/testdata/book/db_connection.yml
@@ -1,0 +1,34 @@
+desc: Test db connection
+runners:
+  db: ${TEST_DB}
+steps:
+  -
+    desc: Get connection id
+    db:
+      query: SELECT CONNECTION_ID() AS id;
+    bind:
+      conn_id: current.rows[0].id
+  -
+    desc: Same connection
+    db:
+      query: SELECT CONNECTION_ID() AS id;
+    test: |
+      current.rows[0].id == conn_id
+  -
+    desc: Same connection
+    include:
+      path: db_connection_included.yml
+    test: |
+      current.conn_id == conn_id
+  -
+    desc: Same connection
+    db:
+      query: SELECT CONNECTION_ID() AS id;
+    test: |
+      current.rows[0].id == conn_id
+  -
+    desc: Different connection
+    include:
+      path: db_connection_included_with_new_conn.yml
+    test: |
+      current.conn_id != conn_id

--- a/testdata/book/db_connection_included.yml
+++ b/testdata/book/db_connection_included.yml
@@ -1,0 +1,9 @@
+desc: Test db connection (included)
+if: included
+steps:
+  -
+    desc: Get connection id
+    db:
+      query: SELECT CONNECTION_ID() AS id;
+    bind:
+      conn_id: current.rows[0].id

--- a/testdata/book/db_connection_included_with_new_conn.yml
+++ b/testdata/book/db_connection_included_with_new_conn.yml
@@ -1,0 +1,11 @@
+desc: Test db connection (included with new connection)
+runners:
+  db: ${TEST_DB}
+if: included
+steps:
+  -
+    desc: Get connection id
+    db:
+      query: SELECT CONNECTION_ID() AS id;
+    bind:
+      conn_id: current.rows[0].id

--- a/testdata/book/mysql.yml
+++ b/testdata/book/mysql.yml
@@ -1,6 +1,6 @@
 desc: Test using MySQL
 runners:
-  db: override
+  db: ${TEST_DB}
 steps:
   select:
     db:

--- a/testutil/runbook.go
+++ b/testutil/runbook.go
@@ -99,7 +99,7 @@ steps:
 	}
 	res.Body.Close()
 	openapi3 := filepath.Join(dir, "github-api.yaml")
-	if err := os.WriteFile(openapi3, b, os.ModePerm); err != nil {
+	if err := os.WriteFile(openapi3, b, os.ModePerm); err != nil { //nolint:gosec
 		t.Fatal(err)
 	}
 	tmpl, err := template.New("http").Parse(httpRunbookTmpl)


### PR DESCRIPTION
SSIA.