### PR TITLE
Add "Runner runner" that allows runners to be defined in the middle of steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1721,6 +1721,23 @@ It bind runner binds any values with another key.
 
 The `bind` runner can run in the same steps as the other runners.
 
+### Runner Runner: Define runner in the middle of steps.
+
+The `runner` runner is a built-in runner, so there is no need to specify it in the `runners:` section.
+
+It defines a runner in the middle of steps.
+
+``` yaml
+  -
+    runner:
+      sc: ssh://username@hostname:port
+  -
+    sc:
+      command: hostname
+```
+
+The `runner` runner can not run in the same steps as the other runners.
+
 ## Expression evaluation engine
 
 runn has embedded [expr-lang/expr](https://github.com/expr-lang/expr) as the evaluation engine for the expression.

--- a/book.go
+++ b/book.go
@@ -719,7 +719,7 @@ func parseBook(in io.Reader) (*book, error) {
 }
 
 func validateRunnerKey(k string) error {
-	if k == includeRunnerKey || k == testRunnerKey || k == dumpRunnerKey || k == execRunnerKey || k == bindRunnerKey {
+	if k == includeRunnerKey || k == testRunnerKey || k == dumpRunnerKey || k == execRunnerKey || k == bindRunnerKey || k == runnerRunnerKey {
 		return fmt.Errorf("runner name %q is reserved for built-in runner", k)
 	}
 	if k == ifSectionKey || k == descSectionKey || k == loopSectionKey {
@@ -732,16 +732,27 @@ func validateStepKeys(s map[string]any) error {
 	if len(s) == 0 {
 		return errors.New("step must specify at least one runner")
 	}
-	custom := 0
+	var mainRunnerKey string
+	mainRunner := 0
+	subRunner := 0
 	for k := range s {
-		if k == testRunnerKey || k == dumpRunnerKey || k == bindRunnerKey || k == ifSectionKey || k == descSectionKey || k == loopSectionKey {
+		if k == ifSectionKey || k == descSectionKey || k == loopSectionKey {
 			continue
 		}
-		custom += 1
+		if k == testRunnerKey || k == dumpRunnerKey || k == bindRunnerKey {
+			subRunner += 1
+			continue
+		}
+		mainRunner += 1
+		mainRunnerKey = k
 	}
-	if custom > 1 {
+	if mainRunner > 1 {
 		return errors.New("runners that cannot be running at the same time are specified")
 	}
+	if mainRunnerKey == runnerRunnerKey && subRunner > 0 {
+		return errors.New("runner: runner cannot be used with other runners")
+	}
+
 	return nil
 }
 

--- a/operator_test.go
+++ b/operator_test.go
@@ -201,15 +201,16 @@ func TestRun(t *testing.T) {
 		{"testdata/book/previous.yml"},
 		{"testdata/book/faker.yml"},
 		{"testdata/book/env.yml"},
+		{"testdata/book/runner_runner.yml"},
 	}
 	ctx := context.Background()
 	t.Setenv("DEBUG", "false")
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
-			t.Parallel()
-			db, _ := testutil.SQLite(t)
-			o, err := New(Book(tt.book), DBRunner("db", db), Scopes(ScopeAllowRunExec))
+			_, dsn := testutil.SQLite(t)
+			t.Setenv("TEST_DB_DSN", dsn)
+			o, err := New(Book(tt.book), Scopes(ScopeAllowRunExec))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/runner_runner.go
+++ b/runner_runner.go
@@ -1,0 +1,83 @@
+package runn
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samber/lo"
+)
+
+const runnerRunnerKey = "runner"
+
+type runnerRunner struct{}
+
+func newRunnerRunner() *runnerRunner {
+	return &runnerRunner{}
+}
+
+func (rnr *runnerRunner) Run(ctx context.Context, s *step) error {
+	o := s.parent
+	if s.runnerDefinition == nil {
+		return fmt.Errorf("runner definition is nil")
+	}
+	switch len(lo.Keys(s.runnerDefinition)) {
+	case 0:
+		return fmt.Errorf("runner definition is empty: %v", s.runnerDefinition)
+	case 1:
+	default:
+		return fmt.Errorf("only one runner can be defined: %v", s.runnerDefinition)
+	}
+	e, err := o.expandBeforeRecord(s.runnerDefinition)
+	if err != nil {
+		return err
+	}
+	d, ok := e.(map[string]any)
+	if !ok {
+		return fmt.Errorf("runner definition: %v", e)
+	}
+	if err := rnr.run(ctx, d, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (rnr *runnerRunner) run(_ context.Context, d map[string]any, s *step) error {
+	o := s.parent
+	bk := newBook()
+	bk.runners = d
+	if err := bk.parseRunners(map[string]any{}); err != nil {
+		return err
+	}
+	for k, r := range bk.httpRunners {
+		if _, ok := o.httpRunners[k]; ok {
+			return fmt.Errorf("http runner key %s is already exists", k)
+		}
+		o.httpRunners[k] = r
+	}
+	for k, r := range bk.dbRunners {
+		if _, ok := o.dbRunners[k]; ok {
+			return fmt.Errorf("db runner key %s is already exists", k)
+		}
+		o.dbRunners[k] = r
+	}
+	for k, r := range bk.grpcRunners {
+		if _, ok := o.grpcRunners[k]; ok {
+			return fmt.Errorf("grpc runner key %s is already exists", k)
+		}
+		o.grpcRunners[k] = r
+	}
+	for k, r := range bk.cdpRunners {
+		if _, ok := o.cdpRunners[k]; ok {
+			return fmt.Errorf("cdp runner key %s is already exists", k)
+		}
+		o.cdpRunners[k] = r
+	}
+	for k, r := range bk.sshRunners {
+		if _, ok := o.sshRunners[k]; ok {
+			return fmt.Errorf("ssh runner key %s is already exists", k)
+		}
+		o.sshRunners[k] = r
+	}
+	o.record(map[string]any{})
+	return nil
+}

--- a/runner_runner_test.go
+++ b/runner_runner_test.go
@@ -1,0 +1,119 @@
+package runn
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/k1LoW/donegroup"
+	"github.com/samber/lo"
+)
+
+func TestRunnerRunner(t *testing.T) {
+	type runnerKeys struct {
+		http []string
+		db   []string
+		grpc []string
+		cdp  []string
+		ssh  []string
+	}
+
+	tests := []struct {
+		definition map[string]any
+		want       runnerKeys
+		wantErr    bool
+	}{
+		{
+			nil,
+			runnerKeys{},
+			true,
+		},
+		{
+			map[string]any{
+				"req": "https://example.com",
+			},
+			runnerKeys{
+				http: []string{"req"},
+				db:   []string{},
+				grpc: []string{},
+				cdp:  []string{},
+				ssh:  []string{},
+			},
+			false,
+		},
+		{
+			map[string]any{
+				"req": "https://example.com",
+				"db":  "sqlite3://:memory:",
+			},
+			runnerKeys{},
+			true,
+		},
+		{
+			map[string]any{
+				"req": map[string]any{
+					"endpoint": "https://example.com",
+				},
+			},
+			runnerKeys{
+				http: []string{"req"},
+				db:   []string{},
+				grpc: []string{},
+				cdp:  []string{},
+				ssh:  []string{},
+			},
+			false,
+		},
+		{
+			map[string]any{
+				"db": "sqlite3://:memory:",
+			},
+			runnerKeys{
+				http: []string{},
+				db:   []string{"db"},
+				grpc: []string{},
+				cdp:  []string{},
+				ssh:  []string{},
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%v", tt.definition), func(t *testing.T) {
+			ctx, cancel := donegroup.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			t.Parallel()
+			o, err := New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			rnr := newRunnerRunner()
+			s := newStep(0, "stepKey", o, nil)
+			s.runnerDefinition = tt.definition
+			if err := rnr.Run(ctx, s); err != nil {
+				if !tt.wantErr {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Error("want error, but no error")
+				return
+			}
+			got := runnerKeys{
+				http: lo.Keys(o.httpRunners),
+				db:   lo.Keys(o.dbRunners),
+				grpc: lo.Keys(o.grpcRunners),
+				cdp:  lo.Keys(o.cdpRunners),
+				ssh:  lo.Keys(o.sshRunners),
+			}
+			opts := []cmp.Option{
+				cmp.AllowUnexported(runnerKeys{}),
+			}
+			if diff := cmp.Diff(got, tt.want, opts...); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/step.go
+++ b/step.go
@@ -13,27 +13,33 @@ type step struct {
 	ifCond    string
 	loop      *Loop
 	// loopIndex - Index of the loop is dynamically recorded at runtime
-	loopIndex     *int
-	httpRunner    *httpRunner
-	httpRequest   map[string]any
-	dbRunner      *dbRunner
-	dbQuery       map[string]any
-	grpcRunner    *grpcRunner
-	grpcRequest   map[string]any
-	cdpRunner     *cdpRunner
-	cdpActions    map[string]any
-	sshRunner     *sshRunner
-	sshCommand    map[string]any
-	execRunner    *execRunner
-	execCommand   map[string]any
-	testRunner    *testRunner
-	testCond      string
-	dumpRunner    *dumpRunner
-	dumpRequest   *dumpRequest
-	bindRunner    *bindRunner
-	bindCond      map[string]any
-	includeRunner *includeRunner
-	includeConfig *includeConfig
+	loopIndex        *int
+	httpRunner       *httpRunner
+	httpRequest      map[string]any
+	dbRunner         *dbRunner
+	dbQuery          map[string]any
+	grpcRunner       *grpcRunner
+	grpcRequest      map[string]any
+	cdpRunner        *cdpRunner
+	cdpActions       map[string]any
+	sshRunner        *sshRunner
+	sshCommand       map[string]any
+	execRunner       *execRunner
+	execCommand      map[string]any
+	testRunner       *testRunner
+	testCond         string
+	dumpRunner       *dumpRunner
+	dumpRequest      *dumpRequest
+	bindRunner       *bindRunner
+	bindCond         map[string]any
+	includeRunner    *includeRunner
+	includeConfig    *includeConfig
+	runnerRunner     *runnerRunner
+	runnerDefinition map[string]any
+
+	// runner values not yet detected.
+	runnerValues map[string]any
+
 	// operator related to step
 	parent  *operator
 	rawStep map[string]any
@@ -140,4 +146,17 @@ func (s *step) setResult(err error) {
 func (s *step) clearResult() {
 	s.result = nil
 	s.nodes = nil
+}
+
+func (s *step) notYetDetectedRunner() bool {
+	return s.httpRunner == nil &&
+		s.dbRunner == nil &&
+		s.grpcRunner == nil &&
+		s.cdpRunner == nil &&
+		s.sshRunner == nil &&
+		s.execRunner == nil &&
+		s.testRunner == nil &&
+		s.dumpRunner == nil &&
+		s.bindRunner == nil &&
+		s.includeRunner == nil
 }

--- a/testdata/book/runner_runner.yml
+++ b/testdata/book/runner_runner.yml
@@ -1,0 +1,13 @@
+desc: Test with Runner runner
+steps:
+  -
+    runner:
+      db:
+        dsn: ${TEST_DB_DSN:-sqlite3://:memory:}  
+  -
+    include: initdb.yml
+  -
+    db:
+      query: SELECT * FROM users;
+  -
+    test: 'steps[2].rows[0].username == "alice"'


### PR DESCRIPTION
## Usage

```yaml
desc: Test with Runner runner
steps:
  -
    exec:
      command: somecommand
  -
    runner:
      db:
        dsn: ${{ previous.stdout }}
  -
    db:
      query: SELECT * FROM users;
    test: 'current.rows[0].username == "alice"'
```