### PR TITLE
Add support for enabling `--no-sandbox` through an environment variable

### DIFF
--- a/cdp.go
+++ b/cdp.go
@@ -60,7 +60,7 @@ func newCDPRunner(name, remote string) (*cdpRunner, error) {
 		)
 	}
 
-	if os.Getenv("RUNN_DISABLE_CHROMIUM_SANDBOX") != "" {
+	if os.Getenv("RUNN_DISABLE_CHROME_SANDBOX") != "" {
 		opts = append(opts, chromedp.Flag("no-sandbox", true))
 	}
 


### PR DESCRIPTION
To avoid requiring privileged mode when running Chrome (Chromium) in a container, this change allows the `--no-sandbox` flag to be set via ~~`RUNN_DISABLE_CHROMIUM_SANDBOX`~~ `RUNN_DISABLE_CHROME_SANDBOX` environment variable.