### PR TITLE
fix: Added support for using defer and force options with other runners.

### DIFF
--- a/book.go
+++ b/book.go
@@ -767,7 +767,7 @@ func validateRunnerKey(k string) error {
 	if k == includeRunnerKey || k == testRunnerKey || k == dumpRunnerKey || k == execRunnerKey || k == bindRunnerKey || k == runnerRunnerKey {
 		return fmt.Errorf("runner name %q is reserved for built-in runner", k)
 	}
-	if k == ifSectionKey || k == descSectionKey || k == loopSectionKey {
+	if k == ifSectionKey || k == descSectionKey || k == loopSectionKey || k == deferSectionKey || k == forceSectionKey {
 		return fmt.Errorf("runner name %q is reserved for built-in section", k)
 	}
 	return nil
@@ -781,7 +781,7 @@ func validateStepKeys(s map[string]any) error {
 	mainRunner := 0
 	subRunner := 0
 	for k := range s {
-		if k == ifSectionKey || k == descSectionKey || k == loopSectionKey {
+		if k == ifSectionKey || k == descSectionKey || k == loopSectionKey || k == deferSectionKey || k == forceSectionKey {
 			continue
 		}
 		if k == testRunnerKey || k == dumpRunnerKey || k == bindRunnerKey {


### PR DESCRIPTION
This PR fixes an issue where `defer` and `force` options could not be used in combination with other runners. 

Currently, the validation incorrectly rejects valid configurations that should be supported according to the documentation.

The following valid configuration results in a validation error:

```yaml
desc: Test for defer
steps:
  - desc: step 1
    test: len(steps) == 0

  - defer: true
    desc: defererd step a
    test: true
    exec:
      command: echo "deferred step a"

```

Error message:

```bash
./runn run testdata/book/defer.yml --debug --scopes run:exec                                                                                                                                                                                                             6s
Error: failed to load runbook testdata/book/defer.yml: invalid steps[1]. runners that cannot be running at the same time are specified: map[defer:%!s(bool=true) desc:defererd step a exec:map[command:echo "deferred step a"] test:%!s(bool=true)]
```