### PR TITLE
STDIN value is handled as `runn.stdin`, not as Runn ID.

### DIFF
--- a/flags/flags.go
+++ b/flags/flags.go
@@ -3,7 +3,6 @@ package flags
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"reflect"
 	"regexp"
@@ -16,7 +15,6 @@ import (
 	"github.com/k1LoW/duration"
 	"github.com/k1LoW/runn"
 	"github.com/k1LoW/runn/capture"
-	"github.com/mattn/go-isatty"
 	"github.com/spf13/cast"
 )
 
@@ -106,15 +104,11 @@ func (f *Flags) ToOpts() ([]runn.Option, error) {
 		runn.Attach(f.Attach),
 	}
 
-	// runbook ID
-	if !isatty.IsTerminal(os.Stdin.Fd()) {
-		// From stdin
-		b, err := io.ReadAll(os.Stdin)
-		if err != nil {
-			return nil, err
-		}
-		opts = append(opts, runn.RunID(string(b)))
+	// STDIN
+	if err := runn.SetStdin(os.Stdin); err != nil {
+		return nil, err
 	}
+
 	// From flags
 	opts = append(opts, runn.RunID(f.RunIDs...))
 

--- a/testdata/book/stdin.yml
+++ b/testdata/book/stdin.yml
@@ -1,0 +1,4 @@
+desc: Dump STDIN
+steps:
+  - desc: Dump STDIN
+    dump: runn.stdin


### PR DESCRIPTION
- Drop handling STDIN as Runn ID.
- Handle STDIN as `runn.stdin`, which can be retrieved from store.