### PR TITLE
chore(dockerfile): [Proposal] Add `curl` in Dockerfile image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
     && apt-get install -y fonts-noto-cjk \
     && apt-get install -y chromium \
     && apt-get install -y git \
+    && apt-get install -y curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Changes

- Install `curl` in Dockerfile

## Background

I would like to install curl in the Docker image for cases where I need to execute HTTP requests that are not supported by runn's functionality.

In my use case, I wanted to upload image data to a Cloud Storage Signed URL in the format like the below, but I couldn't figure out how to upload it as binary data.

```yaml
runners:
  gcs:
    endpoint: "https://storage.googleapis.com"

steps:
  upload_image:
    gcs:
      "{{ trimPrefix(signed_url, 'https://storage.googleapis.com') }}":
        put:
          headers:
            Content-Type: "image/jpeg"
          body:
            "application/octet-stream": "{{ image_data }}"  # <- I wanted to set binary data or read it from image file path.
```

I understand that I could install curl on top of the existing distributed container image, but it would be convenient if it were installed by default. I would appreciate it if this could be accepted if there is no problem.