### PR TITLE
Support `steps[*].force:` `steps.<key>.force:` for running step forcefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,19 @@ The step marked `defer` behaves as follows.
 - If there are multiple steps marked with `defer`, they are run in LIFO order.
     - Also, the included steps are added to run sequence of the parent runbook's deferred steps.
 
+### `steps[*].force:` `steps.<key>.force:`
+
+Force step to run.
+
+```yaml
+steps:
+[...]
+  -
+     force: true
+     dump: previous.res.body
+[...]
+```
+
 ## Variables to be stored
 
 runn can use variables and functions when running step.

--- a/force.go
+++ b/force.go
@@ -1,0 +1,3 @@
+package runn
+
+const forceSectionKey = "force"

--- a/force_test.go
+++ b/force_test.go
@@ -1,0 +1,32 @@
+package runn
+
+import (
+	"context"
+	"testing"
+)
+
+func TestForceRun(t *testing.T) {
+	tests := []struct {
+		book string
+	}{
+		{"testdata/book/force.yml"},
+		{"testdata/book/force_step.yml"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.book, func(t *testing.T) {
+			ctx := context.Background()
+			o, err := New(Book(tt.book))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := o.Run(ctx); err == nil {
+				t.Fatal("expected error")
+			}
+			for _, sr := range o.Result().StepResults {
+				if sr.Skipped {
+					t.Errorf("got %v, want %v", sr.Skipped, false)
+				}
+			}
+		})
+	}
+}

--- a/operator.go
+++ b/operator.go
@@ -706,6 +706,14 @@ func (op *operator) appendStep(idx int, key string, s map[string]any) error {
 		}
 		delete(s, deferSectionKey)
 	}
+	// force section
+	if v, ok := s[forceSectionKey]; ok {
+		st.force, ok = v.(bool)
+		if !ok {
+			return fmt.Errorf("invalid force: %v", v)
+		}
+		delete(s, forceSectionKey)
+	}
 	// loop section
 	if v, ok := s[loopSectionKey]; ok {
 		r, err := newLoop(v)
@@ -1222,7 +1230,7 @@ func (op *operator) runInternal(ctx context.Context) (rerr error) {
 			op.record(s.idx, nil)
 			continue
 		}
-		if failed && !force {
+		if failed && !force && !s.force {
 			s.setResult(errStepSkipped)
 			op.recordNotRun(s.idx)
 			if err := op.recordResult(s.idx, resultSkipped); err != nil {

--- a/step.go
+++ b/step.go
@@ -12,6 +12,7 @@ type step struct {
 	desc      string
 	ifCond    string
 	deferred  bool // deferred step runs after all other steps like defer in Go
+	force     bool // forceed run per step
 	loop      *Loop
 	// loopIndex - Index of the loop is dynamically recorded at runtime
 	loopIndex        *int

--- a/testdata/book/force_step.yml
+++ b/testdata/book/force_step.yml
@@ -1,5 +1,4 @@
-desc: Always force run
-force: true
+desc: Forced run per step
 steps:
   -
     test: true
@@ -7,3 +6,4 @@ steps:
     test: false
   -
     test: true
+    force: true


### PR DESCRIPTION
SSIA.