### PR TITLE
Allow absolute paths and enhance scopes detection

### DIFF
--- a/book.go
+++ b/book.go
@@ -648,14 +648,6 @@ func detectSSHRunner(v any) bool {
 	return false
 }
 
-// fp returns the absolute path of root+p.
-func fp(p, root string) string {
-	if filepath.IsAbs(p) {
-		return p
-	}
-	return filepath.Join(root, p)
-}
-
 func newBook() *book {
 	return &book{
 		runners:        map[string]any{},

--- a/book.go
+++ b/book.go
@@ -447,10 +447,7 @@ func (bk *book) parseSSHRunnerWithDetailed(name string, b []byte) (bool, error) 
 	}
 	var opts []sshc.Option
 	if c.SSHConfig != "" {
-		p := c.SSHConfig
-		if !filepath.IsAbs(c.SSHConfig) {
-			p = filepath.Join(root, c.SSHConfig)
-		}
+		p := fp(c.SSHConfig, root)
 		if _, err := os.Stat(p); err != nil {
 			return false, err
 		}
@@ -466,10 +463,7 @@ func (bk *book) parseSSHRunnerWithDetailed(name string, b []byte) (bool, error) 
 		opts = append(opts, sshc.Port(c.Port))
 	}
 	if c.IdentityFile != "" {
-		p := c.IdentityFile
-		if !filepath.IsAbs(c.IdentityFile) {
-			p = filepath.Join(root, c.IdentityFile)
-		}
+		p := fp(c.IdentityFile, root)
 		b, err := readFile(p)
 		if err != nil {
 			return false, err

--- a/book.go
+++ b/book.go
@@ -300,24 +300,39 @@ func (bk *book) parseHTTPRunnerWithDetailed(name string, b []byte) (bool, error)
 	}
 	r.multipartBoundary = c.MultipartBoundary
 	if c.OpenAPI3DocLocation != "" && !strings.HasPrefix(c.OpenAPI3DocLocation, "https://") && !strings.HasPrefix(c.OpenAPI3DocLocation, "http://") && !strings.HasPrefix(c.OpenAPI3DocLocation, "/") {
-		c.OpenAPI3DocLocation = fp(c.OpenAPI3DocLocation, root)
+		c.OpenAPI3DocLocation, err = fp(c.OpenAPI3DocLocation, root)
+		if err != nil {
+			return false, err
+		}
 	}
 	if c.CACert != "" {
-		b, err := readFile(fp(c.CACert, root))
+		p, err := fp(c.CACert, root)
+		if err != nil {
+			return false, err
+		}
+		b, err := readFile(p)
 		if err != nil {
 			return false, err
 		}
 		r.cacert = b
 	}
 	if c.Cert != "" {
-		b, err := readFile(fp(c.Cert, root))
+		p, err := fp(c.Cert, root)
+		if err != nil {
+			return false, err
+		}
+		b, err := readFile(p)
 		if err != nil {
 			return false, err
 		}
 		r.cert = b
 	}
 	if c.Key != "" {
-		b, err := readFile(fp(c.Key, root))
+		p, err := fp(c.Key, root)
+		if err != nil {
+			return false, err
+		}
+		b, err := readFile(p)
 		if err != nil {
 			return false, err
 		}
@@ -361,7 +376,11 @@ func (bk *book) parseGRPCRunnerWithDetailed(name string, b []byte) (bool, error)
 	if len(c.cacert) != 0 {
 		r.cacert = c.cacert
 	} else if c.CACert != "" {
-		b, err := readFile(fp(c.CACert, root))
+		p, err := fp(c.CACert, root)
+		if err != nil {
+			return false, err
+		}
+		b, err := readFile(p)
 		if err != nil {
 			return false, err
 		}
@@ -370,7 +389,11 @@ func (bk *book) parseGRPCRunnerWithDetailed(name string, b []byte) (bool, error)
 	if len(c.cert) != 0 {
 		r.cert = c.cert
 	} else if c.Cert != "" {
-		b, err := readFile(fp(c.Cert, root))
+		p, err := fp(c.Cert, root)
+		if err != nil {
+			return false, err
+		}
+		b, err := readFile(p)
 		if err != nil {
 			return false, err
 		}
@@ -379,7 +402,11 @@ func (bk *book) parseGRPCRunnerWithDetailed(name string, b []byte) (bool, error)
 	if len(c.key) != 0 {
 		r.key = c.key
 	} else if c.Key != "" {
-		b, err := readFile(fp(c.Key, root))
+		p, err := fp(c.Key, root)
+		if err != nil {
+			return false, err
+		}
+		b, err := readFile(p)
 		if err != nil {
 			return false, err
 		}
@@ -387,19 +414,39 @@ func (bk *book) parseGRPCRunnerWithDetailed(name string, b []byte) (bool, error)
 	}
 	r.skipVerify = c.SkipVerify
 	for _, p := range c.ImportPaths {
-		r.importPaths = append(r.importPaths, fp(p, root))
+		pp, err := fp(p, root)
+		if err != nil {
+			return false, err
+		}
+		r.importPaths = append(r.importPaths, pp)
 	}
 	for _, p := range c.Protos {
-		r.protos = append(r.protos, fp(p, root))
+		pp, err := fp(p, root)
+		if err != nil {
+			return false, err
+		}
+		r.protos = append(r.protos, pp)
 	}
 	for _, p := range c.BufDirs {
-		r.bufDirs = append(r.bufDirs, fp(p, root))
+		pp, err := fp(p, root)
+		if err != nil {
+			return false, err
+		}
+		r.bufDirs = append(r.bufDirs, pp)
 	}
 	for _, p := range c.BufLocks {
-		r.bufLocks = append(r.bufLocks, fp(p, root))
+		pp, err := fp(p, root)
+		if err != nil {
+			return false, err
+		}
+		r.bufLocks = append(r.bufLocks, pp)
 	}
 	for _, p := range c.BufConfigs {
-		r.bufConfigs = append(r.bufConfigs, fp(p, root))
+		pp, err := fp(p, root)
+		if err != nil {
+			return false, err
+		}
+		r.bufConfigs = append(r.bufConfigs, pp)
 	}
 	r.bufModules = c.BufModules
 	r.trace = c.Trace.Enable
@@ -447,7 +494,10 @@ func (bk *book) parseSSHRunnerWithDetailed(name string, b []byte) (bool, error) 
 	}
 	var opts []sshc.Option
 	if c.SSHConfig != "" {
-		p := fp(c.SSHConfig, root)
+		p, err := fp(c.SSHConfig, root)
+		if err != nil {
+			return false, err
+		}
 		if _, err := os.Stat(p); err != nil {
 			return false, err
 		}
@@ -463,7 +513,10 @@ func (bk *book) parseSSHRunnerWithDetailed(name string, b []byte) (bool, error) 
 		opts = append(opts, sshc.Port(c.Port))
 	}
 	if c.IdentityFile != "" {
-		p := fp(c.IdentityFile, root)
+		p, err := fp(c.IdentityFile, root)
+		if err != nil {
+			return false, err
+		}
 		b, err := readFile(p)
 		if err != nil {
 			return false, err

--- a/cache.go
+++ b/cache.go
@@ -33,7 +33,7 @@ func RemoveCacheDir() error {
 	return os.RemoveAll(globalCacheDir)
 }
 
-func cacheDir() (string, error) {
+func cacheDirOrCreate() (string, error) {
 	if globalCacheDir != "" {
 		if _, err := os.Stat(globalCacheDir); err != nil {
 			if err := os.MkdirAll(globalCacheDir, os.ModePerm); err != nil {
@@ -48,4 +48,11 @@ func cacheDir() (string, error) {
 	}
 	globalCacheDir = dir
 	return dir, nil
+}
+
+func cacheDir() (string, error) {
+	if globalCacheDir != "" {
+		return globalCacheDir, nil
+	}
+	return "", fmt.Errorf("cache directory is not set")
 }

--- a/cdp.go
+++ b/cdp.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"reflect"
 	"sync"
 	"time"
@@ -222,9 +221,7 @@ func (rnr *cdpRunner) evalAction(ca CDPAction, s *step) ([]chromedp.Action, erro
 		if !ok {
 			return nil, fmt.Errorf("invalid action: %v", ca)
 		}
-		if !filepath.IsAbs(pp) {
-			ca.Args["path"] = filepath.Join(o.root, pp)
-		}
+		ca.Args["path"] = fp(pp, o.root)
 	}
 
 	fv := reflect.ValueOf(fn.Fn)

--- a/cdp.go
+++ b/cdp.go
@@ -221,7 +221,10 @@ func (rnr *cdpRunner) evalAction(ca CDPAction, s *step) ([]chromedp.Action, erro
 		if !ok {
 			return nil, fmt.Errorf("invalid action: %v", ca)
 		}
-		ca.Args["path"] = fp(pp, o.root)
+		ca.Args["path"], err = fp(pp, o.root)
+		if err != nil {
+			return nil, fmt.Errorf("invalid action: %v: %w", ca, err)
+		}
 	}
 
 	fv := reflect.ValueOf(fn.Fn)

--- a/coverage_test.go
+++ b/coverage_test.go
@@ -25,7 +25,7 @@ func TestCoverage(t *testing.T) {
 		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
 			t.Parallel()
-			o, err := New(Book(tt.book))
+			o, err := New(Book(tt.book), Scopes(ScopeAllowReadParent))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/debugger_test.go
+++ b/debugger_test.go
@@ -44,7 +44,7 @@ func TestDebugger(t *testing.T) {
 				DBRunner("db", db),
 				Capture(NewDebugger(out)),
 				Var("url", hs.URL),
-				Scopes(ScopeAllowRunExec),
+				Scopes(ScopeAllowRunExec, ScopeAllowReadParent),
 			}
 			o, err := New(opts...)
 			if err != nil {

--- a/hosts_test.go
+++ b/hosts_test.go
@@ -23,7 +23,7 @@ func TestHostRules(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.book, func(t *testing.T) {
 				tr.ClearRequests()
-				o, err := New(Book(tt.book))
+				o, err := New(Book(tt.book), Scopes(ScopeAllowReadParent))
 				if err != nil {
 					t.Fatal(err)
 					return

--- a/http.go
+++ b/http.go
@@ -160,7 +160,11 @@ func (r *httpRequest) encodeBody() (io.Reader, error) {
 			if !ok {
 				return nil, fmt.Errorf("invalid body: %v", r.body)
 			}
-			b, err := readFile(fp(fileName, r.root))
+			p, err := fp(fileName, r.root)
+			if err != nil {
+				return nil, err
+			}
+			b, err := readFile(p)
 			if err != nil {
 				return nil, err
 			}
@@ -253,7 +257,11 @@ func (r *httpRequest) encodeMultipart() (io.Reader, error) {
 			default:
 				return nil, fmt.Errorf("invalid body: %v", r.body)
 			}
-			b, err := readFile(fp(fileName, r.root))
+			p, err := fp(fileName, r.root)
+			if err != nil {
+				return nil, err
+			}
+			b, err := readFile(p)
 			patherr := &fs.PathError{}
 			if err != nil && !errors.Is(err, os.ErrNotExist) && !errors.As(err, &patherr) {
 				return nil, err

--- a/http.go
+++ b/http.go
@@ -160,7 +160,7 @@ func (r *httpRequest) encodeBody() (io.Reader, error) {
 			if !ok {
 				return nil, fmt.Errorf("invalid body: %v", r.body)
 			}
-			b, err := readFile(filepath.Join(r.root, fileName))
+			b, err := readFile(fp(fileName, r.root))
 			if err != nil {
 				return nil, err
 			}
@@ -253,7 +253,7 @@ func (r *httpRequest) encodeMultipart() (io.Reader, error) {
 			default:
 				return nil, fmt.Errorf("invalid body: %v", r.body)
 			}
-			b, err := readFile(filepath.Join(r.root, fileName))
+			b, err := readFile(fp(fileName, r.root))
 			patherr := &fs.PathError{}
 			if err != nil && !errors.Is(err, os.ErrNotExist) && !errors.As(err, &patherr) {
 				return nil, err

--- a/include.go
+++ b/include.go
@@ -64,13 +64,17 @@ func (rnr *includeRunner) Run(ctx context.Context, s *step) error {
 	}
 	rnr.runResults = nil
 
+	var err error
 	ipath := rnr.path
 	if ipath == "" {
 		ipath = c.path
 	}
 	// ipath must not be variable expanded. Because it will be impossible to identify the step of the included runbook in case of run failure.
 	if !hasRemotePrefix(ipath) {
-		ipath = fp(ipath, o.root)
+		ipath, err = fp(ipath, o.root)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Store before record

--- a/include.go
+++ b/include.go
@@ -3,7 +3,6 @@ package runn
 import (
 	"context"
 	"errors"
-	"path/filepath"
 )
 
 const includeRunnerKey = "include"
@@ -71,7 +70,7 @@ func (rnr *includeRunner) Run(ctx context.Context, s *step) error {
 	}
 	// ipath must not be variable expanded. Because it will be impossible to identify the step of the included runbook in case of run failure.
 	if !hasRemotePrefix(ipath) {
-		ipath = filepath.Join(o.root, ipath)
+		ipath = fp(ipath, o.root)
 	}
 
 	// Store before record

--- a/operator.go
+++ b/operator.go
@@ -10,7 +10,6 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -482,7 +481,7 @@ func New(opts ...Option) (*operator, error) {
 
 	op.needs = lo.MapEntries(bk.needs, func(key string, path string) (string, *need) {
 		return key, &need{
-			path: filepath.Join(op.root, path),
+			path: fp(path, op.root),
 		}
 	})
 
@@ -1766,7 +1765,7 @@ func (opn *operatorN) traverseOperators(op *operator) error {
 	if opn.skipIncluded {
 		for _, s := range op.steps {
 			if s.includeRunner != nil && s.includeConfig != nil {
-				opn.included = append(opn.included, filepath.Join(op.root, s.includeConfig.path))
+				opn.included = append(opn.included, fp(s.includeConfig.path, op.root))
 			}
 		}
 	}

--- a/operator_test.go
+++ b/operator_test.go
@@ -1042,7 +1042,7 @@ func TestHttp(t *testing.T) {
 		t.Run(tt.book, func(t *testing.T) {
 			ts := testutil.HTTPServer(t)
 			t.Setenv("TEST_HTTP_ENDPOINT", ts.URL)
-			o, err := New(Book(tt.book))
+			o, err := New(Book(tt.book), Scopes(ScopeAllowReadParent))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1091,7 +1091,7 @@ func TestGrpcWithoutReflection(t *testing.T) {
 			ctx, cancel := donegroup.WithCancel(context.Background())
 			t.Cleanup(cancel)
 			t.Parallel()
-			o, err := New(Book(tt.book))
+			o, err := New(Book(tt.book), Scopes(ScopeAllowReadParent))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1303,6 +1303,7 @@ func TestTrace(t *testing.T) {
 			id := "1234567890"
 			opts := []Option{
 				Book(tt.book),
+				Scopes(ScopeAllowReadParent),
 				GrpcRunner("greq", tg.Conn()),
 				Capture(NewDebugger(buf)),
 				Trace(true),

--- a/option.go
+++ b/option.go
@@ -292,24 +292,39 @@ func HTTPRunner(name, endpoint string, client *http.Client, opts ...httpRunnerOp
 		}
 		r.multipartBoundary = c.MultipartBoundary
 		if c.OpenAPI3DocLocation != "" && !strings.HasPrefix(c.OpenAPI3DocLocation, "https://") && !strings.HasPrefix(c.OpenAPI3DocLocation, "http://") && !strings.HasPrefix(c.OpenAPI3DocLocation, "/") {
-			c.OpenAPI3DocLocation = fp(c.OpenAPI3DocLocation, root)
+			c.OpenAPI3DocLocation, err = fp(c.OpenAPI3DocLocation, root)
+			if err != nil {
+				return err
+			}
 		}
 		if c.CACert != "" {
-			b, err := readFile(fp(c.CACert, root))
+			p, err := fp(c.CACert, root)
+			if err != nil {
+				return err
+			}
+			b, err := readFile(p)
 			if err != nil {
 				return err
 			}
 			r.cacert = b
 		}
 		if c.Cert != "" {
-			b, err := readFile(fp(c.Cert, root))
+			p, err := fp(c.Cert, root)
+			if err != nil {
+				return err
+			}
+			b, err := readFile(p)
 			if err != nil {
 				return err
 			}
 			r.cert = b
 		}
 		if c.Key != "" {
-			b, err := readFile(fp(c.Key, root))
+			p, err := fp(c.Key, root)
+			if err != nil {
+				return err
+			}
+			b, err := readFile(p)
 			if err != nil {
 				return err
 			}

--- a/path.go
+++ b/path.go
@@ -328,11 +328,11 @@ func fetchPathViaHTTPS(urlstr string) (string, error) {
 		return "", err
 	}
 	defer res.Body.Close()
-	cd, err := cacheDirOrCreate()
+	ep, err := urlfilepath.Encode(u)
 	if err != nil {
 		return "", err
 	}
-	ep, err := urlfilepath.Encode(u)
+	cd, err := cacheDirOrCreate()
 	if err != nil {
 		return "", err
 	}
@@ -353,15 +353,15 @@ func fetchPathViaHTTPS(urlstr string) (string, error) {
 
 func fetchPathsViaGitHub(fsys fs.FS, base, pattern string) ([]string, error) {
 	var paths []string
-	cd, err := cacheDirOrCreate()
-	if err != nil {
-		return nil, err
-	}
 	u, err := url.Parse(base)
 	if err != nil {
 		return nil, err
 	}
 	ep, err := urlfilepath.Encode(u)
+	if err != nil {
+		return nil, err
+	}
+	cd, err := cacheDirOrCreate()
 	if err != nil {
 		return nil, err
 	}

--- a/path.go
+++ b/path.go
@@ -31,6 +31,14 @@ const (
 	prefixGist   = schemeGist + "://"
 )
 
+// fp returns the absolute path of root+p.
+func fp(p, root string) string {
+	if filepath.IsAbs(p) {
+		return p
+	}
+	return filepath.Join(root, p)
+}
+
 // hasRemotePrefix returns true if the path has remote file prefix.
 func hasRemotePrefix(u string) bool {
 	return strings.HasPrefix(u, prefixHttps) || strings.HasPrefix(u, prefixGitHub) || strings.HasPrefix(u, prefixGist)

--- a/path.go
+++ b/path.go
@@ -60,7 +60,7 @@ func ShortenPath(p string) string {
 // If the file paths are remote files, it fetches them and returns their local cache paths.
 func fetchPaths(pathp string) ([]string, error) {
 	var paths []string
-	listp := splitList(pathp)
+	listp := splitPathList(pathp)
 	for _, pp := range listp {
 		base, pattern := doublestar.SplitPattern(filepath.ToSlash(pp))
 		switch {
@@ -467,8 +467,8 @@ func readFileViaGitHub(urlstr string) ([]byte, error) {
 	return io.ReadAll(f)
 }
 
-// splitList splits the path list by os.PathListSeparator while keeping schemes.
-func splitList(pathp string) []string {
+// splitPathList splits the path list by os.PathListSeparator while keeping schemes.
+func splitPathList(pathp string) []string {
 	rep := strings.NewReplacer(prefixHttps, repKey(prefixHttps), prefixGitHub, repKey(prefixGitHub), prefixGist, repKey(prefixGist))
 	per := strings.NewReplacer(repKey(prefixHttps), prefixHttps, repKey(prefixGitHub), prefixGitHub, repKey(prefixGist), prefixGist)
 	var listp []string

--- a/path_test.go
+++ b/path_test.go
@@ -38,11 +38,17 @@ func TestFetchPaths(t *testing.T) {
 			{"gist://def6fa739fba3fcf211b018f41630adc/book.yml", 1, false},
 		}...)
 	}
+	globalScopes.mu.RLock()
+	globalScopes.readRemote = true
+	globalScopes.mu.RUnlock()
 
 	t.Cleanup(func() {
 		if err := RemoveCacheDir(); err != nil {
 			t.Fatal(err)
 		}
+		globalScopes.mu.RLock()
+		globalScopes.readRemote = false
+		globalScopes.mu.RUnlock()
 	})
 	for _, tt := range tests {
 		t.Run(tt.pathp, func(t *testing.T) {

--- a/runbook.go
+++ b/runbook.go
@@ -576,6 +576,9 @@ func detectRunbookAreas(in string) *areas {
 	if err != nil {
 		return a
 	}
+	if len(parsed.Docs) == 0 {
+		return a
+	}
 	m, ok := parsed.Docs[0].Body.(*ast.MappingNode)
 	if !ok {
 		return a


### PR DESCRIPTION
ref: #1073 

Enhanced scope determination for file paths containing runbooks.
In addition, absolute paths are now allowed everywhere.

It's a bug that in some sections it was reading files in directories higher than the runbook even though there was no `read:parent` scope.