### PR TITLE
fix: remove redundant path validation in mergeURL

### DIFF
--- a/http.go
+++ b/http.go
@@ -580,9 +580,6 @@ func (rnr *httpRunner) run(ctx context.Context, r *httpRequest, s *step) error {
 }
 
 func mergeURL(u *url.URL, p string) (*url.URL, error) {
-	if !strings.HasPrefix(p, "/") {
-		return nil, fmt.Errorf("invalid path: %s", p)
-	}
 	a, err := url.Parse(p)
 	if err != nil {
 		return nil, err

--- a/http_test.go
+++ b/http_test.go
@@ -527,6 +527,9 @@ func TestMergeURL(t *testing.T) {
 		{"https://example.com", "/api/users/", "https://example.com/api/users/"},
 		{"https://example.com/", "/anything/test/", "https://example.com/anything/test/"},
 		{"https://example.com/api", "/users", "https://example.com/api/users"},
+		{"https://example.com/api/v1", "users/", "https://example.com/api/v1/users/"},
+		{"https://example.com/api/v1", "users", "https://example.com/api/v1/users"},
+		{"https://example.com/api/v1", "", "https://example.com/api/v1"},
 	}
 	for _, tt := range tests {
 		u, err := url.Parse(tt.endpoint)

--- a/testdata/book/custom_runner_gqlreq.yml
+++ b/testdata/book/custom_runner_gqlreq.yml
@@ -10,7 +10,7 @@ if: included
 steps:
   -
     req:
-      /:
+      '':
         post:
           headers: '{{ vars.headers }}'
           body:            

--- a/testutil/http.go
+++ b/testutil/http.go
@@ -88,15 +88,13 @@ func setRoutes(r *httpstub.Router) {
 	r.Method(http.MethodPost).Path("/users").Response(http.StatusCreated, nil)
 	r.Method(http.MethodPost).Path("/users/").Response(http.StatusCreated, nil)
 	r.Method(http.MethodPost).Path("/help").Response(http.StatusCreated, nil)
-	graphqlHandler := func(w http.ResponseWriter, r *http.Request) {
+	r.Method(http.MethodPost).Path("/graphql").Header("Content-Type", "application/json").Handler(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		b, _ := io.ReadAll(r.Body)
 		h, _ := json.Marshal(r.Header)
 		fmt.Fprintf(w, `{"data":{"request":%s,"headers":%s}}`, string(b), string(h))
-	}
-	r.Method(http.MethodPost).Path("/graphql").Header("Content-Type", "application/json").Handler(graphqlHandler)
-	r.Method(http.MethodPost).Path("/graphql/").Header("Content-Type", "application/json").Handler(graphqlHandler)
+	})
 	r.Method(http.MethodGet).Path("/users/1").Header("Content-Type", "application/json").ResponseString(http.StatusOK, `{"data":{"username":"alice"}}`)
 	r.Method(http.MethodGet).Path("/users").Header("Content-Type", "application/json").ResponseString(http.StatusOK, `[{"username":"alice"}, {"username":"bob"}]`)
 	r.Method(http.MethodGet).Path("/private").Match(func(r *http.Request) bool {


### PR DESCRIPTION
This pull request improves the handling of URL paths in HTTP requests, allowing for more flexible path inputs and better test coverage. The main change is the removal of a restriction requiring paths to start with a slash, which enables support for empty and relative paths. Related tests and stubs have been updated to reflect this new behavior.

**URL path handling improvements:**

* Removed the check in `mergeURL` that required the path to start with `/`, allowing for empty and relative paths when merging URLs (`http.go`).
* Expanded test cases in `TestMergeURL` to cover scenarios with empty strings and relative paths, ensuring the new behavior is properly validated (`http_test.go`).
* Updated test data to use an empty string for the request path, aligning with the new path handling (`testdata/book/custom_runner_gqlreq.yml`).

**Test utility adjustments:**

* Refactored the GraphQL handler setup in the HTTP test router for improved clarity and consistency, consolidating handler definitions (`testutil/http.go`).