### PR TITLE
Fix a bug that caused store values to be lost when using `loop:`.

### DIFF
--- a/store.go
+++ b/store.go
@@ -114,11 +114,6 @@ func (s *store) recordAsMapped(idx int, v map[string]any) {
 	if !s.useMap {
 		panic("recordAsMapped can only be used if useMap = true")
 	}
-	if s.loopIndex != nil && *s.loopIndex > 0 {
-		// delete values of prevous loop
-		latestKey := s.stepMapKeys[idx-1]
-		delete(s.stepMap, latestKey)
-	}
 	k := s.stepMapKeys[idx]
 	s.stepMap[k] = v
 }
@@ -126,10 +121,6 @@ func (s *store) recordAsMapped(idx int, v map[string]any) {
 func (s *store) recordAsListed(idx int, v map[string]any) {
 	if s.useMap {
 		panic("recordAsMapped can only be used if useMap = false")
-	}
-	if s.loopIndex != nil && *s.loopIndex > 0 {
-		// delete values of prevous loop
-		delete(s.stepList, idx-1)
 	}
 	s.stepList[idx] = v
 }

--- a/testdata/book/loop.yml
+++ b/testdata/book/loop.yml
@@ -84,3 +84,15 @@ steps:
       // 11,12
       steps[7].res.rawBody contains "12"
       && loopmap['hi'].rawBody contains "12"
+  -
+    desc: Check that the values of the steps are not lost when using loop
+    test: |
+      steps[0] != null
+      && steps[1] != null
+      && steps[2] != null
+      && steps[3] != null
+      && steps[4] != null
+      && steps[5] != null
+      && steps[6] != null
+      && steps[7] != null
+      && steps[8] != null


### PR DESCRIPTION
Fix: https://github.com/k1LoW/runn/issues/1128