### PR TITLE
fix: line not found

### DIFF
--- a/runbook.go
+++ b/runbook.go
@@ -679,7 +679,7 @@ func pickStepYAML(in string, idx int) (string, error) {
 	end := step.End.Line
 	lines := strings.Split(in, "\n")
 	if len(lines) < end {
-		return "", fmt.Errorf("line not found: %d", end)
+		end = len(lines)
 	}
 	w := len(strconv.Itoa(end))
 	var picked []string


### PR DESCRIPTION
# Problem
In some cases, the parser registers more rows for the test than it actually occupies. Because of this, if this test is the last one in the file, runn crashes completely without displaying the test results.
This problem is most serious when splitting tests into different files (include), because one file causes all subsequent tests to crash.
# What changed
Instead of outputting an error about “line not found”, assign the end of the test to the end of the file.