### PR TITLE
Add coverage and coverage-out flags to run command

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -23,7 +23,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -31,6 +30,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/goccy/go-json"
 	"github.com/k1LoW/donegroup"
 	"github.com/k1LoW/runn"
 	"github.com/k1LoW/runn/internal/fs"

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -23,6 +23,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -108,6 +109,20 @@ var runCmd = &cobra.Command{
 			}
 		}
 
+		if flgs.Coverage {
+			cov, err := o.CollectCoverage(ctx)
+			if err != nil {
+				return err
+			}
+			b, err := json.MarshalIndent(cov, "", "  ")
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(filepath.Clean(flgs.CoverageOut), b, os.ModePerm); err != nil { //nolint:gosec
+				return err
+			}
+		}
+
 		if r.HasFailure() {
 			os.Exit(1)
 		}
@@ -157,4 +172,6 @@ func init() {
 	runCmd.Flags().BoolVarP(&flgs.Verbose, "verbose", "", false, flgs.Usage("Verbose"))
 	runCmd.Flags().BoolVarP(&flgs.Attach, "attach", "", false, flgs.Usage("Attach"))
 	runCmd.Flags().BoolVarP(&flgs.ForceColor, "force-color", "", false, flgs.Usage("ForceColor"))
+	runCmd.Flags().BoolVarP(&flgs.Coverage, "coverage", "", false, flgs.Usage("Coverage"))
+	runCmd.Flags().StringVarP(&flgs.CoverageOut, "coverage-out", "", "runn.coverage.json", flgs.Usage("CoverageOut"))
 }

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -73,6 +73,8 @@ type Flags struct {
 	EnvFile         string   `usage:"load environment variables from a file"`
 	ForceColor      bool     `usage:"force colorized output even in non-tty output streams"`
 	Verbose         bool     `usage:"verbose"`
+	Coverage        bool     `usage:"coverage for OpenAPI spec and protocol buffers"`
+	CoverageOut     string   `usage:"coverage output path (JSON format)"`
 }
 
 func (f *Flags) ToOpts() ([]runn.Option, error) {


### PR DESCRIPTION
Thank you for always maintaining this great tool.

This PR closes #762 and adds support for the `--coverage` and `--coverage-out` flags in the `run` command.
