### PR TITLE
Implement `secrets:` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,17 @@ vars:
 
 In the example, each variable can be used in `{{ vars.username }}` or `{{ vars.token }}` in `steps:`.
 
+### `secrets:`
+
+List of secret var names to be masked.
+
+``` yaml
+secrets:
+  - vars.secret_token
+  - binded_password
+  - current.res.message.token
+```
+
 ### `debug:`
 
 Enable debug output for runn.
@@ -1673,7 +1684,8 @@ or
   dump:
     expr: steps[4].rows
     out: path/to/dump.out
-    disableTrailingNewline: true
+    disableTrailingNewline: true # disable trailing newline. default is false
+    disableMaskingSecrets: true  # disable masking secrets. default is false
 ```
 
 The `dump` runner can run in the same steps as the other runners.

--- a/book.go
+++ b/book.go
@@ -591,6 +591,7 @@ func (bk *book) merge(loaded *book) error {
 	for k, v := range loaded.vars {
 		bk.vars[k] = v
 	}
+	bk.secrets = append(bk.secrets, loaded.secrets...)
 	bk.runnerErrs = loaded.runnerErrs
 	bk.rawSteps = loaded.rawSteps
 	bk.hostRules = loaded.hostRules

--- a/dump.go
+++ b/dump.go
@@ -54,9 +54,11 @@ func (rnr *dumpRunner) Run(ctx context.Context, s *step, first bool) error {
 			if err != nil {
 				return err
 			}
-			donegroup.Cleanup(ctx, func() error {
+			if err := donegroup.Cleanup(ctx, func() error {
 				return f.Close()
-			})
+			}); err != nil {
+				return err
+			}
 			out = o.maskRule.NewWriter(f)
 		default:
 			return fmt.Errorf("invalid dump out: %v", pp)

--- a/dump.go
+++ b/dump.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 
 	"github.com/goccy/go-json"
+	"github.com/k1LoW/donegroup"
 )
 
 const dumpRunnerKey = "dump"
@@ -53,7 +54,10 @@ func (rnr *dumpRunner) Run(ctx context.Context, s *step, first bool) error {
 			if err != nil {
 				return err
 			}
-			out = f
+			donegroup.Cleanup(ctx, func() error {
+				return f.Close()
+			})
+			out = o.maskRule.NewWriter(f)
 		default:
 			return fmt.Errorf("invalid dump out: %v", pp)
 		}

--- a/dump_test.go
+++ b/dump_test.go
@@ -512,6 +512,30 @@ func TestDumpRunnerRunWithSecrets(t *testing.T) {
 			`value
 `,
 		},
+		{
+			store{
+				steps: []map[string]any{},
+				stepMap: map[string]map[string]any{
+					"stepkey": {"key": "value"},
+				},
+				vars:        map[string]any{},
+				useMap:      true,
+				stepMapKeys: []string{"stepkey", "stepnext"},
+			},
+			"steps",
+			[]*step{
+				{key: "stepkey"},
+				{key: "stepnext"},
+			},
+			[]string{"current.key"},
+			false,
+			`{
+  "stepkey": {
+    "key": "*****"
+  }
+}
+`,
+		},
 	}
 
 	for i, tt := range tests {

--- a/dump_test.go
+++ b/dump_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/k1LoW/donegroup"
 	"github.com/k1LoW/maskedio"
 )
 
@@ -140,9 +141,10 @@ func TestDumpRunnerRun(t *testing.T) {
 			`hello`,
 		},
 	}
-	ctx := context.Background()
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("%d.%s", i, tt.expr), func(t *testing.T) {
+			ctx, cancel := donegroup.WithCancel(context.Background())
+			t.Cleanup(cancel)
 			o, err := New()
 			if err != nil {
 				t.Fatal(err)
@@ -298,9 +300,11 @@ func TestDumpRunnerRunWithOut(t *testing.T) {
 			`hello`,
 		},
 	}
-	ctx := context.Background()
+
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("%d.%s with out", i, tt.expr), func(t *testing.T) {
+			ctx, cancel := donegroup.WithCancel(context.Background())
+			t.Cleanup(cancel)
 			p := filepath.Join(t.TempDir(), "tmp")
 			o, err := New()
 			if err != nil {
@@ -385,9 +389,11 @@ func TestDumpRunnerRunWithExpandOut(t *testing.T) {
 			filepath.Join(tmp, "value3.ext"),
 		},
 	}
-	ctx := context.Background()
+
 	for _, tt := range tests {
 		t.Run(tt.out, func(t *testing.T) {
+			ctx, cancel := donegroup.WithCancel(context.Background())
+			t.Cleanup(cancel)
 			o, err := New()
 			if err != nil {
 				t.Fatal(err)
@@ -493,9 +499,11 @@ func TestDumpRunnerRunWithSecrets(t *testing.T) {
 `,
 		},
 	}
-	ctx := context.Background()
+
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("%d.%s", i, tt.expr), func(t *testing.T) {
+			ctx, cancel := donegroup.WithCancel(context.Background())
+			t.Cleanup(cancel)
 			buf := new(bytes.Buffer)
 			o, err := New(Stdout(buf))
 			if err != nil {

--- a/exec.go
+++ b/exec.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/cli/safeexec"
@@ -84,8 +83,8 @@ func (rnr *execRunner) run(ctx context.Context, c *execCommand, s *step) error {
 		o.capturers.captureExecStdin(c.stdin)
 	}
 	if c.liveOutput {
-		cmd.Stdout = io.MultiWriter(stdout, os.Stdout)
-		cmd.Stderr = io.MultiWriter(stderr, os.Stderr)
+		cmd.Stdout = io.MultiWriter(stdout, o.maskRule.NewWriter(o.stdout))
+		cmd.Stderr = io.MultiWriter(stderr, o.maskRule.NewWriter(o.stderr))
 	} else {
 		cmd.Stdout = stdout
 		cmd.Stderr = stderr

--- a/exec_test.go
+++ b/exec_test.go
@@ -1,6 +1,7 @@
 package runn
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strings"
@@ -103,6 +104,94 @@ func TestExecShell(t *testing.T) {
 			}
 			if !strings.HasPrefix(got, want) {
 				t.Errorf("got %s, want %s", got, want)
+			}
+		})
+	}
+}
+
+func TestExecRunWithSecrets(t *testing.T) {
+	if err := setScopes(ScopeAllowRunExec); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := setScopes(ScopeDenyRunExec); err != nil {
+			t.Fatal(err)
+		}
+	})
+	tests := []struct {
+		vars       map[string]any
+		secrets    []string
+		command    string
+		liveOutput bool
+		want       map[string]any
+		wantStdout string
+		wantStderr string
+	}{
+		{
+			map[string]any{"message": "hello"},
+			[]string{"vars.message"},
+			"echo hello!!",
+			false,
+			map[string]any{
+				"stdout":    "hello!!\n",
+				"stderr":    "",
+				"exit_code": 0,
+			},
+			"",
+			"",
+		},
+		{
+			map[string]any{"message": "hello"},
+			[]string{"vars.message"},
+			"echo hello!!",
+			true,
+			map[string]any{
+				"stdout":    "hello!!\n",
+				"stderr":    "",
+				"exit_code": 0,
+			},
+			"*****!!\n",
+			"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.command, func(t *testing.T) {
+			ctx, cancel := donegroup.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			stdout := new(bytes.Buffer)
+			stderr := new(bytes.Buffer)
+			opts := []Option{
+				Stdout(stdout),
+				Stderr(stderr),
+				Secret(tt.secrets...),
+			}
+			for k, v := range tt.vars {
+				opts = append(opts, Var(k, v))
+			}
+
+			o, err := New(opts...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			r := newExecRunner()
+			s := newStep(0, "stepKey", o, nil)
+			c := &execCommand{command: tt.command, liveOutput: tt.liveOutput}
+			if err := r.run(ctx, c, s); err != nil {
+				t.Error(err)
+				return
+			}
+			got := o.store.steps[0]
+			if diff := cmp.Diff(got, tt.want, nil); diff != "" {
+				t.Error(diff)
+			}
+
+			gotStdout := stdout.String()
+			if gotStdout != tt.wantStdout {
+				t.Errorf("got %s, want %s", gotStdout, tt.wantStdout)
+			}
+			gotStderr := stderr.String()
+			if gotStderr != tt.wantStderr {
+				t.Errorf("got %s, want %s", gotStderr, tt.wantStderr)
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/k1LoW/grpcstub v0.24.1
 	github.com/k1LoW/grpcurlreq v0.2.1
 	github.com/k1LoW/httpstub v0.17.0
-	github.com/k1LoW/maskedio v0.4.0
+	github.com/k1LoW/maskedio v0.4.2
 	github.com/k1LoW/protoresolv v0.1.1
 	github.com/k1LoW/repin v0.3.4
 	github.com/k1LoW/sshc/v4 v4.2.0

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/k1LoW/grpcstub v0.24.1
 	github.com/k1LoW/grpcurlreq v0.2.1
 	github.com/k1LoW/httpstub v0.17.0
-	github.com/k1LoW/maskedio v0.3.0
+	github.com/k1LoW/maskedio v0.4.0
 	github.com/k1LoW/protoresolv v0.1.1
 	github.com/k1LoW/repin v0.3.4
 	github.com/k1LoW/sshc/v4 v4.2.0

--- a/go.sum
+++ b/go.sum
@@ -1028,8 +1028,8 @@ github.com/k1LoW/grpcurlreq v0.2.1 h1:vV5XPcudceX5+DvnEvyDY11E/MkJ01RmYoHO3/8aNj
 github.com/k1LoW/grpcurlreq v0.2.1/go.mod h1:fYHtOo6/5ans9ub1CDRIQQfvo4NyTGwPud+FH/Rnx90=
 github.com/k1LoW/httpstub v0.17.0 h1:VOeyfSriYbHQL1wGk9sfqa8TDpP6Zti/MPT3xcYDtF0=
 github.com/k1LoW/httpstub v0.17.0/go.mod h1:r9Cu3m/G+ILM8jjPebA/P4dXbIH8s8jnPVrhFETAFYA=
-github.com/k1LoW/maskedio v0.4.0 h1:YmPBXo+NOOzucZx8K4k1i63YUz7nwbG1Hya8PUQnRiA=
-github.com/k1LoW/maskedio v0.4.0/go.mod h1:ugf3OzV7imakceGtmkOY13oJsDynL2YVXRcn9VUZEiE=
+github.com/k1LoW/maskedio v0.4.2 h1:8s1qIWEJHvi8oEXq7fl72SabWTDK634OcxhGlEnv/GY=
+github.com/k1LoW/maskedio v0.4.2/go.mod h1:ugf3OzV7imakceGtmkOY13oJsDynL2YVXRcn9VUZEiE=
 github.com/k1LoW/protoresolv v0.1.1 h1:3Q5Sl4bOGyXy9etMZJraF60XqPQBqodFMfGoqBEBwYE=
 github.com/k1LoW/protoresolv v0.1.1/go.mod h1:eVklYuDOPjSNzmbHZiNmXwmXX4OHqscY0MduCGQbSK0=
 github.com/k1LoW/repin v0.3.4 h1:xcNuBBc/ISHUNBzjXNTCux4OYZND5ZMiyz4SrRtpDhg=

--- a/go.sum
+++ b/go.sum
@@ -1028,8 +1028,8 @@ github.com/k1LoW/grpcurlreq v0.2.1 h1:vV5XPcudceX5+DvnEvyDY11E/MkJ01RmYoHO3/8aNj
 github.com/k1LoW/grpcurlreq v0.2.1/go.mod h1:fYHtOo6/5ans9ub1CDRIQQfvo4NyTGwPud+FH/Rnx90=
 github.com/k1LoW/httpstub v0.17.0 h1:VOeyfSriYbHQL1wGk9sfqa8TDpP6Zti/MPT3xcYDtF0=
 github.com/k1LoW/httpstub v0.17.0/go.mod h1:r9Cu3m/G+ILM8jjPebA/P4dXbIH8s8jnPVrhFETAFYA=
-github.com/k1LoW/maskedio v0.3.0 h1:MTtPgMC47v+VhX2i8c/XLMtAlH7E5RFC+oSjh8f22cA=
-github.com/k1LoW/maskedio v0.3.0/go.mod h1:ugf3OzV7imakceGtmkOY13oJsDynL2YVXRcn9VUZEiE=
+github.com/k1LoW/maskedio v0.4.0 h1:YmPBXo+NOOzucZx8K4k1i63YUz7nwbG1Hya8PUQnRiA=
+github.com/k1LoW/maskedio v0.4.0/go.mod h1:ugf3OzV7imakceGtmkOY13oJsDynL2YVXRcn9VUZEiE=
 github.com/k1LoW/protoresolv v0.1.1 h1:3Q5Sl4bOGyXy9etMZJraF60XqPQBqodFMfGoqBEBwYE=
 github.com/k1LoW/protoresolv v0.1.1/go.mod h1:eVklYuDOPjSNzmbHZiNmXwmXX4OHqscY0MduCGQbSK0=
 github.com/k1LoW/repin v0.3.4 h1:xcNuBBc/ISHUNBzjXNTCux4OYZND5ZMiyz4SrRtpDhg=

--- a/operator.go
+++ b/operator.go
@@ -72,8 +72,8 @@ type operator struct {
 	ifCond          string
 	skipTest        bool
 	skipped         bool
-	stdout          io.Writer
-	stderr          io.Writer
+	stdout          *maskedio.Writer
+	stderr          *maskedio.Writer
 	newOnly         bool // Skip some errors for `runn list`
 	bookPath        string
 	numberOfSteps   int // Number of steps for `runn list`
@@ -457,8 +457,8 @@ func New(opts ...Option) (*operator, error) {
 		included:       bk.included,
 		ifCond:         bk.ifCond,
 		skipTest:       bk.skipTest,
-		stdout:         bk.stdout,
-		stderr:         bk.stderr,
+		stdout:         st.maskRule().NewWriter(bk.stdout),
+		stderr:         st.maskRule().NewWriter(bk.stderr),
 		newOnly:        bk.loadOnly,
 		bookPath:       bk.path,
 		beforeFuncs:    bk.beforeFuncs,

--- a/operator.go
+++ b/operator.go
@@ -722,10 +722,15 @@ func (op *operator) appendStep(idx int, key string, s map[string]any) error {
 			if !ok {
 				disableNL = false
 			}
+			disableMask, ok := vv["disableMaskingSecrets"]
+			if !ok {
+				disableMask = false
+			}
 			step.dumpRequest = &dumpRequest{
 				expr:                   cast.ToString(expr),
 				out:                    cast.ToString(out),
 				disableTrailingNewline: cast.ToBool(disableNL),
+				disableMaskingSecrets:  cast.ToBool(disableMask),
 			}
 		default:
 			return fmt.Errorf("invalid dump request: %v", vv)

--- a/operator_test.go
+++ b/operator_test.go
@@ -970,7 +970,7 @@ func TestShard(t *testing.T) {
 				cmp.AllowUnexported(allow...),
 				cmpopts.IgnoreUnexported(ignore...),
 				cmpopts.IgnoreFields(stopw.Span{}, "ID"),
-				cmpopts.IgnoreFields(operator{}, "id", "concurrency", "mu", "dbg", "needs", "nm", "maskRule"),
+				cmpopts.IgnoreFields(operator{}, "id", "concurrency", "mu", "dbg", "needs", "nm", "maskRule", "stdout", "stderr"),
 				cmpopts.IgnoreFields(cdpRunner{}, "ctx", "cancel", "opts", "mu", "operatorID"),
 				cmpopts.IgnoreFields(sshRunner{}, "client", "sess", "stdin", "stdout", "stderr", "operatorID"),
 				cmpopts.IgnoreFields(grpcRunner{}, "mu", "operatorID"),

--- a/option.go
+++ b/option.go
@@ -699,6 +699,25 @@ func Var(k any, v any) Option {
 	}
 }
 
+// Secret - Set secret var names to be masked.
+func Secret(secrets ...string) Option {
+	return func(bk *book) error {
+		if bk == nil {
+			return ErrNilBook
+		}
+		for _, secret := range secrets {
+			if strings.HasPrefix(secret, storeRootKeyCurrent+".") {
+				return fmt.Errorf("secrets: does not support 'current.': %s", secret)
+			}
+			if strings.HasPrefix(secret, storeRootKeyPrevious+".") {
+				return fmt.Errorf("secrets: does not support 'previous.': %s", secret)
+			}
+		}
+		bk.secrets = append(bk.secrets, secrets...)
+		return nil
+	}
+}
+
 // Func - Set function to runner.
 func Func(k string, v any) Option {
 	return func(bk *book) error {

--- a/option.go
+++ b/option.go
@@ -706,9 +706,6 @@ func Secret(secrets ...string) Option {
 			return ErrNilBook
 		}
 		for _, secret := range secrets {
-			if strings.HasPrefix(secret, storeRootKeyCurrent+".") {
-				return fmt.Errorf("secrets: does not support 'current.': %s", secret)
-			}
 			if strings.HasPrefix(secret, storeRootKeyPrevious+".") {
 				return fmt.Errorf("secrets: does not support 'previous.': %s", secret)
 			}

--- a/store.go
+++ b/store.go
@@ -356,6 +356,11 @@ func (s *store) toMapForDbg() map[string]any {
 }
 
 func (s *store) setMaskKeywords(store map[string]any) {
+	store[storeRootKeyCurrent] = s.latest()
+	defer func() {
+		delete(store, storeRootKeyCurrent)
+	}()
+
 	for _, key := range s.secrets {
 		v, err := Eval(key, store)
 		if err != nil {

--- a/testdata/book/with_secrets.yml
+++ b/testdata/book/with_secrets.yml
@@ -1,0 +1,19 @@
+desc: With secrets
+debug: true
+vars:
+  message: hello
+secrets:
+  - vars.message
+steps:
+  -
+    desc: 'Print "hello world!!"'
+    exec:
+      command: echo hello world!!
+  -
+    desc: 'Print "hello world!!" again'
+    exec:
+      command: cat
+      stdin: '{{ steps[0].stdout }}'
+  -
+    desc: 'Check result of previous command contains "hello"'
+    test: 'steps[1].stdout contains "hello"'

--- a/testdata/with_secrets.yml.debugger.golden
+++ b/testdata/with_secrets.yml.debugger.golden
@@ -1,0 +1,30 @@
+Run "Print \"***** world!!\"" on "With secrets".steps[0]
+-----START COMMAND-----
+echo ***** world!!
+-----END COMMAND-----
+-----START STDOUT-----
+***** world!!
+
+-----END STDOUT-----
+-----START STDERR-----
+
+-----END STDERR-----
+
+Run "Print \"***** world!!\" again" on "With secrets".steps[1]
+-----START COMMAND-----
+cat
+-----END COMMAND-----
+-----START STDIN-----
+***** world!!
+
+-----END STDIN-----
+-----START STDOUT-----
+***** world!!
+
+-----END STDOUT-----
+-----START STDERR-----
+
+-----END STDERR-----
+
+Run "Check result of previous command contains \"*****\"" on "With secrets".steps[2]
+Run "test" on "With secrets".steps[2]


### PR DESCRIPTION
ref: #986 

By listing the names of variables stored in the secrets section, you can mask all the values of those variables in the output.

```console
$ cat testdata/book/with_secrets.yml
desc: With secrets
debug: true
vars:
  message: hello
secrets:
  - vars.message
steps:
  -
    desc: 'Print "hello world!!"'
    exec:
      command: echo hello world!!
  -
    desc: 'Print "hello world!!" again'
    exec:
      command: cat
      stdin: '{{ steps[0].stdout }}'
  -
    desc: 'Check result of previous command contains "hello"'
    test: 'steps[1].stdout contains "hello"'
$ go run cmd/runn/main.go run testdata/book/with_secrets.yml --scopes run:exec
Run "Print \"***** world!!\"" on "With secrets".steps[0]
-----START COMMAND-----
echo ***** world!!
-----END COMMAND-----
-----START STDOUT-----
***** world!!

-----END STDOUT-----
-----START STDERR-----

-----END STDERR-----

Run "Print \"***** world!!\" again" on "With secrets".steps[1]
-----START COMMAND-----
cat
-----END COMMAND-----
-----START STDIN-----
***** world!!

-----END STDIN-----
-----START STDOUT-----
***** world!!

-----END STDOUT-----
-----START STDERR-----

-----END STDERR-----

Run "Check result of previous command contains \"*****\"" on "With secrets".steps[2]
Run "test" on "With secrets".steps[2]
.

1 scenario, 0 skipped, 0 failures
$
```

## Decision

- Should we mask explicit output by the Dump runner?
    - Dump Runner output may be used to link with other tools via pipes.
    - **Add option to explicitly disable masking**