### PR TITLE
If there are runbook run failures in `runn run`, list the failure results at the end (always).

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -86,7 +86,7 @@ var runCmd = &cobra.Command{
 		case "none":
 		default:
 			// If --verbose == true, leave it to cmdout to display results
-			if err := r.Out(os.Stdout, !flgs.Verbose); err != nil {
+			if err := r.Out(os.Stdout); err != nil {
 				return err
 			}
 		}

--- a/result.go
+++ b/result.go
@@ -103,10 +103,10 @@ func (r *runNResult) HasFailure() bool {
 	return false
 }
 
-func (r *runNResult) Out(out io.Writer, verbose bool) error {
+func (r *runNResult) Out(out io.Writer) error {
 	var ts, fs string
 	_, _ = fmt.Fprintln(out, "")
-	if verbose && r.HasFailure() {
+	if r.HasFailure() {
 		_, _ = fmt.Fprintln(out, "")
 		i := 1
 		var err error

--- a/result_test.go
+++ b/result_test.go
@@ -13,8 +13,7 @@ import (
 func TestResultOut(t *testing.T) {
 	noColor(t)
 	tests := []struct {
-		r       *runNResult
-		verbose bool
+		r *runNResult
 	}{
 		{newRunNResult(t, 4, []*RunResult{
 			{
@@ -37,7 +36,7 @@ func TestResultOut(t *testing.T) {
 				Path: "testdata/book/runn_3.skip.yml",
 				Err:  nil,
 			},
-		}), false},
+		})},
 		{newRunNResult(t, 5, []*RunResult{
 			{
 				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
@@ -64,7 +63,7 @@ func TestResultOut(t *testing.T) {
 				Path: "testdata/book/always_failure.yml",
 				Err:  nil,
 			},
-		}), false},
+		})},
 		{newRunNResult(t, 2, []*RunResult{
 			{
 				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
@@ -76,7 +75,7 @@ func TestResultOut(t *testing.T) {
 				Path: "testdata/book/runn_1_fail.yml",
 				Err:  ErrDummy,
 			},
-		}), false},
+		})},
 		{newRunNResult(t, 2, []*RunResult{
 			{
 				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
@@ -88,13 +87,13 @@ func TestResultOut(t *testing.T) {
 				Path: "testdata/book/runn_1_fail.yml",
 				Err:  ErrDummy,
 			},
-		}), true},
+		})},
 	}
 	for i, tt := range tests {
 		key := fmt.Sprintf("result_out_%d", i)
 		t.Run(key, func(t *testing.T) {
 			buf := new(bytes.Buffer)
-			if err := tt.r.Out(buf, tt.verbose); err != nil {
+			if err := tt.r.Out(buf); err != nil {
 				t.Error(err)
 			}
 			got := buf.String()

--- a/testdata/result_out_0.golden
+++ b/testdata/result_out_0.golden
@@ -1,3 +1,6 @@
 
 
+1) testdata/book/runn_1_fail.yml ab13ba1e546838ceafa17f91ab3220102f397b2e
+  Failure/Error: dummy
+
 4 scenarios, 0 skipped, 1 failure

--- a/testdata/result_out_1.golden
+++ b/testdata/result_out_1.golden
@@ -1,3 +1,6 @@
 
 
+1) testdata/book/runn_1_fail.yml ab13ba1e546838ceafa17f91ab3220102f397b2e
+  Failure/Error: dummy
+
 5 scenarios, 0 skipped, 1 failure

--- a/testdata/result_out_2.golden
+++ b/testdata/result_out_2.golden
@@ -1,3 +1,6 @@
 
 
+1) testdata/book/runn_1_fail.yml ab13ba1e546838ceafa17f91ab3220102f397b2e
+  Failure/Error: dummy
+
 2 scenarios, 0 skipped, 1 failure


### PR DESCRIPTION
SSIA.

ref: https://zenn.dev/link/comments/7054a8d20effdf