### PR TITLE
fix: parsing errors in the response body should not be treated as runner failures.

### DIFF
--- a/http.go
+++ b/http.go
@@ -519,7 +519,7 @@ func (rnr *httpRunner) run(ctx context.Context, r *httpRequest, s *step) error {
 		return fmt.Errorf("invalid http runner: %s", rnr.name)
 	}
 
-	var resError error
+	var resError error //nostyle:repetition
 	o.capturers.captureHTTPResponse(rnr.name, res)
 
 	if err := rnr.validator.ValidateResponse(ctx, req, res); err != nil {
@@ -534,6 +534,7 @@ func (rnr *httpRunner) run(ctx context.Context, r *httpRequest, s *step) error {
 
 	resBody, err := readPlainBody(res)
 	if err != nil {
+		o.Debugf("Failed to read response body: %s", err.Error())
 		resError = errors.Join(resError, fmt.Errorf("failed to read response body: %w", err))
 	}
 
@@ -542,6 +543,7 @@ func (rnr *httpRunner) run(ctx context.Context, r *httpRequest, s *step) error {
 	if strings.Contains(res.Header.Get("Content-Type"), "json") && len(resBody) > 0 {
 		var b any
 		if err := json.Unmarshal(resBody, &b); err != nil {
+			o.Debugf("Failed to unmarshal response body: %s", err.Error())
 			resError = errors.Join(resError, fmt.Errorf("failed to unmarshal response body: %w", err))
 		}
 		d[httpStoreBodyKey] = b

--- a/operator.go
+++ b/operator.go
@@ -36,6 +36,11 @@ import (
 	"github.com/spf13/cast"
 )
 
+const (
+	// runnerStoreErrorKey includes errors that do not clearly prevent execution from proceeding.
+	runnerStoreErrorKey = "error"
+)
+
 var errStepSkipped = errors.New("step skipped")
 var ErrFailFast = errors.New("fail fast")
 


### PR DESCRIPTION
This pull request improves error handling in the HTTP runner by capturing non-critical errors encountered during response validation and processing, rather than immediately halting execution. These errors are now stored in the step's result for later inspection, making the runner more robust and debuggable.

**Error handling improvements:**

* Introduced a new constant `runnerStoreErrorKey` to store non-critical errors encountered during HTTP request execution.
* Modified the `run` method in `http.go` to collect errors related to unsupported response formats, failed response body reads, and failed JSON unmarshalling into a single `resError` variable instead of returning early.
* Recorded the collected `resError` in the step's result map under the new `runnerStoreErrorKey`, allowing errors to be inspected after execution without stopping the runner.