### PR TITLE
Support `steps[*].defer:` `steps.<key>.defer:` for deferring steps in a runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,7 +726,7 @@ steps:
 [...]
 ```
 
-The step marked defer behaves as follows.
+The step marked `defer` behaves as follows.
 
 - If `defer: true` is set, run of the step is deferred until finish of the runbook.
 - Steps marked with `defer` are always run even if the running of intermediate steps fails.

--- a/README.md
+++ b/README.md
@@ -711,7 +711,7 @@ steps:
 [...]
 ```
 
-### `steps[*].defer:` `steps.<key>.defer:`
+### `steps[*].defer:` `steps.<key>.defer:` [THIS IS EXPERIMENT]
 
 Deferring setting for step.
 

--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ steps:
 
 ### `steps[*].loop:` `steps.<key>.loop:`
 
-Loop settings for steps.
+Loop setting for step.
 
 #### Simple loop step
 
@@ -710,6 +710,28 @@ steps:
           body:
 [...]
 ```
+
+### `steps[*].defer:` `steps.<key>.defer:`
+
+Deferring setting for step.
+
+```yaml
+steps:
+  -
+    defer: true
+    req:
+      /cart:
+        delete:
+          body: null
+[...]
+```
+
+The step marked defer behaves as follows.
+
+- If `defer: true` is set, run of the step is deferred until finish of the runbook.
+- Steps marked with `defer` are always run even if the running of intermediate steps fails.
+- If there are multiple steps marked with `defer`, they are run in LIFO order.
+    - Also, the included steps are added to run sequence of the parent runbook's deferred steps.
 
 ## Variables to be stored
 

--- a/bind.go
+++ b/bind.go
@@ -25,9 +25,13 @@ func (rnr *bindRunner) Run(ctx context.Context, s *step, first bool) error {
 	store := o.store.toMap()
 	store[storeRootKeyIncluded] = o.included
 	if first {
-		store[storeRootKeyPrevious] = o.store.latest()
+		if !s.deferred {
+			store[storeRootKeyPrevious] = o.store.latest()
+		}
 	} else {
-		store[storeRootKeyPrevious] = o.store.previous()
+		if !s.deferred {
+			store[storeRootKeyPrevious] = o.store.previous()
+		}
 		store[storeRootKeyCurrent] = o.store.latest()
 	}
 	keys := lo.Keys(cond)

--- a/cdp.go
+++ b/cdp.go
@@ -88,7 +88,7 @@ func (rnr *cdpRunner) Renew() error {
 
 func (rnr *cdpRunner) Run(ctx context.Context, s *step) error {
 	o := s.parent
-	cas, err := parseCDPActions(s.cdpActions, o.expandBeforeRecord)
+	cas, err := parseCDPActions(s.cdpActions, s, o.expandBeforeRecord)
 	if err != nil {
 		return fmt.Errorf("failed to parse: %w", err)
 	}

--- a/db.go
+++ b/db.go
@@ -84,7 +84,7 @@ func normalizeDSN(dsn string) string {
 
 func (rnr *dbRunner) Run(ctx context.Context, s *step) error {
 	o := s.parent
-	e, err := o.expandBeforeRecord(s.dbQuery)
+	e, err := o.expandBeforeRecord(s.dbQuery, s)
 	if err != nil {
 		return err
 	}

--- a/dbg.go
+++ b/dbg.go
@@ -95,7 +95,9 @@ func (c *completer) do(d prompt.Document) ([]prompt.Suggest, pstrings.RuneNumber
 		// print
 		store := c.step.parent.store.toMap()
 		store[storeRootKeyIncluded] = c.step.parent.included
-		store[storeRootKeyPrevious] = c.step.parent.store.latest()
+		if !c.step.deferred {
+			store[storeRootKeyPrevious] = c.step.parent.store.latest()
+		}
 		keys := storeKeys(store)
 		for _, k := range keys {
 			if strings.HasPrefix(k, w) {
@@ -193,7 +195,9 @@ L:
 			}
 			store := s.parent.store.toMapForDbg()
 			store[storeRootKeyIncluded] = s.parent.included
-			store[storeRootKeyPrevious] = s.parent.store.latest()
+			if !s.deferred {
+				store[storeRootKeyPrevious] = s.parent.store.latest()
+			}
 			e, err := Eval(cmd[1], store)
 			if err != nil {
 				_, _ = fmt.Fprintf(os.Stderr, "%s\n", err.Error())
@@ -244,7 +248,9 @@ L:
 			case "variables", "v":
 				store := s.parent.store.toMapForDbg()
 				store[storeRootKeyIncluded] = s.parent.included
-				store[storeRootKeyPrevious] = s.parent.store.latest()
+				if !s.deferred {
+					store[storeRootKeyPrevious] = s.parent.store.latest()
+				}
 				keys := lo.Keys(store)
 				sort.Strings(keys)
 				for _, k := range keys {

--- a/defer.go
+++ b/defer.go
@@ -1,0 +1,3 @@
+package runn
+
+const deferSectionKey = "defer"

--- a/defer_test.go
+++ b/defer_test.go
@@ -6,74 +6,90 @@ import (
 )
 
 func TestDeferRun(t *testing.T) {
-	book := "testdata/book/defer.yml"
-	ctx := context.Background()
-	o, err := New(Book(book))
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		book string
+	}{
+		{"testdata/book/defer.yml"},
+		{"testdata/book/defer_map.yml"},
 	}
-	if err := o.Run(ctx); err == nil {
-		t.Fatal("expected error")
-	}
-	if want := 8; len(o.store.steps) != want {
-		t.Errorf("o.store.steps got %v, want %v", len(o.store.steps), want)
-	}
-	r := o.Result()
-	if want := 8; len(r.StepResults) != want {
-		t.Errorf("r.StepResults got %v, want %v", len(r.StepResults), want)
-	}
+	for _, tt := range tests {
+		t.Run(tt.book, func(t *testing.T) {
+			ctx := context.Background()
+			o, err := New(Book(tt.book))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := o.Run(ctx); err == nil {
+				t.Fatal("expected error")
+			}
 
-	t.Run("main steps", func(t *testing.T) {
-		wantResults := []struct {
-			desc    string
-			skipped bool
-			err     bool
-		}{
-			{"step 1", false, false},
-			{"include step", false, false},
-			{"step 2", false, false},
-			{"step 3", false, true},
-			{"step 4", true, false},
-			{"defererd step c", false, false},
-			{"defererd step b", false, true},
-			{"defererd step a", false, false},
-		}
-		for i, want := range wantResults {
-			got := r.StepResults[i]
-			if got.Desc != want.desc {
-				t.Errorf("got %v, want %v", got.Desc, want.desc)
+			if o.useMap {
+				if want := 8; len(o.store.stepMap) != want {
+					t.Errorf("o.store.steps got %v, want %v", len(o.store.steps), want)
+				}
+			} else {
+				if want := 8; len(o.store.steps) != want {
+					t.Errorf("o.store.steps got %v, want %v", len(o.store.steps), want)
+				}
 			}
-			if got.Skipped != want.skipped {
-				t.Errorf("got %v, want %v", got.Skipped, want.skipped)
+			r := o.Result()
+			if want := 8; len(r.StepResults) != want {
+				t.Errorf("r.StepResults got %v, want %v", len(r.StepResults), want)
 			}
-			if (got.Err == nil) == want.err {
-				t.Errorf("got %v, want %v", got.Err, want.err)
-			}
-		}
-	})
 
-	t.Run("include steps", func(t *testing.T) {
-		wantResults := []struct {
-			desc    string
-			skipped bool
-			err     bool
-		}{
-			{"included step 1", false, false},
-			{"included step 2", false, false},
-			{"included defererd step d", false, false},
-		}
+			t.Run("main steps", func(t *testing.T) {
+				wantResults := []struct {
+					desc    string
+					skipped bool
+					err     bool
+				}{
+					{"step 1", false, false},
+					{"include step", false, false},
+					{"step 2", false, false},
+					{"step 3", false, true},
+					{"step 4", true, false},
+					{"defererd step c", false, false},
+					{"defererd step b", false, true},
+					{"defererd step a", false, false},
+				}
+				for i, want := range wantResults {
+					got := r.StepResults[i]
+					if got.Desc != want.desc {
+						t.Errorf("got %v, want %v", got.Desc, want.desc)
+					}
+					if got.Skipped != want.skipped {
+						t.Errorf("got %v, want %v", got.Skipped, want.skipped)
+					}
+					if (got.Err == nil) == want.err {
+						t.Errorf("got %v, want %v", got.Err, want.err)
+					}
+				}
+			})
 
-		for i, want := range wantResults {
-			got := r.StepResults[1].IncludedRunResults[0].StepResults[i]
-			if got.Desc != want.desc {
-				t.Errorf("got %v, want %v", got.Desc, want.desc)
-			}
-			if got.Skipped != want.skipped {
-				t.Errorf("got %v, want %v", got.Skipped, want.skipped)
-			}
-			if (got.Err == nil) == want.err {
-				t.Errorf("got %v, want %v", got.Err, want.err)
-			}
-		}
-	})
+			t.Run("include steps", func(t *testing.T) {
+				wantResults := []struct {
+					desc    string
+					skipped bool
+					err     bool
+				}{
+					{"included step 1", false, false},
+					{"included step 2", false, false},
+					{"included defererd step d", false, false},
+				}
+
+				for i, want := range wantResults {
+					got := r.StepResults[1].IncludedRunResults[0].StepResults[i]
+					if got.Desc != want.desc {
+						t.Errorf("got %v, want %v", got.Desc, want.desc)
+					}
+					if got.Skipped != want.skipped {
+						t.Errorf("got %v, want %v", got.Skipped, want.skipped)
+					}
+					if (got.Err == nil) == want.err {
+						t.Errorf("got %v, want %v", got.Err, want.err)
+					}
+				}
+			})
+		})
+	}
 }

--- a/defer_test.go
+++ b/defer_test.go
@@ -1,0 +1,79 @@
+package runn
+
+import (
+	"context"
+	"testing"
+)
+
+func TestDeferRun(t *testing.T) {
+	book := "testdata/book/defer.yml"
+	ctx := context.Background()
+	o, err := New(Book(book))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Run(ctx); err == nil {
+		t.Fatal("expected error")
+	}
+	if want := 8; len(o.store.steps) != want {
+		t.Errorf("o.store.steps got %v, want %v", len(o.store.steps), want)
+	}
+	r := o.Result()
+	if want := 8; len(r.StepResults) != want {
+		t.Errorf("r.StepResults got %v, want %v", len(r.StepResults), want)
+	}
+
+	t.Run("main steps", func(t *testing.T) {
+		wantResults := []struct {
+			desc    string
+			skipped bool
+			err     bool
+		}{
+			{"step 1", false, false},
+			{"include step", false, false},
+			{"step 2", false, false},
+			{"step 3", false, true},
+			{"step 4", true, false},
+			{"defererd step c", false, false},
+			{"defererd step b", false, true},
+			{"defererd step a", false, false},
+		}
+		for i, want := range wantResults {
+			got := r.StepResults[i]
+			if got.Desc != want.desc {
+				t.Errorf("got %v, want %v", got.Desc, want.desc)
+			}
+			if got.Skipped != want.skipped {
+				t.Errorf("got %v, want %v", got.Skipped, want.skipped)
+			}
+			if (got.Err == nil) == want.err {
+				t.Errorf("got %v, want %v", got.Err, want.err)
+			}
+		}
+	})
+
+	t.Run("include steps", func(t *testing.T) {
+		wantResults := []struct {
+			desc    string
+			skipped bool
+			err     bool
+		}{
+			{"included step 1", false, false},
+			{"included step 2", false, false},
+			{"included defererd step d", false, false},
+		}
+
+		for i, want := range wantResults {
+			got := r.StepResults[1].IncludedRunResults[0].StepResults[i]
+			if got.Desc != want.desc {
+				t.Errorf("got %v, want %v", got.Desc, want.desc)
+			}
+			if got.Skipped != want.skipped {
+				t.Errorf("got %v, want %v", got.Skipped, want.skipped)
+			}
+			if (got.Err == nil) == want.err {
+				t.Errorf("got %v, want %v", got.Err, want.err)
+			}
+		}
+	})
+}

--- a/docs/designs/defer.md
+++ b/docs/designs/defer.md
@@ -1,0 +1,133 @@
+# Behavior of `defer:`
+
+Authors: @k1low
+
+Status: Add continuously
+
+## Objective
+
+This document describes the `defer:` behavior in runn.
+
+## Backgroud
+
+Allow post-processing of the runbook to be described using `defer:`
+
+## Behavior of `defer:`
+
+As the name suggests, `defer:` is inspired by the [defer](https://go.dev/blog/defer-panic-and-recover) of the Go programming language.
+
+Behavior is also similar to the defer of the Go programming language, but some differences.
+
+The order of run of steps not marked `defer:` are as follows.
+
+```yaml
+# main.yml
+steps:
+  - desc: step 1
+    test: true
+  - desc: step 2
+    test: true
+  - desc: step 3
+    test: true
+  - desc: step 4
+    include:
+      path: include.yml
+  - desc: step 5
+    test: true
+```
+
+```yaml
+# include.yml
+steps:
+  - desc: included step 1
+    test: true
+  - desc: included step 2
+    test: true
+  - desc: included step 3
+    test: true
+```
+
+``` mermaid
+flowchart TB
+  subgraph "(main.yml)"
+    A[step 1]
+    B[step 2]
+    C[step 3]
+    G[step 5]
+  end
+
+  subgraph "step 4 (include.yml)"
+    D[included step 1]
+    E[included step 2]
+    F[included step 3]
+  end
+  
+  A --> B
+  B --> C
+  C --> D
+  D --> E
+  E --> F
+  F --> G
+```
+
+The steps with `defer:` are run as follows.
+
+```yaml
+# main.yml
+steps:
+  - desc: step 1
+    test: true
+  - desc: step 2
+    defer: true
+    test: true
+  - desc: step 3
+    defer: true
+    test: true
+  - desc: step 4
+    include:
+      path: include.yml
+  - desc: step 5
+    test: true
+```
+
+```yaml
+# include.yml
+steps:
+  - desc: included step 1
+    test: true
+  - desc: included step 2
+    defer: true
+    test: true
+  - desc: included step 3
+    test: true
+```
+
+``` mermaid
+flowchart TB
+  subgraph "(main.yml)"
+    A[step 1]
+    B["step 2 (defer: true)"]
+    C["step 3 (defer: true)"]
+    G[step 5]
+  end
+
+  subgraph "step 4 (include.yml)"
+    D[included step 1]
+    E["included step 2 (defer: true)"]
+    F[included step 3]
+  end
+  
+  A --> D
+  D --> F
+  F --> G
+  G --> E
+  E --> C
+  C --> B
+```
+
+The step marked `defer` behaves as follows.
+
+- If `defer: true` is set, run of the step is deferred until finish of the runbook.
+- Steps marked with `defer` are always run even if the running of intermediate steps fails.
+- If there are multiple steps marked with `defer`, they are run in LIFO order.
+    - Also, the included steps are added to run sequence of the parent runbook's deferred steps.

--- a/dump.go
+++ b/dump.go
@@ -34,9 +34,13 @@ func (rnr *dumpRunner) Run(ctx context.Context, s *step, first bool) error {
 	store := o.store.toMap()
 	store[storeRootKeyIncluded] = o.included
 	if first {
-		store[storeRootKeyPrevious] = o.store.latest()
+		if !s.deferred {
+			store[storeRootKeyPrevious] = o.store.latest()
+		}
 	} else {
-		store[storeRootKeyPrevious] = o.store.previous()
+		if !s.deferred {
+			store[storeRootKeyPrevious] = o.store.previous()
+		}
 		store[storeRootKeyCurrent] = o.store.latest()
 	}
 	if r.out == "" {

--- a/exec.go
+++ b/exec.go
@@ -48,7 +48,7 @@ func (rnr *execRunner) Run(ctx context.Context, s *step) error {
 	}
 	globalScopes.mu.RUnlock()
 	o := s.parent
-	e, err := o.expandBeforeRecord(s.execCommand)
+	e, err := o.expandBeforeRecord(s.execCommand, s)
 	if err != nil {
 		return err
 	}

--- a/grpc.go
+++ b/grpc.go
@@ -131,7 +131,7 @@ func (rnr *grpcRunner) Close() error {
 
 func (rnr *grpcRunner) Run(ctx context.Context, s *step) error {
 	o := s.parent
-	req, err := parseGrpcRequest(s.grpcRequest, o.expandBeforeRecord)
+	req, err := parseGrpcRequest(s.grpcRequest, s, o.expandBeforeRecord)
 	if err != nil {
 		return err
 	}
@@ -732,7 +732,7 @@ func setHeaders(ctx context.Context, h metadata.MD) context.Context {
 func (rnr *grpcRunner) setMessage(req proto.Message, message map[string]any, s *step) error {
 	o := s.parent
 	// Lazy expand due to the possibility of computing variables between multiple messages.
-	e, err := o.expandBeforeRecord(message)
+	e, err := o.expandBeforeRecord(message, s)
 	if err != nil {
 		return err
 	}

--- a/http.go
+++ b/http.go
@@ -374,7 +374,7 @@ func isLocalhost(domain string) (bool, error) {
 
 func (rnr *httpRunner) Run(ctx context.Context, s *step) error {
 	o := s.parent
-	e, err := o.expandBeforeRecord(s.httpRequest)
+	e, err := o.expandBeforeRecord(s.httpRequest, s)
 	if err != nil {
 		return err
 	}

--- a/include.go
+++ b/include.go
@@ -78,7 +78,9 @@ func (rnr *includeRunner) Run(ctx context.Context, s *step) error {
 	// Store before record
 	store := o.store.toMap()
 	store[storeRootKeyIncluded] = o.included
-	store[storeRootKeyPrevious] = o.store.latest()
+	if !s.deferred {
+		store[storeRootKeyPrevious] = o.store.latest()
+	}
 
 	nodes, err := s.expandNodes()
 	if err != nil {
@@ -96,7 +98,7 @@ func (rnr *includeRunner) Run(ctx context.Context, s *step) error {
 		switch ov := v.(type) {
 		case string:
 			var vv any
-			vv, err = o.expandBeforeRecord(ov)
+			vv, err = o.expandBeforeRecord(ov, s)
 			if err != nil {
 				return err
 			}
@@ -106,7 +108,7 @@ func (rnr *includeRunner) Run(ctx context.Context, s *step) error {
 			}
 			params[k] = evv
 		case map[string]any, []any:
-			vv, err := o.expandBeforeRecord(ov)
+			vv, err := o.expandBeforeRecord(ov, s)
 			if err != nil {
 				return err
 			}
@@ -133,7 +135,7 @@ func (rnr *includeRunner) Run(ctx context.Context, s *step) error {
 		switch ov := v.(type) {
 		case string:
 			var vv any
-			vv, err = o.expandBeforeRecord(ov)
+			vv, err = o.expandBeforeRecord(ov, s)
 			if err != nil {
 				return err
 			}
@@ -143,7 +145,7 @@ func (rnr *includeRunner) Run(ctx context.Context, s *step) error {
 			}
 			oo.store.vars[k] = evv
 		case map[string]any, []any:
-			vv, err := o.expandBeforeRecord(ov)
+			vv, err := o.expandBeforeRecord(ov, s)
 			if err != nil {
 				return err
 			}

--- a/include.go
+++ b/include.go
@@ -215,6 +215,7 @@ func (o *operator) newNestedOperator(parent *step, opts ...Option) (*operator, e
 	oo.store.runNIndex = o.store.runNIndex
 	oo.dbg = o.dbg
 	oo.nm = o.nm
+	oo.deferred = o.deferred
 	return oo, nil
 }
 

--- a/operator.go
+++ b/operator.go
@@ -1275,7 +1275,6 @@ func (op *operator) runInternal(ctx context.Context) (rerr error) {
 				return err
 			}
 			rerr = errors.Join(rerr, err)
-			failed = true
 		default:
 			if err := os.op.recordResultToLatest(resultSuccess); err != nil {
 				return err

--- a/operator_test.go
+++ b/operator_test.go
@@ -209,7 +209,6 @@ func TestRun(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv("DEBUG", "false")
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
 			_, dsn := testutil.SQLite(t)
 			t.Setenv("TEST_DB_DSN", dsn)
@@ -984,7 +983,7 @@ func TestShard(t *testing.T) {
 				cmp.AllowUnexported(allow...),
 				cmpopts.IgnoreUnexported(ignore...),
 				cmpopts.IgnoreFields(stopw.Span{}, "ID"),
-				cmpopts.IgnoreFields(operator{}, "id", "concurrency", "mu", "dbg", "needs", "nm", "maskRule", "stdout", "stderr"),
+				cmpopts.IgnoreFields(operator{}, "id", "concurrency", "mu", "dbg", "needs", "nm", "maskRule", "stdout", "stderr", "deferred"),
 				cmpopts.IgnoreFields(cdpRunner{}, "ctx", "cancel", "opts", "mu", "operatorID"),
 				cmpopts.IgnoreFields(sshRunner{}, "client", "sess", "stdin", "stdout", "stderr", "operatorID"),
 				cmpopts.IgnoreFields(grpcRunner{}, "mu", "operatorID"),

--- a/operator_test.go
+++ b/operator_test.go
@@ -147,7 +147,7 @@ func TestExpand(t *testing.T) {
 		o.store.steps = tt.steps
 		o.store.vars = tt.vars
 
-		got, err := o.expandBeforeRecord(tt.in)
+		got, err := o.expandBeforeRecord(tt.in, &step{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/parse.go
+++ b/parse.go
@@ -144,7 +144,7 @@ func parseDBQuery(v map[string]any) (*dbQuery, error) {
 	return q, nil
 }
 
-func parseGrpcRequest(v map[string]any, expand func(any) (any, error)) (*grpcRequest, error) {
+func parseGrpcRequest(v map[string]any, s *step, expand func(any, *step) (any, error)) (*grpcRequest, error) {
 	v = trimDelimiter(v)
 	req := &grpcRequest{
 		headers: metadata.MD{},
@@ -157,7 +157,7 @@ func parseGrpcRequest(v map[string]any, expand func(any) (any, error)) (*grpcReq
 		return nil, fmt.Errorf("invalid request: %s", string(part))
 	}
 	for k, vv := range v {
-		pe, err := expand(k)
+		pe, err := expand(k, s)
 		if err != nil {
 			return nil, err
 		}
@@ -177,7 +177,7 @@ func parseGrpcRequest(v map[string]any, expand func(any) (any, error)) (*grpcReq
 		}
 		hm, ok := vvv["headers"]
 		if ok {
-			hme, err := expand(hm)
+			hme, err := expand(hm, s)
 			if err != nil {
 				return nil, err
 			}
@@ -204,7 +204,7 @@ func parseGrpcRequest(v map[string]any, expand func(any) (any, error)) (*grpcReq
 		}
 		tm, ok := vvv["timeout"]
 		if ok {
-			tme, err := expand(tm)
+			tme, err := expand(tm, s)
 			if err != nil {
 				return nil, err
 			}
@@ -223,7 +223,7 @@ func parseGrpcRequest(v map[string]any, expand func(any) (any, error)) (*grpcReq
 			ms, ok := mm.(string)
 			if ok {
 				// Only for string, variable expansion is acceptable.
-				mm, err = expand(ms)
+				mm, err = expand(ms, s)
 				if err != nil {
 					return nil, err
 				}
@@ -242,7 +242,7 @@ func parseGrpcRequest(v map[string]any, expand func(any) (any, error)) (*grpcReq
 				ms, ok := mm.(string)
 				if ok {
 					// Only for string, variable expansion is acceptable.
-					mm, err = expand(ms)
+					mm, err = expand(ms, s)
 					if err != nil {
 						return nil, err
 					}
@@ -255,7 +255,7 @@ func parseGrpcRequest(v map[string]any, expand func(any) (any, error)) (*grpcReq
 					// Only for string, variable expansion is acceptable.
 					mms, ok := mm.(string)
 					if ok {
-						mm, err = expand(mms)
+						mm, err = expand(mms, s)
 						if err != nil {
 							return nil, err
 						}
@@ -295,7 +295,7 @@ func parseGrpcRequest(v map[string]any, expand func(any) (any, error)) (*grpcReq
 	return req, nil
 }
 
-func parseCDPActions(v map[string]any, expand func(any) (any, error)) (CDPActions, error) {
+func parseCDPActions(v map[string]any, s *step, expand func(any, *step) (any, error)) (CDPActions, error) {
 	v = trimDelimiter(v)
 	cas := CDPActions{}
 	part, err := yaml.Marshal(v)
@@ -317,7 +317,7 @@ func parseCDPActions(v map[string]any, expand func(any) (any, error)) (CDPAction
 		ca := CDPAction{
 			Args: map[string]any{},
 		}
-		v, err := expand(v)
+		v, err := expand(v, s)
 		if err != nil {
 			return nil, err
 		}
@@ -352,14 +352,14 @@ func parseCDPActions(v map[string]any, expand func(any) (any, error)) (CDPAction
 	return cas, nil
 }
 
-func parseSSHCommand(v map[string]any, expand func(any) (any, error)) (*sshCommand, error) {
+func parseSSHCommand(v map[string]any, s *step, expand func(any, *step) (any, error)) (*sshCommand, error) {
 	var err error
 	part, err := yaml.Marshal(v)
 	if err != nil {
 		return nil, err
 	}
 	v = trimDelimiter(v)
-	vv, err := expand(v)
+	vv, err := expand(v, s)
 	if err != nil {
 		return nil, err
 	}

--- a/parse_test.go
+++ b/parse_test.go
@@ -378,7 +378,7 @@ my.custom.server.Service/Method:
 		if err := yaml.Unmarshal([]byte(tt.in), &v); err != nil {
 			t.Fatal(err)
 		}
-		got, err := parseGrpcRequest(v, o.expandBeforeRecord)
+		got, err := parseGrpcRequest(v, &step{}, o.expandBeforeRecord)
 		if err != nil {
 			if !tt.wantErr {
 				t.Error(err)

--- a/runner_runner.go
+++ b/runner_runner.go
@@ -27,7 +27,7 @@ func (rnr *runnerRunner) Run(ctx context.Context, s *step) error {
 	default:
 		return fmt.Errorf("only one runner can be defined: %v", s.runnerDefinition)
 	}
-	e, err := o.expandBeforeRecord(s.runnerDefinition)
+	e, err := o.expandBeforeRecord(s.runnerDefinition, s)
 	if err != nil {
 		return err
 	}

--- a/ssh.go
+++ b/ssh.go
@@ -194,7 +194,7 @@ func (rnr *sshRunner) Close() error {
 
 func (rnr *sshRunner) Run(ctx context.Context, s *step) error {
 	o := s.parent
-	cmd, err := parseSSHCommand(s.sshCommand, o.expandBeforeRecord)
+	cmd, err := parseSSHCommand(s.sshCommand, s, o.expandBeforeRecord)
 	if err != nil {
 		return fmt.Errorf("invalid ssh command: %w", err)
 	}

--- a/step.go
+++ b/step.go
@@ -11,6 +11,7 @@ type step struct {
 	runnerKey string
 	desc      string
 	ifCond    string
+	deferred  bool // deferred step runs after all other steps like defer in Go
 	loop      *Loop
 	// loopIndex - Index of the loop is dynamically recorded at runtime
 	loopIndex        *int

--- a/step.go
+++ b/step.go
@@ -60,7 +60,7 @@ func (s *step) expandNodes() (map[string]any, error) {
 		return s.nodes, nil
 	}
 	o := s.parent
-	nodes, err := o.expandBeforeRecord(s.rawStep)
+	nodes, err := o.expandBeforeRecord(s.rawStep, s)
 	if err != nil {
 		return nil, err
 	}

--- a/store.go
+++ b/store.go
@@ -296,7 +296,7 @@ func (s *store) toMap() map[string]any {
 }
 
 // toMapForIncludeRunner - returns a map for include runner.
-// toMap without s.parentVars and s.needsVars and runn
+// toMap without s.parentVars and s.needsVars.
 func (s *store) toMapForIncludeRunner() map[string]any {
 	store := map[string]any{}
 	store[storeRootKeyEnv] = envMap()

--- a/test.go
+++ b/test.go
@@ -38,9 +38,13 @@ func (rnr *testRunner) Run(ctx context.Context, s *step, first bool) error {
 	store := exprtrace.EvalEnv(o.store.toMap())
 	store[storeRootKeyIncluded] = o.included
 	if first {
-		store[storeRootKeyPrevious] = o.store.latest()
+		if !s.deferred {
+			store[storeRootKeyPrevious] = o.store.latest()
+		}
 	} else {
-		store[storeRootKeyPrevious] = o.store.previous()
+		if !s.deferred {
+			store[storeRootKeyPrevious] = o.store.previous()
+		}
 		store[storeRootKeyCurrent] = o.store.latest()
 	}
 	if err := rnr.run(ctx, cond, store, s, first); err != nil {

--- a/testdata/book/custom_runner_http.yml
+++ b/testdata/book/custom_runner_http.yml
@@ -1,4 +1,4 @@
-desc: HTTP runner with defferent syntax
+desc: HTTP runner with different syntax
 runners:
   req:
     endpoint: '{{ parent.nodes.url }}'

--- a/testdata/book/defer.yml
+++ b/testdata/book/defer.yml
@@ -1,0 +1,31 @@
+desc: Test for defer
+steps:
+  -
+    desc: step 1
+    test: len(steps) == 0
+  -
+    defer: true
+    desc: defererd step a
+    test: len(steps) == 7
+  -
+    desc: include step
+    include:
+      path: defer_included.yml
+  -
+    defer: true
+    desc: defererd step b
+    test: false
+  -
+    defer: true
+    desc: defererd step c
+    test: len(steps) == 5
+  -
+    desc: step 2
+    test: len(steps) == 2
+  -
+    desc: step 3
+    test: false
+  -
+    desc: step 4
+    test: true
+            

--- a/testdata/book/defer_included.yml
+++ b/testdata/book/defer_included.yml
@@ -1,0 +1,13 @@
+desc: Test for defer (included)
+steps:
+  -
+    desc: included step 1
+    test: len(steps) == 0
+  -
+    defer: true
+    desc: included defererd step d
+    test: len(steps) == 2
+  -
+    desc: included step 2
+    test: len(steps) == 1
+    

--- a/testdata/book/defer_map.yml
+++ b/testdata/book/defer_map.yml
@@ -1,0 +1,31 @@
+desc: Test for defer
+steps:
+  step1: 
+    desc: step 1
+    test: len(steps) == 0
+  step2:
+    defer: true
+    desc: defererd step a
+    test: len(steps) == 7
+  step3:
+    desc: include step
+    include:
+      path: defer_included.yml
+  step4:
+    defer: true
+    desc: defererd step b
+    test: false
+  step5:
+    defer: true
+    desc: defererd step c
+    test: len(steps) == 5
+  step6:
+    desc: step 2
+    test: len(steps) == 2
+  step7:
+    desc: step 3
+    test: false
+  step8:
+    desc: step 4
+    test: true
+            


### PR DESCRIPTION
Support `defer:` for deferring steps in a runbook.