### PR TITLE
✨ Add configurable CDP timeout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1240,6 +1240,26 @@ steps:
       previous.text == 'Install the latest version of Go'
 ```
 
+#### CDP Configuration Options
+
+The CDP runner supports additional configuration options:
+
+``` yaml
+runners:
+  cc:
+    addr: chrome://new  # or cdp://new
+    timeout: 120sec     # Timeout for each CDP action (default: 60s)
+    flags:              # Chrome browser flags
+      headless: true
+      disable-gpu: true
+      no-sandbox: true
+```
+
+**Configuration parameters:**
+- `addr`: Chrome DevTools Protocol address. Use `chrome://new` or `cdp://new` to launch a new browser instance
+- `timeout`: Timeout duration for each CDP action/step (e.g., "30s", "2m", "1m30s"). Default is 60 seconds
+- `flags`: Chrome browser launch flags as key-value pairs
+
 See [testdata/book/cdp.yml](testdata/book/cdp.yml).
 
 #### Functions for action to control browser

--- a/cdp_timeout_test.go
+++ b/cdp_timeout_test.go
@@ -1,0 +1,208 @@
+package runn
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseCDPRunnerWithTimeout(t *testing.T) {
+	tests := []struct {
+		name          string
+		yamlConfig    string
+		wantTimeout   time.Duration
+		wantDetected  bool
+		wantErr       bool
+	}{
+		{
+			name: "valid timeout configuration",
+			yamlConfig: `
+addr: new
+timeout: 120s
+flags:
+  headless: true
+`,
+			wantTimeout:  120 * time.Second,
+			wantDetected: true,
+			wantErr:      false,
+		},
+		{
+			name: "timeout with minutes",
+			yamlConfig: `
+timeout: 2m
+`,
+			wantTimeout:  2 * time.Minute,
+			wantDetected: true,
+			wantErr:      false,
+		},
+		{
+			name: "timeout with complex duration",
+			yamlConfig: `
+timeout: 1m30s
+`,
+			wantTimeout:  90 * time.Second,
+			wantDetected: true,
+			wantErr:      false,
+		},
+		{
+			name: "no timeout specified - uses default",
+			yamlConfig: `
+addr: new
+flags:
+  headless: true
+`,
+			wantTimeout:  cdpTimeoutByStep, // default value
+			wantDetected: true,
+			wantErr:      false,
+		},
+		{
+			name: "invalid timeout format",
+			yamlConfig: `
+timeout: invalid
+`,
+			wantDetected: false,
+			wantErr:      true,
+		},
+		{
+			name:         "empty config - not detected as CDP runner",
+			yamlConfig:   ``,
+			wantDetected: false,
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bk := &book{
+				cdpRunners: map[string]*cdpRunner{},
+			}
+
+			detected, err := bk.parseCDPRunnerWithDetailed("test", []byte(tt.yamlConfig))
+
+			// Check error condition
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseCDPRunnerWithDetailed() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// Check detection
+			if detected != tt.wantDetected {
+				t.Errorf("parseCDPRunnerWithDetailed() detected = %v, want %v", detected, tt.wantDetected)
+				return
+			}
+
+			// If runner was created and no error, check timeout value
+			if tt.wantDetected && !tt.wantErr {
+				runner, ok := bk.cdpRunners["test"]
+				if !ok {
+					t.Error("CDP runner not found in book")
+					return
+				}
+				if runner.timeoutByStep != tt.wantTimeout {
+					t.Errorf("timeout = %v, want %v", runner.timeoutByStep, tt.wantTimeout)
+				}
+			}
+		})
+	}
+}
+
+func TestCDPTimeoutOption(t *testing.T) {
+	tests := []struct {
+		name        string
+		timeout     string
+		wantTimeout time.Duration
+		wantErr     bool
+	}{
+		{
+			name:        "valid timeout string",
+			timeout:     "30s",
+			wantTimeout: 30 * time.Second,
+			wantErr:     false,
+		},
+		{
+			name:        "timeout in minutes",
+			timeout:     "5m",
+			wantTimeout: 5 * time.Minute,
+			wantErr:     false,
+		},
+		{
+			name:        "empty timeout - use default",
+			timeout:     "",
+			wantTimeout: cdpTimeoutByStep,
+			wantErr:     false,
+		},
+		{
+			name:        "invalid timeout format",
+			timeout:     "invalid",
+			wantTimeout: 0,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := CDPTimeout(tt.timeout)
+			config := &cdpRunnerConfig{
+				Flags:  map[string]any{},
+				Remote: cdpNewKey,
+			}
+
+			err := opt(config)
+			if err != nil {
+				t.Errorf("CDPTimeout option returned error: %v", err)
+				return
+			}
+
+			if config.Timeout != tt.timeout {
+				t.Errorf("config.Timeout = %s, want %s", config.Timeout, tt.timeout)
+			}
+		})
+	}
+}
+
+func TestApplyCDPTimeout(t *testing.T) {
+	tests := []struct {
+		name        string
+		timeout     string
+		wantTimeout time.Duration
+		wantErr     bool
+	}{
+		{
+			name:        "valid timeout",
+			timeout:     "90s",
+			wantTimeout: 90 * time.Second,
+			wantErr:     false,
+		},
+		{
+			name:        "empty timeout - no change",
+			timeout:     "",
+			wantTimeout: cdpTimeoutByStep, // default remains unchanged
+			wantErr:     false,
+		},
+		{
+			name:        "invalid timeout format",
+			timeout:     "not-a-duration",
+			wantTimeout: cdpTimeoutByStep,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock CDP runner
+			runner := &cdpRunner{
+				timeoutByStep: cdpTimeoutByStep, // start with default
+			}
+
+			err := applyCDPTimeout(runner, tt.timeout)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("applyCDPTimeout() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && runner.timeoutByStep != tt.wantTimeout {
+				t.Errorf("timeoutByStep = %v, want %v", runner.timeoutByStep, tt.wantTimeout)
+			}
+		})
+	}
+}

--- a/option.go
+++ b/option.go
@@ -634,6 +634,10 @@ func CDPRunner(name string, opts ...cdpRunnerOption) Option {
 		if err != nil {
 			return err
 		}
+		// Apply timeout if specified
+		if err := applyCDPTimeout(r, c.Timeout); err != nil {
+			return err
+		}
 		for n, v := range c.Flags {
 			r.opts = append(r.opts, chromedp.Flag(n, v))
 		}

--- a/runner_option.go
+++ b/runner_option.go
@@ -85,9 +85,10 @@ type includeRunnerConfig struct {
 }
 
 type cdpRunnerConfig struct {
-	Addr   string         `yaml:"addr,omitempty"`
-	Flags  map[string]any `yaml:"flags,omitempty"`
-	Remote string         `yaml:"-"`
+	Addr    string         `yaml:"addr,omitempty"`
+	Flags   map[string]any `yaml:"flags,omitempty"`
+	Timeout string         `yaml:"timeout,omitempty"`
+	Remote  string         `yaml:"-"`
 }
 
 type httpRunnerOption func(*httpRunnerConfig) error
@@ -416,6 +417,16 @@ func LocalForward(l string) sshRunnerOption {
 func CDPFlag(flag string, tf any) cdpRunnerOption {
 	return func(c *cdpRunnerConfig) error {
 		c.Flags[flag] = tf
+		return nil
+	}
+}
+
+// CDPTimeout sets the timeout for each CDP step.
+// The timeout should be a valid duration string (e.g., "30s", "2m", "1m30s").
+// Default timeout is 60 seconds if not specified.
+func CDPTimeout(timeout string) cdpRunnerOption {
+	return func(c *cdpRunnerConfig) error {
+		c.Timeout = timeout
 		return nil
 	}
 }


### PR DESCRIPTION
- Add cdpTimeout configuration option in YAML files
- Enable timeout configuration for Chrome DevTools Protocol operations
- Fix CDP book parsing error for proper timeout handling
- Add comprehensive tests for CDP timeout functionality

This allows users to configure timeouts for CDP operations through the YAML configuration file, improving control over browser automation timeouts.

This is PR for https://github.com/k1LoW/runn/issues/1307 .