### PR TITLE
Add `skipCircularReferenceCheck` for skipping circular reference check in the OpenAPI3 document.

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,6 +824,7 @@ runners:
     openapi3: path/to/openapi.yaml
     # skipValidateRequest: false
     # skipValidateResponse: false
+    # skipCircularReferenceCheck: false # skip checking circular references in OpenAPIv3 document.
 ```
 
 #### Custom CA and Certificates

--- a/cdp_test.go
+++ b/cdp_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/k1LoW/donegroup"
 	"github.com/k1LoW/runn/testutil"
+	"github.com/samber/lo"
 )
 
 func TestCDPRunner(t *testing.T) {
@@ -289,10 +291,16 @@ func TestSetUploadFile(t *testing.T) {
 		}
 	}
 	{
-		r := hr.Requests()[1]
+		r, ok := lo.Find(hr.Requests(), func(req *http.Request) bool {
+			return req.Method == http.MethodPost && req.URL.Path == "/upload"
+		})
+		if !ok {
+			t.Fatal("not found")
+		}
 		f, _, err := r.FormFile("upload0")
 		if err != nil {
 			t.Error(err)
+			return
 		}
 		t.Cleanup(func() {
 			_ = f.Close()

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/k1LoW/go-github-client/v58 v58.0.12
 	github.com/k1LoW/grpcstub v0.23.0
 	github.com/k1LoW/grpcurlreq v0.2.1
-	github.com/k1LoW/httpstub v0.16.8
+	github.com/k1LoW/httpstub v0.17.0
 	github.com/k1LoW/protoresolv v0.1.1
 	github.com/k1LoW/repin v0.3.4
 	github.com/k1LoW/sshc/v4 v4.2.0

--- a/go.sum
+++ b/go.sum
@@ -1033,8 +1033,8 @@ github.com/k1LoW/grpcstub v0.23.0 h1:xY9wvtEBnMY/UgHAJ9afMt6HPevXI+98lSqkYoHiaTU
 github.com/k1LoW/grpcstub v0.23.0/go.mod h1:kHUehWZHE+s3EuqLGLjk4GkYz+oxiCIj9Q9Co57jCUk=
 github.com/k1LoW/grpcurlreq v0.2.1 h1:vV5XPcudceX5+DvnEvyDY11E/MkJ01RmYoHO3/8aNjg=
 github.com/k1LoW/grpcurlreq v0.2.1/go.mod h1:fYHtOo6/5ans9ub1CDRIQQfvo4NyTGwPud+FH/Rnx90=
-github.com/k1LoW/httpstub v0.16.8 h1:rQN/kRiQCeiTcUq9cZhc/vtUWczSNITFtCsYEIdcNyE=
-github.com/k1LoW/httpstub v0.16.8/go.mod h1:r9Cu3m/G+ILM8jjPebA/P4dXbIH8s8jnPVrhFETAFYA=
+github.com/k1LoW/httpstub v0.17.0 h1:VOeyfSriYbHQL1wGk9sfqa8TDpP6Zti/MPT3xcYDtF0=
+github.com/k1LoW/httpstub v0.17.0/go.mod h1:r9Cu3m/G+ILM8jjPebA/P4dXbIH8s8jnPVrhFETAFYA=
 github.com/k1LoW/protoresolv v0.1.1 h1:3Q5Sl4bOGyXy9etMZJraF60XqPQBqodFMfGoqBEBwYE=
 github.com/k1LoW/protoresolv v0.1.1/go.mod h1:eVklYuDOPjSNzmbHZiNmXwmXX4OHqscY0MduCGQbSK0=
 github.com/k1LoW/repin v0.3.4 h1:xcNuBBc/ISHUNBzjXNTCux4OYZND5ZMiyz4SrRtpDhg=

--- a/http_validator.go
+++ b/http_validator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pb33f/libopenapi"
 	validator "github.com/pb33f/libopenapi-validator"
 	verrors "github.com/pb33f/libopenapi-validator/errors"
+	"github.com/pb33f/libopenapi/datamodel"
 )
 
 type httpValidator interface { //nostyle:ifacenames
@@ -113,7 +114,12 @@ func newOpenAPI3Validator(c *httpRunnerConfig) (*openAPI3Validator, error) {
 					validator:            v,
 				}, nil
 			}
-			doc, err = libopenapi.NewDocumentWithConfiguration(b, openAPIConfig)
+			oc := &datamodel.DocumentConfiguration{
+				AllowFileReferences:        true,
+				AllowRemoteReferences:      true,
+				SkipCircularReferenceCheck: c.SkipCircularReferenceCheck,
+			}
+			doc, err = libopenapi.NewDocumentWithConfiguration(b, oc)
 			if err != nil {
 				return nil, err
 			}
@@ -138,8 +144,13 @@ func newOpenAPI3Validator(c *httpRunnerConfig) (*openAPI3Validator, error) {
 					validator:            v,
 				}, nil
 			}
-			openAPIConfig.BasePath = filepath.Dir(l)
-			doc, err = libopenapi.NewDocumentWithConfiguration(b, openAPIConfig)
+			oc := &datamodel.DocumentConfiguration{
+				AllowFileReferences:        true,
+				AllowRemoteReferences:      true,
+				SkipCircularReferenceCheck: c.SkipCircularReferenceCheck,
+				BasePath:                   filepath.Dir(l),
+			}
+			doc, err = libopenapi.NewDocumentWithConfiguration(b, oc)
 			if err != nil {
 				return nil, err
 			}

--- a/operator_test.go
+++ b/operator_test.go
@@ -303,12 +303,12 @@ func TestLoad(t *testing.T) {
 		{"testdata/book/**/*", "nonexistent", "", "", 0},
 		{"testdata/book/**/*", "", "eb33c9aed04a7f1e03c1a1246b5d7bdaefd903d3", "", 1},
 		{"testdata/book/**/*", "", "eb33c9a", "", 1},
-		{"testdata/book/**/*", "", "", "http", 12},
-		{"testdata/book/**/*", "", "", "openapi3", 8},
-		{"testdata/book/**/*", "", "", "http,openapi3", 12},
-		{"testdata/book/**/*", "", "", "http and openapi3", 8},
+		{"testdata/book/**/*", "", "", "http", 13},
+		{"testdata/book/**/*", "", "", "openapi3", 9},
+		{"testdata/book/**/*", "", "", "http,openapi3", 13},
+		{"testdata/book/**/*", "", "", "http and openapi3", 9},
 		{"testdata/book/**/*", "", "", "http and nothing", 0},
-		{"testdata/book/**/*", "", "", "http or nothing", 12},
+		{"testdata/book/**/*", "", "", "http or nothing", 13},
 		{"testdata/book/**/*", "", "", "http and not openapi3", 4},
 		{"testdata/book/needs_3.yml", "", "", "", 1}, // Runbooks that are only in the needs section are not counted at Load
 	}

--- a/operator_test.go
+++ b/operator_test.go
@@ -980,6 +980,7 @@ func TestHttp(t *testing.T) {
 		{"testdata/book/http.yml"},
 		{"testdata/book/http_not_follow_redirect.yml"},
 		{"testdata/book/http_with_json.yml"},
+		{"testdata/book/http_circular_refs.yml"},
 	}
 	ctx := context.Background()
 	for _, tt := range tests {

--- a/option.go
+++ b/option.go
@@ -203,6 +203,17 @@ func Runner(name, dsn string, opts ...httpRunnerOption) Option {
 		}
 		// HTTP Runner
 		c := &httpRunnerConfig{}
+		// Set SkipCircularReferenceCheck first
+		for _, opt := range opts {
+			tmp := &httpRunnerConfig{}
+			_ = opt(tmp)
+			if tmp.SkipCircularReferenceCheck {
+				if err := opt(c); err != nil {
+					bk.runnerErrs[name] = err
+				}
+				break
+			}
+		}
 		for _, opt := range opts {
 			if err := opt(c); err != nil {
 				bk.runnerErrs[name] = err
@@ -258,6 +269,17 @@ func HTTPRunner(name, endpoint string, client *http.Client, opts ...httpRunnerOp
 			return nil
 		}
 		c := &httpRunnerConfig{}
+		// Set SkipCircularReferenceCheck first
+		for _, opt := range opts {
+			tmp := &httpRunnerConfig{}
+			_ = opt(tmp)
+			if tmp.SkipCircularReferenceCheck {
+				if err := opt(c); err != nil {
+					bk.runnerErrs[name] = err
+				}
+				break
+			}
+		}
 		for _, opt := range opts {
 			if err := opt(c); err != nil {
 				bk.runnerErrs[name] = err
@@ -328,6 +350,17 @@ func HTTPRunnerWithHandler(name string, h http.Handler, opts ...httpRunnerOption
 		}
 		if len(opts) > 0 {
 			c := &httpRunnerConfig{}
+			// Set SkipCircularReferenceCheck first
+			for _, opt := range opts {
+				tmp := &httpRunnerConfig{}
+				_ = opt(tmp)
+				if tmp.SkipCircularReferenceCheck {
+					if err := opt(c); err != nil {
+						bk.runnerErrs[name] = err
+					}
+					break
+				}
+			}
 			for _, opt := range opts {
 				if err := opt(c); err != nil {
 					bk.runnerErrs[name] = err

--- a/testdata/book/http_circular_refs.yml
+++ b/testdata/book/http_circular_refs.yml
@@ -1,0 +1,18 @@
+desc: Test with circular references
+labels:
+  - http
+  - openapi3
+runners:
+  req:
+    endpoint: ${TEST_HTTP_ENDPOINT:-https:example.com}
+    openapi3: ../openapi3-circular-references.yml
+    skipCircularReferenceCheck: true
+    skipValidateResponse: true
+steps:
+  TestHello:
+    req:
+      /circular/hello:
+        get:
+          body: null
+    test: |
+      current.res.status == 200

--- a/testdata/openapi3-circular-references.yml
+++ b/testdata/openapi3-circular-references.yml
@@ -1,0 +1,40 @@
+openapi: 3.1.0
+info:
+  title: Circular References
+  version: 1.0.0
+paths:
+  /circular/hello:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Response"
+          description: Debugging
+components:
+  schemas:
+    Response:
+      type: object
+      properties:
+        rows:
+          type: array
+          items:
+            $ref: "#/components/schemas/Row"
+      required:
+        - rows
+    Row:
+      type: object
+      properties:
+        name:
+          description: Name of the row
+          type: string
+        rows:
+          description: A collection of row
+          type: array
+          items:
+            $ref: "#/components/schemas/Row"
+      required:
+        - name
+        - rows
+        

--- a/testutil/http.go
+++ b/testutil/http.go
@@ -128,5 +128,6 @@ func setRoutes(r *httpstub.Router) {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"url": "http://localhost:8080/ping", "single_escaped": "http:\/\/localhost:8080\/ping"}`))
 		})
+	r.Method(http.MethodGet).Path("/circular/hello").Header("Content-Type", "application/json").ResponseString(http.StatusOK, `{"rows":[]}`)
 	r.Method(http.MethodGet).Header("Content-Type", "text/html; charset=utf-8").ResponseString(http.StatusNotFound, "<h1>Not Found</h1>")
 }


### PR DESCRIPTION


Fix https://github.com/k1LoW/runn/issues/1026