### PR TITLE
Update signature of compare/diff built-in functions step by step

### DIFF
--- a/book.go
+++ b/book.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/goccy/go-json"
-	"github.com/k1LoW/duration"
 	"github.com/goccy/go-yaml"
+	"github.com/k1LoW/duration"
 	"github.com/k1LoW/sshc/v4"
 )
 

--- a/builtin/compare.go
+++ b/builtin/compare.go
@@ -1,7 +1,7 @@
 package builtin
 
-func Compare(x, y any, ignorePaths ...string) (bool, error) {
-	d, err := Diff(x, y, ignorePaths...)
+func Compare(x, y any, ignores ...any) (bool, error) {
+	d, err := Diff(x, y, ignores...)
 	if err != nil {
 		return false, err
 	}

--- a/builtin/compare_test.go
+++ b/builtin/compare_test.go
@@ -90,7 +90,7 @@ func TestCompareWithIgnorePathOrKeys(t *testing.T) {
 	}
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("Case %d", i), func(t *testing.T) {
-			got, err := Compare(tt.x, tt.y, tt.ignorePathOrKeys...)
+			got, err := Compare(tt.x, tt.y, tt.ignorePathOrKeys)
 			if err != nil {
 				t.Error(err)
 			}

--- a/builtin/diff.go
+++ b/builtin/diff.go
@@ -26,6 +26,10 @@ func Diff(x, y any, ignores ...any) (string, error) {
 				}
 				ignoreSpecifiers = append(ignoreSpecifiers, s)
 			}
+		case []string:
+			for _, s := range v {
+				ignoreSpecifiers = append(ignoreSpecifiers, s)
+			}
 		default:
 			return "", fmt.Errorf("invalid ignore specifiers: %v", i)
 		}

--- a/builtin/diff.go
+++ b/builtin/diff.go
@@ -10,13 +10,18 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/itchyny/gojq"
+	"github.com/k1LoW/runn/internal/deprecation"
 )
 
 func Diff(x, y any, ignores ...any) (string, error) {
 	var ignoreSpecifiers []string
+	if len(ignores) > 1 {
+		deprecation.AddWarning("diff/compare", "diff/compare(x, y, ignores...string) is deprecated. Use diff/compare(x, y, ignores []string) instead.")
+	}
 	for _, i := range ignores {
 		switch v := i.(type) {
 		case string:
+			deprecation.AddWarning("diff/compare", "diff/compare(x, y, ignores...string) is deprecated. Use diff/compare(x, y, ignores []string) instead.")
 			ignoreSpecifiers = append(ignoreSpecifiers, v)
 		case []any:
 			for _, vv := range v {

--- a/builtin/diff_test.go
+++ b/builtin/diff_test.go
@@ -164,7 +164,7 @@ func TestDiffWithIgnorePathOrKeys(t *testing.T) {
 	}
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("Case %d", i), func(t *testing.T) {
-			got, err := Diff(tt.x, tt.y, tt.ignorePathOrKeys...)
+			got, err := Diff(tt.x, tt.y, tt.ignorePathOrKeys)
 			if err != nil {
 				t.Error(err)
 			}

--- a/eval.go
+++ b/eval.go
@@ -14,6 +14,7 @@ import (
 	"github.com/k1LoW/expand"
 	"github.com/k1LoW/runn/builtin"
 	"github.com/k1LoW/runn/exprtrace"
+	"github.com/k1LoW/runn/internal/deprecation"
 	"github.com/xlab/treeprint"
 )
 
@@ -205,7 +206,7 @@ func trimDeprecatedComment(cond string) string {
 	}
 
 	// Deprecated comment token
-	deprecationWarnings.Store("Sharp comment", "`#` comment is deprecated. Use `//` instead.")
+	deprecation.AddWarning("Sharp comment", "`#` comment is deprecated. Use `//` instead.")
 
 	var trimed []string
 	for _, l := range strings.Split(cond, "\n") {

--- a/eval.go
+++ b/eval.go
@@ -262,7 +262,7 @@ func onPrintTraceCallNode(tp exprtrace.TreePrinter, tree treeprint.Tree, callNod
 			}
 		}
 
-		diff, _ := builtin.Diff(a, b, ignoreKeys...) //nostyle:handlerror
+		diff, _ := builtin.Diff(a, b, ignoreKeys) //nostyle:handlerror
 
 		// Normalize NBSP to SPACE
 		diff = strings.Map(func(r rune) rune {

--- a/internal/deprecation/warning.go
+++ b/internal/deprecation/warning.go
@@ -1,4 +1,4 @@
-package runn
+package deprecation
 
 import (
 	"fmt"
@@ -9,21 +9,27 @@ import (
 	"github.com/mattn/go-colorable"
 )
 
-var deprecationWarnings sync.Map
+var warnings sync.Map
 
-func printDeprecationWarnings() {
+// AddWarning adds a deprecation warning message for a key.
+func AddWarning(key, message string) {
+	warnings.Store(key, message)
+}
+
+// PrintWarnings prints all deprecation warnings.
+func PrintWarnings() {
 	if os.Getenv("RUNN_DISABLE_DEPRECATION_WARNING") != "" {
 		return
 	}
 	first := true
 	if os.Getenv("GTIHUB_ACTIONS") != "" {
-		deprecationWarnings.Range(func(key, value any) bool {
+		warnings.Range(func(key, value any) bool {
 			if first {
 				fmt.Println()
 				first = false
 			}
 			fmt.Printf("::warning title=runn deprecation warning::%s\n", value)
-			deprecationWarnings.Delete(key)
+			warnings.Delete(key)
 			return true
 		})
 		return
@@ -31,13 +37,13 @@ func printDeprecationWarnings() {
 
 	warningf := color.New(color.FgYellow).FprintfFunc()
 	stderr := colorable.NewColorableStderr()
-	deprecationWarnings.Range(func(key, value any) bool {
+	warnings.Range(func(key, value any) bool {
 		if first {
 			fmt.Println()
 			first = false
 		}
 		warningf(stderr, "Deprecation warning: %s\n", value)
-		deprecationWarnings.Delete(key)
+		warnings.Delete(key)
 		return true
 	})
 }

--- a/operator.go
+++ b/operator.go
@@ -21,6 +21,7 @@ import (
 	"github.com/k1LoW/concgroup"
 	"github.com/k1LoW/donegroup"
 	"github.com/k1LoW/runn/exprtrace"
+	"github.com/k1LoW/runn/internal/deprecation"
 	"github.com/k1LoW/stopw"
 	"github.com/k1LoW/waitmap"
 	"github.com/ryo-yamaoka/otchkiss"
@@ -119,7 +120,7 @@ func (op *operator) NumberOfSteps() int {
 // Store returns stored values.
 // Deprecated: Use Result().Store() instead.
 func (op *operator) Store() map[string]any {
-	deprecationWarnings.Store("operator.Store", "Use Result().Store() instead.")
+	deprecation.AddWarning("operator.Store", "Use Result().Store() instead.")
 	return op.Result().Store()
 }
 
@@ -876,7 +877,7 @@ func (op *operator) appendStep(idx int, key string, s map[string]any) error {
 
 // Run runbook.
 func (op *operator) Run(ctx context.Context) (err error) {
-	defer printDeprecationWarnings()
+	defer deprecation.PrintWarnings()
 	cctx, cancel := donegroup.WithCancel(ctx)
 	defer func() {
 		cancel()
@@ -1500,7 +1501,7 @@ func Load(pathp string, opts ...Option) (*operatorN, error) {
 }
 
 func (opn *operatorN) RunN(ctx context.Context) (err error) {
-	defer printDeprecationWarnings()
+	defer deprecation.PrintWarnings()
 	cctx, cancel := donegroup.WithCancel(ctx)
 	defer func() {
 		cancel()

--- a/option_test.go
+++ b/option_test.go
@@ -1044,6 +1044,7 @@ func TestBuiltinFunctionBooks(t *testing.T) {
 		{"testdata/book/builtin_pick.yml", false},
 		{"testdata/book/builtin_omit.yml", false},
 		{"testdata/book/builtin_merge.yml", false},
+		{"testdata/book/builtin_compare.yml", false},
 	}
 	ctx := context.Background()
 	for _, tt := range tests {

--- a/parse.go
+++ b/parse.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/k1LoW/duration"
 	"github.com/goccy/go-yaml"
+	"github.com/k1LoW/duration"
 	"google.golang.org/grpc/metadata"
 )
 

--- a/runner_option.go
+++ b/runner_option.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/goccy/go-yaml"
+	"github.com/k1LoW/runn/internal/deprecation"
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi/datamodel"
 )
@@ -110,7 +111,7 @@ func (c *sshRunnerConfig) validate() error {
 // OpenApi3 sets OpenAPI Document using file path.
 // Deprecated: Use OpenAPI3 instead.
 func OpenApi3(l string) httpRunnerOption {
-	deprecationWarnings.Store("OpenApi3", "runn.OpenApi3 is deprecated. Use runn.OpenAPI3 instead.")
+	deprecation.AddWarning("OpenApi3", "runn.OpenApi3 is deprecated. Use runn.OpenAPI3 instead.")
 	return OpenAPI3(l)
 }
 
@@ -125,7 +126,7 @@ func OpenAPI3(l string) httpRunnerOption {
 // OpenApi3FromData sets OpenAPI Document from data.
 // Deprecated: Use OpenAPI3FromData instead.
 func OpenApi3FromData(d []byte) httpRunnerOption {
-	deprecationWarnings.Store("OpenApi3FromData", "runn.OpenApi3FromData is deprecated. Use runn.OpenAPI3FromData instead.")
+	deprecation.AddWarning("OpenApi3FromData", "runn.OpenApi3FromData is deprecated. Use runn.OpenAPI3FromData instead.")
 	return OpenAPI3FromData(d)
 }
 

--- a/testdata/book/builtin_compare.yml
+++ b/testdata/book/builtin_compare.yml
@@ -1,0 +1,16 @@
+desc: For compare() built-in function
+steps:
+  merge:
+    test: |
+      compare(
+        {"a": 1, "b": 3, "c": 5},
+        {"a": 1, "b": 2, "c": 4},
+        "b", "c"
+      )
+  merge2:
+    test: |
+      compare(
+        {"a": 1, "b": 3, "c": 5},
+        {"a": 1, "b": 2, "c": 4},
+        ["b", "c"]
+      )


### PR DESCRIPTION
ref: https://github.com/k1LoW/runn/issues/1047

Because variadic arguments like Go cannot be used in expr-lang.

While accepting both arguments, deprecate the variadic argument type.