### PR TITLE
fix(db): Support UUID type column of PostgreSQL in db query

### DIFF
--- a/db.go
+++ b/db.go
@@ -249,6 +249,8 @@ func (rnr *dbRunner) run(ctx context.Context, q *dbQuery, s *step) error {
 								return fmt.Errorf("invalid column: evaluated %s, but got %s(%v): %w", c, t, s, err)
 							}
 							row[c] = jsonColumn
+						case t == "UUID": // PostgreSQL UUID
+							row[c] = s
 						default: // MySQL: BOOLEAN = TINYINT
 							num, err := strconv.Atoi(s) //nostyle:repetition
 							if err != nil {


### PR DESCRIPTION
Thank you for developing such a wonderful tool 🙂 

## Changes

- **db.go**: Added `case t == "UUID": // PostgreSQL UUID` to handle UUID type explicitly

## Background

```yaml
runners:
  db: postgres://postgres:postgres@host.docker.internal:5432/postgres?sslmode=disable

steps:
  params:
    bind:
      id: faker.UUIDv7()
      name: faker.Name()

  test_users:
    db:
      query: |
        CREATE TABLE IF NOT EXISTS test_users (
          id UUID PRIMARY KEY,
          name VARCHAR(255) NOT NULL
        );

        INSERT INTO test_users (
          id,
          name
        ) VALUES (
          '{{ id }}',
          '{{ name }}'
        );

        SELECT * FROM test_users
        WHERE id = '{{ id }}';

```

When querying databases with UUID columns in PostgreSQL, runn would fail with the following error:

```
  Failure/Error: db query failed on "[No Description]".steps.test_users: invalid column: evaluated id, but got UUID(01980281-5ca2-72ec-a44f-1535536546fe): strconv.Atoi: parsing "01980281-5ca2-72ec-a44f-1535536546fe": invalid syntax
```

In PostgreSQL, UUID type values are converted to []byte type by the database driver.

After this change, UUID values are now properly handled as strings and the query executes successfully.

```bash
➜ docker run -it --rm -v "$(pwd)/.runn:/.runn" runn-local-slim run .runn/test.yaml --debug
Run "bind" on "[No Description]".steps.params

Run "db" on "[No Description]".steps.test_users
-----START QUERY-----
CREATE TABLE IF NOT EXISTS test_users (
  id UUID PRIMARY KEY,
  name VARCHAR(255) NOT NULL
);
-----END QUERY-----
-----START QUERY RESULT-----
rows affected: 0
-----END QUERY RESULT-----
-----START QUERY-----
INSERT INTO test_users (
  id,
  name
) VALUES (
  '01980289-7ea2-74c3-9fcf-d3d604544c39',
  'Raul Windler'
);
-----END QUERY-----
-----START QUERY RESULT-----
rows affected: 1
-----END QUERY RESULT-----
-----START QUERY-----
SELECT * FROM test_users
WHERE id = '01980289-7ea2-74c3-9fcf-d3d604544c39';
-----END QUERY-----
-----START QUERY RESULT-----
+--------------------------------------+--------------+
|                  id                  |     name     |
+--------------------------------------+--------------+
| 01980289-7ea2-74c3-9fcf-d3d604544c39 | Raul Windler |
+--------------------------------------+--------------+
(1 row)
-----END QUERY RESULT-----
.

1 scenario, 0 skipped, 0 failures
```



