### PR TITLE
feat: support postgresql numeric column type

### DIFF
--- a/db.go
+++ b/db.go
@@ -230,7 +230,8 @@ func (rnr *dbRunner) run(ctx context.Context, q *dbQuery, s *step) error {
 						switch {
 						case strings.Contains(t, "TEXT") || strings.Contains(t, "CHAR") || t == "ENUM" || t == "TIME":
 							row[c] = s
-						case t == "DECIMAL" || t == "FLOAT" || t == "DOUBLE": // MySQL: NUMERIC = DECIMAL ( FLOAT, DOUBLE maybe not used )
+						// MySQL: NUMERIC is aliased to DECIMAL. PostgreSQL: DECIMAL is aliased to NUMERIC. ( FLOAT, DOUBLE maybe not used )
+						case t == "DECIMAL" || t == "NUMERIC" || t == "FLOAT" || t == "DOUBLE":
 							num, err := strconv.ParseFloat(s, 64) //nostyle:repetition
 							if err != nil {
 								return fmt.Errorf("invalid column: evaluated %s, but got %s(%v): %w", c, t, s, err)


### PR DESCRIPTION
Hello, thank you for maintaining such a great tool.

Recently, I encountered a situation that I want to handle postgresql `NUMERIC` type column.
This PR will fix this error.
```
 Failure/Error: db query failed on "Test fixed-point data types".steps[0]: invalid column: evaluated n_decimal, but got NUMERIC(1234.56789): strconv.Atoi: parsing "1234.56789": invalid syntax
```

# Suggested Feature
Support postgresql `NUMERIC` column type. It also support `DECIMAL`, which is aliased to `NUMERIC`.

# Minimal reproducible example

`init.sql`
```sql
CREATE TABLE IF NOT EXISTS "runn_test" (
    n_decimal DECIMAL(10,5) NOT NULL,
    n_numeric NUMERIC(10,5) NOT NULL
);

INSERT INTO "runn_test" (n_decimal, n_numeric) VALUES (1234.56789, 98765.4321);
```

`compose.yml`
```yaml
services:
  postgres:
    image: postgres:17-alpine
    container_name: runn-postgres
    environment:
      POSTGRES_DB: runn_test
      POSTGRES_USER: postgres
      POSTGRES_PASSWORD: password
    ports:
      - "127.0.0.1:5432:5432"
    volumes:
      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
```

`test_postgres.yml`
```yaml
desc: Test fixed-point data types
runners:
  db:
    dsn: postgres://postgres:password@localhost:5432/runn_test?sslmode=disable

steps:
  - db:
      query: SELECT * FROM runn_test
    test: |
      current.rows[0].n_decimal == 1234.56789
      && current.rows[0].n_numeric == 98765.4321
```


# Backward compatibility check for other supported DBs

`compose.yml` (`init_mysql.sql` is shown in following section)
```yaml
services:
  mysql:
    image: mysql:8.0
    container_name: runn-mysql
    environment:
      MYSQL_DATABASE: runn_test
      MYSQL_ROOT_PASSWORD: rootpassword
      MYSQL_USER: mysql
      MYSQL_PASSWORD: password
    ports:
      - "127.0.0.1:3306:3306"
    volumes:
      - ./init_mysql.sql:/docker-entrypoint-initdb.d/init.sql

  sqlite:
    image: alpine:3.22
    container_name: runn-sqlite
  
    command: sh -c "apk add --no-cache sqlite=3.49.2-r1 && sleep infinity"
    volumes:
      - ./data:/app/data

  spanner:
    image: gcr.io/cloud-spanner-emulator/emulator
    container_name: runn-spanner
    ports:
      - "9010:9010"
      - "9020:9020"
```

### MySQL

`init_mysql.sql`
```sql
CREATE TABLE IF NOT EXISTS `runn_test` (
    n_decimal DECIMAL(10,5) NOT NULL,
    n_numeric NUMERIC(10,5) NOT NULL
);

INSERT INTO `runn_test` (n_decimal, n_numeric) VALUES (1234.56789, 98765.4321);
```

`test_mysql.yml`
```yaml
desc: Test fixed-point data types (MySQL)
runners:
  db:
    dsn: mysql://root:rootpassword@localhost:3306/runn_test

steps:
  - db:
      query: SELECT * FROM `runn_test`
    test: |
      current.rows[0].n_decimal == 1234.56789
      && current.rows[0].n_numeric == 98765.4321
```

### SQLite3
`init_sqlite.sql`
```sql
CREATE TABLE users (
  id INTEGER PRIMARY KEY AUTOINCREMENT,
  n NUMERIC
);

INSERT INTO users (n) VALUES (1234.56789);
```

```bash
docker-compose exec -T sqlite sqlite3 /app/data/database.db < init_sqlite.sql
```

`test_sqlite.yml`
```yaml
desc: Test fixed-point data types (SQLite3)
runners:
  db:
    dsn: sqlite://./data/database.db
steps:
  -
    desc: Verify both records exist with correct NUMERIC values
    db:
      query: |
        SELECT id, n FROM users ORDER BY id;
    test: |
      current.rows[0].n == 1234.56789
  
```

### Cloud Spanner
```bash
gcloud config configurations create runn-emulator
gcloud config set auth/disable_credentials true
gcloud config set project runn-test-project
gcloud config set api_endpoint_overrides/spanner http://localhost:9020/

gcloud spanner instances create runn-test-instance --config=emulator-config --description="Test Instance" --nodes=1
gcloud spanner databases create test-db  --instance=runn-test-instance    
gcloud spanner databases ddl update test-db --instance=runn-test-instance --ddl="CREATE TABLE numeric_test (n NUMERIC NOT NULL) PRIMARY KEY (n);" 
gcloud spanner rows insert --instance=runn-test-instance --database=test-db --table=numeric_test --data=n=1234.56789
```

`test_spanner.yml`


(run with envirionment variable set. `SPANNER_EMULATOR_HOST=localhost:9010 runn run test_spanner.yml`)
```yaml
desc: Test fixed-point data types (Cloud Spanner)
runners:
  db:
    dsn: spanner://runn-test-project/runn-test-instance/test-db
steps:  
# Unfortunately, I couldn't figure out how to test its value directly, but no error occurs when handling query results
  - db:
      query: SELECT n FROM numeric_test
# possible workaround
  - db:
      query: SELECT CAST(n AS STRING) as n_string FROM numeric_test
    test: current.rows[0].n_string == "1234.56789"
```