### PR TITLE
fix(loadt): Fix a bug that overwrote the original error

### DIFF
--- a/cmd/loadt.go
+++ b/cmd/loadt.go
@@ -62,7 +62,7 @@ var loadtCmd = &cobra.Command{
 		}
 		defer func() {
 			if !flgs.RetainCacheDir {
-				err = errors.Join(runn.RemoveCacheDir())
+				err = errors.Join(err, runn.RemoveCacheDir())
 			}
 		}()
 


### PR DESCRIPTION
## What I did in this PR

Currently at `runn loadt` cmd, the existing error (`err`) was overwritten by the new error returned from `runn.RemoveCacheDir()`. This change uses `errors.Join(err, ...)` to merge both errors and ensure the original context is not lost.

## Background

By this bug, even if the condition of `--threshold` flag does not meets, no error was returned (exit with 0).

before
```console
$ go run cmd/runn/main.go loadt --env-file load_test/.env load_test/main.yaml --duration 1s --warm-up 0s --threshold 'total > 10'

Number of runbooks per RunN....: 1
Warm up time (--warm-up).......: 0s
Duration (--duration)..........: 1s
Concurrent (--load-concurrent).: 1
Max RunN per second (--max-rps): 1

Total..........................: 2
Succeeded......................: 2
Failed.........................: 0
Error rate.....................: 0%
RunN per second................: 2
Latency .......................: max=21.0ms min=11.2ms avg=16.1ms med=11.2ms p(90)=11.2ms p(99)=11.2ms
```

after
```console
$ go run cmd/runn/main.go loadt --env-file load_test/.env load_test/main.yaml --duration 1s --warm-up 0s --threshold 'total > 10'

Number of runbooks per RunN....: 1
Warm up time (--warm-up).......: 0s
Duration (--duration)..........: 1s
Concurrent (--load-concurrent).: 1
Max RunN per second (--max-rps): 1

Total..........................: 2
Succeeded......................: 2
Failed.........................: 0
Error rate.....................: 0%
RunN per second................: 2
Latency .......................: max=54.4ms min=16.0ms avg=35.2ms med=16.0ms p(90)=16.0ms p(99)=16.0ms

Error: (total > 10) is not true
total > 10
│
├── total => 2
└── 10

exit status 1
```