### PR TITLE
Support for the combined use of Include Runner and `needs:`

### DIFF
--- a/cmdout.go
+++ b/cmdout.go
@@ -119,10 +119,12 @@ func (d *cmdOut) verboseOutResultForStep(idx int, sr *StepResult, path string, n
 		// fail
 		lineformat := indent + "        %s\n"
 		_, _ = fmt.Fprintf(d.out, "%s    --- %s(%s) ... %s\n%s", indent, desc, sr.Key, red("fail"), red(SprintMultilinef(lineformat, "Failure/Error: %s", strings.TrimRight(sr.Err.Error(), "\n"))))
-		if sr.IncludedRunResult != nil {
-			_, _ = fmt.Fprintf(d.out, "%s        === %s (%s)\n", indent, sr.IncludedRunResult.Desc, sr.IncludedRunResult.Path)
-			sr.IncludedRunResult.included = false
-			d.verboseOutResult(sr.IncludedRunResult, nest+1)
+		if len(sr.IncludedRunResults) > 0 {
+			for _, ir := range sr.IncludedRunResults {
+				_, _ = fmt.Fprintf(d.out, "%s        === %s (%s)\n", indent, ir.Desc, ir.Path)
+				ir.included = false
+				d.verboseOutResult(ir, nest+1)
+			}
 			return
 		}
 		b, err := readFile(path)
@@ -139,19 +141,23 @@ func (d *cmdOut) verboseOutResultForStep(idx int, sr *StepResult, path string, n
 	case sr.Skipped:
 		// skip
 		_, _ = fmt.Fprintf(d.out, "%s    --- %s(%s) ... %s\n", indent, desc, sr.Key, yellow("skip"))
-		if sr.IncludedRunResult != nil {
-			_, _ = fmt.Fprintf(d.out, "%s        === %s (%s)\n", indent, sr.IncludedRunResult.Desc, sr.IncludedRunResult.Path)
-			sr.IncludedRunResult.included = false
-			d.verboseOutResult(sr.IncludedRunResult, nest+1)
+		if len(sr.IncludedRunResults) > 0 {
+			for _, ir := range sr.IncludedRunResults {
+				_, _ = fmt.Fprintf(d.out, "%s        === %s (%s)\n", indent, ir.Desc, ir.Path)
+				ir.included = false
+				d.verboseOutResult(ir, nest+1)
+			}
 			return
 		}
 	default:
 		// ok
 		_, _ = fmt.Fprintf(d.out, "%s    --- %s(%s) ... %s\n", indent, desc, sr.Key, green("ok"))
-		if sr.IncludedRunResult != nil {
-			_, _ = fmt.Fprintf(d.out, "%s        === %s (%s)\n", indent, sr.IncludedRunResult.Desc, sr.IncludedRunResult.Path)
-			sr.IncludedRunResult.included = false
-			d.verboseOutResult(sr.IncludedRunResult, nest+1)
+		if len(sr.IncludedRunResults) > 0 {
+			for _, ir := range sr.IncludedRunResults {
+				_, _ = fmt.Fprintf(d.out, "%s        === %s (%s)\n", indent, ir.Desc, ir.Path)
+				ir.included = false
+				d.verboseOutResult(ir, nest+1)
+			}
 			return
 		}
 	}

--- a/cmdout_test.go
+++ b/cmdout_test.go
@@ -20,13 +20,13 @@ func TestCmdOutCaptureResult(t *testing.T) {
 				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path: "testdata/book/runn_1_fail.yml",
 				Err:  ErrDummy,
-				StepResults: []*StepResult{{Key: "0", Err: ErrDummy, IncludedRunResult: &RunResult{
+				StepResults: []*StepResult{{Key: "0", Err: ErrDummy, IncludedRunResults: []*RunResult{{
 					ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 					Path:        "testdata/book/runn_included_0_fail.yml",
 					Err:         ErrDummy,
 					StepResults: []*StepResult{{Key: "0", Err: ErrDummy}},
 					included:    true,
-				}}},
+				}}}},
 			},
 			false,
 		},
@@ -35,13 +35,13 @@ func TestCmdOutCaptureResult(t *testing.T) {
 				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path: "testdata/book/runn_1_fail.yml",
 				Err:  ErrDummy,
-				StepResults: []*StepResult{{Key: "0", Err: ErrDummy, IncludedRunResult: &RunResult{
+				StepResults: []*StepResult{{Key: "0", Err: ErrDummy, IncludedRunResults: []*RunResult{{
 					ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 					Path:        "testdata/book/runn_included_0_fail.yml",
 					Err:         ErrDummy,
 					StepResults: []*StepResult{{Key: "0", Err: ErrDummy}},
 					included:    true,
-				}}},
+				}}}},
 			},
 			true,
 		},
@@ -75,13 +75,13 @@ func TestCmdOutCaptureResultByStep(t *testing.T) {
 				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path: "testdata/book/runn_1_fail.yml",
 				Err:  ErrDummy,
-				StepResults: []*StepResult{{Key: "0", Err: ErrDummy, IncludedRunResult: &RunResult{
+				StepResults: []*StepResult{{Key: "0", Err: ErrDummy, IncludedRunResults: []*RunResult{{
 					ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 					Path:        "testdata/book/runn_included_0_fail.yml",
 					Err:         ErrDummy,
 					StepResults: []*StepResult{{Key: "0", Err: ErrDummy}},
 					included:    true,
-				}}},
+				}}}},
 			},
 			false,
 		},
@@ -90,13 +90,13 @@ func TestCmdOutCaptureResultByStep(t *testing.T) {
 				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path: "testdata/book/runn_1_fail.yml",
 				Err:  ErrDummy,
-				StepResults: []*StepResult{{Key: "0", Err: ErrDummy, IncludedRunResult: &RunResult{
+				StepResults: []*StepResult{{Key: "0", Err: ErrDummy, IncludedRunResults: []*RunResult{{
 					ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 					Path:        "testdata/book/runn_included_0_fail.yml",
 					Err:         ErrDummy,
 					StepResults: []*StepResult{{Key: "0", Err: ErrDummy}},
 					included:    true,
-				}}},
+				}}}},
 			},
 			true,
 		},
@@ -109,13 +109,13 @@ func TestCmdOutCaptureResultByStep(t *testing.T) {
 					{
 						Key: "0",
 						Err: nil,
-						IncludedRunResult: &RunResult{
+						IncludedRunResults: []*RunResult{{
 							ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 							Path:        "testdata/book/runn_included_0_success.yml",
 							Err:         nil,
 							StepResults: []*StepResult{{Key: "0", Err: nil}},
 							included:    true,
-						},
+						}},
 					},
 					{
 						Key: "1",

--- a/include.go
+++ b/include.go
@@ -3,7 +3,6 @@ package runn
 import (
 	"context"
 	"errors"
-	"fmt"
 	"path/filepath"
 )
 
@@ -160,8 +159,8 @@ func (rnr *includeRunner) Run(ctx context.Context, s *step) error {
 }
 
 func (rnr *includeRunner) run(ctx context.Context, oo *operator, s *step) error {
-	fmt.Println("trails", oo.trails())
 	o := s.parent
+
 	ops := oo.toOperators()
 	sorted, err := sortWithNeeds(ops.ops)
 	if err != nil {
@@ -170,10 +169,14 @@ func (rnr *includeRunner) run(ctx context.Context, oo *operator, s *step) error 
 	// Filter already runned runbooks
 	var filtered []*operator
 	for _, ooo := range sorted {
-		if _, ok := ops.nm.TryGet(ooo.bookPath); !ok {
+		if oo.bookPath == ooo.bookPath {
+			// The originally included oo is not filtered.
+			filtered = append(filtered, ooo)
+		} else if _, ok := ops.nm.TryGet(ooo.bookPath); !ok {
 			filtered = append(filtered, ooo)
 		}
 	}
+
 	// Do not use ops.runN because runN closes the runners.
 	// And one runbook should be run sequentially.
 	// ref: https://github.com/k1LoW/runn/blob/b81205550f0e15fec509a596fcee8619e345ae95/docs/designs/id.md

--- a/operator.go
+++ b/operator.go
@@ -1566,6 +1566,7 @@ func (ops *operators) SelectedOperators() (tops []*operator, err error) {
 	defer func() {
 		selected := &operators{
 			ops:          tops,
+			sw:           ops.sw,
 			om:           ops.om,
 			nm:           ops.nm,
 			skipIncluded: ops.skipIncluded,
@@ -1774,6 +1775,7 @@ func (ops *operators) traverseOperators(o *operator) error {
 	o.store.kv = ops.kv // set pointer of kv
 	o.dbg = ops.dbg
 	o.nm = ops.nm
+	o.sw = ops.sw
 
 	if _, ok := ops.om[o.bookPath]; !ok {
 		ops.om[o.bookPath] = o

--- a/operator.go
+++ b/operator.go
@@ -1305,13 +1305,12 @@ func (o *operator) skip() error {
 
 // toOperators convert *operator to *operators.
 func (o *operator) toOperators() *operators {
-	sw := stopw.New()
 	ops := &operators{
 		ops:     []*operator{o},
 		nm:      o.nm,
 		om:      map[string]*operator{},
 		t:       o.t,
-		sw:      sw,
+		sw:      o.sw,
 		profile: o.profile,
 		concmax: 1,
 		kv:      newKV(),
@@ -1956,8 +1955,8 @@ func setElaspedByRunbookIDFull(r *RunResult, m map[string]time.Duration) error {
 			continue
 		}
 		sr.Elapsed = e
-		if sr.IncludedRunResult != nil {
-			if err := setElaspedByRunbookIDFull(sr.IncludedRunResult, m); err != nil {
+		for _, ir := range sr.IncludedRunResults {
+			if err := setElaspedByRunbookIDFull(ir, m); err != nil {
 				return err
 			}
 		}

--- a/operator_test.go
+++ b/operator_test.go
@@ -466,6 +466,129 @@ func TestRunN(t *testing.T) {
 				StepResults: []*StepResult{{ID: "727b0e891f454ff06e4a07ae441cfd7e6b2f224f?step=0", Key: "0", Err: nil}},
 			},
 		})},
+		{"testdata/book/needs_4.yml", "", false, newRunNResult(t, 1, []*RunResult{
+			{
+				ID:   "b7a2c3d17c31e57390a5bc2052be04c17d9af609",
+				Path: "testdata/book/needs_4.yml",
+				Err:  nil,
+				StepResults: []*StepResult{
+					{
+						ID:  "b7a2c3d17c31e57390a5bc2052be04c17d9af609?step=0",
+						Key: "0",
+						Err: nil,
+						IncludedRunResults: []*RunResult{
+							{
+								ID:   "r-xxx",
+								Path: "testdata/book/needs_1.yml",
+								Err:  nil,
+								StepResults: []*StepResult{
+									{
+										ID:  "r-xxx?step=0",
+										Key: "0",
+										Err: nil,
+									},
+									{
+										ID:  "r-xxx?step=1",
+										Key: "1",
+										Err: nil,
+									},
+								},
+							},
+							{
+								ID:   "r-xxx",
+								Path: "testdata/book/needs_2.yml",
+								Err:  nil,
+								StepResults: []*StepResult{
+									{
+										ID:  "r-xxx?step=0",
+										Key: "0",
+										Err: nil,
+									},
+									{
+										ID:  "r-xxx?step=1",
+										Key: "1",
+										Err: nil,
+									},
+								},
+							},
+							{
+								ID:   "b7a2c3d17c31e57390a5bc2052be04c17d9af609?step=0",
+								Path: "testdata/book/needs_3.yml",
+								Err:  nil,
+								StepResults: []*StepResult{
+									{
+										ID:  "b7a2c3d17c31e57390a5bc2052be04c17d9af609?step=0&step=0",
+										Key: "0",
+										Err: nil,
+									},
+								},
+							},
+						},
+					},
+					{
+						ID:  "b7a2c3d17c31e57390a5bc2052be04c17d9af609?step=1",
+						Key: "1",
+						Err: nil,
+					},
+				},
+			},
+		})},
+		{"testdata/book/needs_5.yml", "", false, newRunNResult(t, 2, []*RunResult{
+			{
+				Path: "testdata/book/needs_1.yml",
+				Err:  nil,
+				StepResults: []*StepResult{
+					{
+						Key: "0",
+						Err: nil,
+					},
+					{
+						Key: "1",
+						Err: nil,
+					},
+				},
+			},
+			{
+				Path: "testdata/book/needs_5.yml",
+				Err:  nil,
+				StepResults: []*StepResult{
+					{
+						Key: "0",
+						Err: nil,
+						IncludedRunResults: []*RunResult{
+							{
+								Path: "testdata/book/needs_2.yml",
+								Err:  nil,
+								StepResults: []*StepResult{
+									{
+										Key: "0",
+										Err: nil,
+									},
+									{
+										Key: "1",
+										Err: nil,
+									},
+								},
+							},
+							{
+								Path: "testdata/book/needs_3.yml",
+								Err:  nil,
+								StepResults: []*StepResult{
+									{
+										Key: "0",
+										Err: nil,
+									},
+								},
+							},
+						},
+					},
+					{
+						Key: "1",
+						Err: nil,
+					},
+				},
+			},
+		})},
 	}
 	ctx := context.Background()
 	for i, tt := range tests {
@@ -479,8 +602,8 @@ func TestRunN(t *testing.T) {
 			got := ops.Result().simplify()
 			want := tt.want.simplify()
 			opts := []cmp.Option{
-				cmpopts.IgnoreFields(runResultSimplified{}, "Elapsed"),
-				cmpopts.IgnoreFields(stepResultSimplified{}, "Elapsed"),
+				cmpopts.IgnoreFields(runResultSimplified{}, "Elapsed", "ID"),
+				cmpopts.IgnoreFields(stepResultSimplified{}, "Elapsed", "ID"),
 			}
 			if diff := cmp.Diff(got, want, opts...); diff != "" {
 				t.Error(diff)

--- a/result.go
+++ b/result.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/samber/lo"
 )
 
 type result string
@@ -44,9 +46,9 @@ type StepResult struct {
 	Desc    string
 	Skipped bool
 	Err     error
-	// Run result of runbook loaded by include runner
-	IncludedRunResult *RunResult
-	Elapsed           time.Duration
+	// Run results of runbook loaded by include runner
+	IncludedRunResults []*RunResult
+	Elapsed            time.Duration
 }
 
 type runNResult struct {
@@ -74,11 +76,11 @@ type runResultSimplified struct {
 }
 
 type stepResultSimplified struct {
-	ID                string               `json:"id"`
-	Key               string               `json:"key"`
-	Result            result               `json:"result"`
-	IncludedRunResult *runResultSimplified `json:"included_run_result,omitempty"`
-	Elapsed           time.Duration        `json:"elapsed,omitempty"`
+	ID                 string                 `json:"id"`
+	Key                string                 `json:"key"`
+	Result             result                 `json:"result"`
+	IncludedRunResults []*runResultSimplified `json:"included_run_result,omitempty"`
+	Elapsed            time.Duration          `json:"elapsed,omitempty"`
 }
 
 func newRunResult(desc string, labels []string, path string, included bool, store *store) *RunResult {
@@ -231,19 +233,21 @@ func failedRunbookPathsAndErrors(rr *RunResult) ([][]string, []int, []error) {
 		if sr.Err == nil {
 			continue
 		}
-		if sr.IncludedRunResult == nil {
+		if len(sr.IncludedRunResults) == 0 {
 			paths = append(paths, []string{rr.Path})
 			errs = append(errs, sr.Err)
 			indexes = append(indexes, i)
 			continue
 		}
-		ps, is, es := failedRunbookPathsAndErrors(sr.IncludedRunResult)
-		for _, p := range ps {
-			p = append([]string{rr.Path}, p...)
-			paths = append(paths, p)
+		for _, ir := range sr.IncludedRunResults {
+			ps, is, es := failedRunbookPathsAndErrors(ir)
+			for _, p := range ps {
+				p = append([]string{rr.Path}, p...)
+				paths = append(paths, p)
+			}
+			indexes = append(indexes, is...)
+			errs = append(errs, es...)
 		}
-		indexes = append(indexes, is...)
-		errs = append(errs, es...)
 	}
 	if len(paths) == 0 {
 		paths = append(paths, []string{rr.Path})
@@ -292,27 +296,33 @@ func simplifyStepResults(stepResults []*StepResult) []*stepResultSimplified {
 		switch {
 		case sr.Err != nil:
 			simplified = append(simplified, &stepResultSimplified{
-				ID:                sr.ID,
-				Key:               sr.Key,
-				Result:            resultFailure,
-				IncludedRunResult: simplifyRunResult(sr.IncludedRunResult),
-				Elapsed:           sr.Elapsed,
+				ID:     sr.ID,
+				Key:    sr.Key,
+				Result: resultFailure,
+				IncludedRunResults: lo.Map(sr.IncludedRunResults, func(ir *RunResult, _ int) *runResultSimplified {
+					return simplifyRunResult(ir)
+				}),
+				Elapsed: sr.Elapsed,
 			})
 		case sr.Skipped:
 			simplified = append(simplified, &stepResultSimplified{
-				ID:                sr.ID,
-				Key:               sr.Key,
-				Result:            resultSkipped,
-				IncludedRunResult: simplifyRunResult(sr.IncludedRunResult),
-				Elapsed:           sr.Elapsed,
+				ID:     sr.ID,
+				Key:    sr.Key,
+				Result: resultSkipped,
+				IncludedRunResults: lo.Map(sr.IncludedRunResults, func(ir *RunResult, _ int) *runResultSimplified {
+					return simplifyRunResult(ir)
+				}),
+				Elapsed: sr.Elapsed,
 			})
 		default:
 			simplified = append(simplified, &stepResultSimplified{
-				ID:                sr.ID,
-				Key:               sr.Key,
-				Result:            resultSuccess,
-				IncludedRunResult: simplifyRunResult(sr.IncludedRunResult),
-				Elapsed:           sr.Elapsed,
+				ID:     sr.ID,
+				Key:    sr.Key,
+				Result: resultSuccess,
+				IncludedRunResults: lo.Map(sr.IncludedRunResults, func(ir *RunResult, _ int) *runResultSimplified {
+					return simplifyRunResult(ir)
+				}),
+				Elapsed: sr.Elapsed,
 			})
 		}
 	}

--- a/result_test.go
+++ b/result_test.go
@@ -196,12 +196,12 @@ func TestResultOutJSON(t *testing.T) {
 				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
 				Path: "testdata/book/runn_1_fail.yml",
 				Err:  ErrDummy,
-				StepResults: []*StepResult{{ID: "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0", Key: "0", Err: ErrDummy, IncludedRunResult: &RunResult{
+				StepResults: []*StepResult{{ID: "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0", Key: "0", Err: ErrDummy, IncludedRunResults: []*RunResult{{
 					ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
 					Path:        "testdata/book/runn_included_0_fail.yml",
 					Err:         ErrDummy,
 					StepResults: []*StepResult{{Key: "0", Err: ErrDummy}},
-				}}},
+				}}}},
 			},
 		})},
 	}

--- a/step.go
+++ b/step.go
@@ -132,15 +132,15 @@ func (s *step) setResult(err error) {
 	if s.result != nil {
 		panic("duplicate record of step results")
 	}
-	var runResult *RunResult
+	var runResults []*RunResult
 	if s.includeRunner != nil {
-		runResult = s.includeRunner.runResult
+		runResults = s.includeRunner.runResults
 	}
 	if errors.Is(errStepSkiped, err) {
-		s.result = &StepResult{ID: s.runbookID(), Key: s.key, Desc: s.desc, Skipped: true, Err: nil, IncludedRunResult: runResult}
+		s.result = &StepResult{ID: s.runbookID(), Key: s.key, Desc: s.desc, Skipped: true, Err: nil, IncludedRunResults: runResults}
 		return
 	}
-	s.result = &StepResult{ID: s.runbookID(), Key: s.key, Desc: s.desc, Skipped: false, Err: err, IncludedRunResult: runResult}
+	s.result = &StepResult{ID: s.runbookID(), Key: s.key, Desc: s.desc, Skipped: false, Err: err, IncludedRunResults: runResults}
 }
 
 func (s *step) clearResult() {

--- a/testdata/book/needs_3.yml
+++ b/testdata/book/needs_3.yml
@@ -10,3 +10,6 @@ steps:
     test: |
       needs.needs1.hello == 'world'
       && needs.needs2.hello2 == 'wide'
+    bind:
+      needs1: needs.needs1
+      needs2: needs.needs2

--- a/testdata/book/needs_4.yml
+++ b/testdata/book/needs_4.yml
@@ -1,0 +1,16 @@
+desc: For needs test (4)
+labels:
+  - needs
+steps:
+  - 
+    desc: Step 1-3
+    include:
+      path: needs_3.yml
+    bind:
+      needs1: current.needs1
+      needs2: current.needs2
+  -
+    desc: Step 4
+    test: |
+      needs1.hello == 'world'
+      && needs2.hello2 == 'wide'

--- a/testdata/book/needs_5.yml
+++ b/testdata/book/needs_5.yml
@@ -1,0 +1,19 @@
+desc: For needs test (5)
+labels:
+  - needs
+needs:
+  needs1: needs_1.yml
+steps:
+  - 
+    desc: Step 1-3
+    include:
+      path: needs_3.yml
+    bind:
+      needs1: current.needs1
+      needs2: current.needs2
+  -
+    desc: Step 4
+    test: |
+      needs.needs1.hello == 'world'
+      && needs1.hello == 'world'
+      && needs2.hello2 == 'wide'

--- a/testdata/result_out_json_3.golden
+++ b/testdata/result_out_json_3.golden
@@ -25,18 +25,20 @@
           "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
           "key": "0",
           "result": "failure",
-          "included_run_result": {
-            "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
-            "path": "testdata/book/runn_included_0_fail.yml",
-            "result": "failure",
-            "steps": [
-              {
-                "id": "",
-                "key": "0",
-                "result": "failure"
-              }
-            ]
-          }
+          "included_run_result": [
+            {
+              "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
+              "path": "testdata/book/runn_included_0_fail.yml",
+              "result": "failure",
+              "steps": [
+                {
+                  "id": "",
+                  "key": "0",
+                  "result": "failure"
+                }
+              ]
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
Previously, when the needs: section was specified in the included runbook, execution was blocked in some cases.

This fix resolves the needs: section of the included runbook.

This resulted in the Include runner running multiple runbooks. So we also modified the structure of the results.