### PR TITLE
Fix the output of `runn new` for a gRPC method which needs a empty message

### DIFF
--- a/runbook.go
+++ b/runbook.go
@@ -297,7 +297,7 @@ func (rb *runbook) grpcurlToStep(in ...string) error {
 	case len(p.Messages) == 0:
 		hm = append(hm, yaml.MapItem{
 			Key:   "message",
-			Value: map[string]interface{}{},
+			Value: map[string]any{},
 		})
 	case len(p.Messages) == 1:
 		hm = append(hm, yaml.MapItem{

--- a/runbook.go
+++ b/runbook.go
@@ -294,6 +294,11 @@ func (rb *runbook) grpcurlToStep(in ...string) error {
 
 	// messages
 	switch {
+	case len(p.Messages) == 0:
+		hm = append(hm, yaml.MapItem{
+			Key:   "message",
+			Value: map[string]interface{}{},
+		})
 	case len(p.Messages) == 1:
 		hm = append(hm, yaml.MapItem{
 			Key:   "message",


### PR DESCRIPTION
Resolves #1009 

## Test result
### Before(tested on `53cf1c02d87d` which is newest commit of main)
```sh
$ go run ./cmd/runn/main.go new -- grpcurl -plaintext localhost:8080 myApp.MyService/Health
desc: Generated by `runn new`
runners:
  greq: grpc://localhost:8080
steps:
- greq:
    myApp.MyService/Health: {}
```

### After(tested on `ee9d9220c391` which is newest commit of this branch)
```sh
$ go run ./cmd/runn/main.go new -- grpcurl -plaintext localhost:8080 myApp.MyService/Health
desc: Generated by `runn new`
runners:
  greq: grpc://localhost:8080
steps:
- greq:
    myApp.MyService/Health:
      message: {}
```

## Needs help
When I ran `go run cmd/runn/main.go new --and-run --grpc-no-tls -- grpcurl -plaintext localhost:8080 myApp.myService/Health`, the output was like this.

```yaml
desc: Generated by `runn new`
runners:
  greq: grpc://localhost:8080
steps:
- greq:
    myApp.myService/Health: {}
  test: |
    current.res.headers["content-type"][0] == "application/grpc"
    && compare(current.res.message, {"message":"myApp"})
    && current.res.status == 0
```

I couldn't understand why `myApp.MyService/Health:\n\tmessage: {}` is not shown but `myApp.myService/Health: {}` thought I read code a little to understand.
When I have enough time, I will do more investigate.