### PR TITLE
fix: make retry on runner errors (e.g. connection refused) instead of failing immediately on `loop:` in steps

### DIFF
--- a/cdp.go
+++ b/cdp.go
@@ -144,7 +144,7 @@ func (rnr *cdpRunner) run(ctx context.Context, cas CDPActions, s *step) error {
 			}
 			return rnr.Renew()
 		}); err != nil {
-			return err
+			return newErrUnrecoverable(err)
 		}
 	}
 	o.capturers.captureCDPStart(rnr.name)
@@ -173,7 +173,7 @@ func (rnr *cdpRunner) run(ctx context.Context, cas CDPActions, s *step) error {
 		o.capturers.captureCDPAction(ca)
 		k, fn, err := findCDPFn(ca.Fn)
 		if err != nil {
-			return fmt.Errorf("actions[%d] error: %w", i, err)
+			return newErrUnrecoverable(fmt.Errorf("actions[%d] error: %w", i, err))
 		}
 		if k == "tabTo" {
 			infos, err := chromedp.Targets(rnr.ctx)

--- a/db.go
+++ b/db.go
@@ -165,7 +165,7 @@ func (rnr *dbRunner) run(ctx context.Context, q *dbQuery, s *step) error {
 	}
 	tc, err := q.generateTraceStmtComment(s)
 	if err != nil {
-		return err
+		return newErrUnrecoverable(err)
 	}
 	for _, stmt := range stmts {
 		stmt = stmt + tc // add trace comment
@@ -234,20 +234,20 @@ func (rnr *dbRunner) run(ctx context.Context, q *dbQuery, s *step) error {
 						case t == "DECIMAL" || t == "NUMERIC" || t == "FLOAT" || t == "DOUBLE":
 							num, err := strconv.ParseFloat(s, 64) //nostyle:repetition
 							if err != nil {
-								return fmt.Errorf("invalid column: evaluated %s, but got %s(%v): %w", c, t, s, err)
+								return newErrUnrecoverable(fmt.Errorf("invalid column: evaluated %s, but got %s(%v): %w", c, t, s, err))
 							}
 							row[c] = num
 						case t == "DATE" || t == "TIMESTAMP" || t == "DATETIME": // MySQL(SSH port fowarding)
 							d, err := dateparse.ParseStrict(s)
 							if err != nil {
-								return fmt.Errorf("invalid column: evaluated %s, but got %s(%v): %w", c, t, s, err)
+								return newErrUnrecoverable(fmt.Errorf("invalid column: evaluated %s, but got %s(%v): %w", c, t, s, err))
 							}
 							row[c] = d
 						case t == "JSONB": // PostgreSQL JSONB
 							var jsonColumn map[string]any
 							err = json.Unmarshal(v, &jsonColumn)
 							if err != nil {
-								return fmt.Errorf("invalid column: evaluated %s, but got %s(%v): %w", c, t, s, err)
+								return newErrUnrecoverable(fmt.Errorf("invalid column: evaluated %s, but got %s(%v): %w", c, t, s, err))
 							}
 							row[c] = jsonColumn
 						case t == "UUID": // PostgreSQL UUID
@@ -255,7 +255,7 @@ func (rnr *dbRunner) run(ctx context.Context, q *dbQuery, s *step) error {
 						default: // MySQL: BOOLEAN = TINYINT
 							num, err := strconv.Atoi(s) //nostyle:repetition
 							if err != nil {
-								return fmt.Errorf("invalid column: evaluated %s, but got %s(%v): %w", c, t, s, err)
+								return newErrUnrecoverable(fmt.Errorf("invalid column: evaluated %s, but got %s(%v): %w", c, t, s, err))
 							}
 							row[c] = num
 						}
@@ -265,7 +265,7 @@ func (rnr *dbRunner) run(ctx context.Context, q *dbQuery, s *step) error {
 							var jsonColumn map[string]any
 							err = json.Unmarshal([]byte(v), &jsonColumn)
 							if err != nil {
-								return fmt.Errorf("invalid column: evaluated %s, but got %s(%v): %w", c, t, v, err)
+								return newErrUnrecoverable(fmt.Errorf("invalid column: evaluated %s, but got %s(%v): %w", c, t, v, err))
 							}
 							row[c] = jsonColumn
 						default:
@@ -275,7 +275,7 @@ func (rnr *dbRunner) run(ctx context.Context, q *dbQuery, s *step) error {
 						s := strconv.FormatFloat(float64(v), 'f', -1, 32)
 						num, err := strconv.ParseFloat(s, 64) //nostyle:repetition
 						if err != nil {
-							return fmt.Errorf("invalid column: evaluated %s, but got %s(%v): %w", c, t, v, err)
+							return newErrUnrecoverable(fmt.Errorf("invalid column: evaluated %s, but got %s(%v): %w", c, t, v, err))
 						}
 						row[c] = num
 					case float64: // MySQL: DOUBLE

--- a/dump.go
+++ b/dump.go
@@ -89,7 +89,12 @@ func (rnr *dumpRunner) Run(ctx context.Context, s *step, first bool) error {
 	return nil
 }
 
-func (rnr *dumpRunner) run(_ context.Context, out io.Writer, v any, disableNL bool, s *step, first bool) error {
+func (rnr *dumpRunner) run(_ context.Context, out io.Writer, v any, disableNL bool, s *step, first bool) (err error) {
+	defer func() {
+		if err != nil {
+			err = newErrUnrecoverable(err)
+		}
+	}()
 	o := s.parent
 	switch vv := v.(type) {
 	case string:

--- a/errors.go
+++ b/errors.go
@@ -21,3 +21,13 @@ func (e *AfterFuncError) Unwrap() error { return e.err }
 func newAfterFuncError(err error) *AfterFuncError {
 	return &AfterFuncError{err: err}
 }
+
+type ErrUnrecoverable struct{ err error }
+
+func (e *ErrUnrecoverable) Error() string { return e.err.Error() }
+
+func (e *ErrUnrecoverable) Unwrap() error { return e.err }
+
+func newErrUnrecoverable(err error) *ErrUnrecoverable {
+	return &ErrUnrecoverable{err: err}
+}

--- a/exec.go
+++ b/exec.go
@@ -78,11 +78,11 @@ func (rnr *execRunner) run(ctx context.Context, c *execCommand, s *step) error {
 	}
 	o.capturers.captureExecCommand(c.command, c.shell, c.background)
 	if !strings.Contains(c.shell, "{0}") {
-		return fmt.Errorf("invalid shell setting. custom shell option requires `{0}`.: %q", c.shell)
+		return newErrUnrecoverable(fmt.Errorf("invalid shell setting. custom shell option requires `{0}`.: %q", c.shell))
 	}
 	shWithOpts, err := shellwords.Parse(c.shell)
 	if err != nil {
-		return nil
+		return newErrUnrecoverable(fmt.Errorf("failed to parse shell options: %w", err))
 	}
 	for i := range shWithOpts {
 		shWithOpts[i] = strings.Replace(shWithOpts[i], "{0}", c.command, 1)
@@ -96,7 +96,7 @@ func (rnr *execRunner) run(ctx context.Context, c *execCommand, s *step) error {
 		// fallback to sh
 		fallback, errr := safeexec.LookPath("sh")
 		if errr != nil {
-			return err
+			return newErrUnrecoverable(err)
 		}
 		sh = fallback
 	}

--- a/include.go
+++ b/include.go
@@ -171,7 +171,7 @@ func (rnr *includeRunner) run(ctx context.Context, oo *operator, s *step) error 
 	ops := oo.toOperatorN()
 	sorted, err := sortWithNeeds(ops.ops)
 	if err != nil {
-		return err
+		return newErrUnrecoverable(err)
 	}
 	// Filter already runned runbooks
 	var filtered []*operator
@@ -208,7 +208,7 @@ func (o *operator) newNestedOperator(parent *step, opts ...Option) (*operator, e
 	opts = append(popts, opts...)
 	oo, err := New(opts...)
 	if err != nil {
-		return nil, err
+		return nil, newErrUnrecoverable(err)
 	}
 	// Nested operatorN do not inherit beforeFuncs/afterFuncs
 	oo.t = o.thisT

--- a/ssh.go
+++ b/ssh.go
@@ -238,7 +238,7 @@ func (rnr *sshRunner) run(ctx context.Context, c *sshCommand, s *step) error {
 				}
 				return rnr.Renew()
 			}); err != nil {
-				return err
+				return newErrUnrecoverable(err)
 			}
 		}
 	}
@@ -252,7 +252,7 @@ func (rnr *sshRunner) run(ctx context.Context, c *sshCommand, s *step) error {
 	stderr := ""
 
 	if _, err := fmt.Fprintf(rnr.stdin, "%s\n", strings.TrimRight(c.command, "\n")); err != nil {
-		return err
+		return newErrUnrecoverable(err)
 	}
 
 	timer := time.NewTimer(0)

--- a/test.go
+++ b/test.go
@@ -59,12 +59,12 @@ func (rnr *testRunner) run(_ context.Context, cond string, sm exprtrace.EvalEnv,
 	o := s.parent
 	tf, err := expr.EvalWithTrace(cond, sm)
 	if err != nil {
-		return err
+		return newErrUnrecoverable(err)
 	}
 	if !tf.OutputAsBool() {
 		t, err := tf.FormatTraceTree()
 		if err != nil {
-			return err
+			return newErrUnrecoverable(err)
 		}
 		return newCondFalseError(cond, t)
 	}


### PR DESCRIPTION
Fix: https://github.com/k1LoW/runn/issues/1303

This pull request introduces a new error type, `ErrUnrecoverable`, to standardize the handling of unrecoverable errors across multiple runner implementations. The main focus is to ensure that certain errors are consistently wrapped and can be identified and handled as unrecoverable throughout the codebase. This improves error propagation and allows for more robust error handling, especially in looping and orchestration logic.

Key changes include:

**Core error handling improvements:**

* Added a new error type, `ErrUnrecoverable`, and helper constructor `newErrUnrecoverable` in `errors.go` to encapsulate unrecoverable errors.
* Updated all runner implementations (`cdpRunner`, `dbRunner`, `dumpRunner`, `execRunner`, `httpRunner`, `includeRunner`, `sshRunner`, `testRunner`) to wrap relevant errors with `newErrUnrecoverable`, ensuring consistent error propagation. [[1]](diffhunk://#diff-75375af7b025d6a6715e190945260e43d68f031373febe19ce3e5ba2467fe01bL147-R147) [[2]](diffhunk://#diff-75375af7b025d6a6715e190945260e43d68f031373febe19ce3e5ba2467fe01bL176-R176) [[3]](diffhunk://#diff-ac94c91f8ea84762d55b6932ef1466a2165984591d3e646360c5bb31b2130900L168-R168) [[4]](diffhunk://#diff-ac94c91f8ea84762d55b6932ef1466a2165984591d3e646360c5bb31b2130900L237-R258) [[5]](diffhunk://#diff-ac94c91f8ea84762d55b6932ef1466a2165984591d3e646360c5bb31b2130900L268-R268) [[6]](diffhunk://#diff-ac94c91f8ea84762d55b6932ef1466a2165984591d3e646360c5bb31b2130900L278-R278) [[7]](diffhunk://#diff-7e208a132876ae1bd6e4709fb93c4a5710e91335c1ed5926a423cc57d63c9cbdL92-R97) [[8]](diffhunk://#diff-5dbc24f000f25dbb39d02206d7efaac855fe1766eb4970b721f6ac18efdb1cc7L81-R85) [[9]](diffhunk://#diff-5dbc24f000f25dbb39d02206d7efaac855fe1766eb4970b721f6ac18efdb1cc7L99-R99) [[10]](diffhunk://#diff-6971e2713fe98b79ea18e9748bf68928f6ebcd4d93e7a27f10e7472ce6d78a48L409-R409) [[11]](diffhunk://#diff-6971e2713fe98b79ea18e9748bf68928f6ebcd4d93e7a27f10e7472ce6d78a48L421-R421) [[12]](diffhunk://#diff-6971e2713fe98b79ea18e9748bf68928f6ebcd4d93e7a27f10e7472ce6d78a48L442-R468) [[13]](diffhunk://#diff-6a166587768a9bf684d77ea762110449a32ebf9c3e2f0bcaadfacaeff08d5337L174-R174) [[14]](diffhunk://#diff-6a166587768a9bf684d77ea762110449a32ebf9c3e2f0bcaadfacaeff08d5337L211-R211) [[15]](diffhunk://#diff-2705f40b61c6c903a22ce3c907292f8a75812055a41e0d22c292026d909a4465L241-R241) [[16]](diffhunk://#diff-2705f40b61c6c903a22ce3c907292f8a75812055a41e0d22c292026d909a4465L255-R255) [[17]](diffhunk://#diff-7b4ebd72afff2f875fc36a078155ef095d624c0653f9cfa724513f69e8d51b4bL62-R67)

**Operator loop and orchestration logic:**

* Enhanced the loop error-handling logic in `operator.go` to detect and immediately return on unrecoverable errors, while aggregating and reporting other errors after all loop iterations. [[1]](diffhunk://#diff-5063501a84242fcc60e366cd9998632d2f48cd7838a1c58d6b7167c965986600R342-R343) [[2]](diffhunk://#diff-5063501a84242fcc60e366cd9998632d2f48cd7838a1c58d6b7167c965986600R358-L365) [[3]](diffhunk://#diff-5063501a84242fcc60e366cd9998632d2f48cd7838a1c58d6b7167c965986600R400) [[4]](diffhunk://#diff-5063501a84242fcc60e366cd9998632d2f48cd7838a1c58d6b7167c965986600R409-R416)
* Minor cleanup in the orchestration logic for running multiple operators.

These changes make error handling more predictable and maintainable, especially for complex workflows involving loops and nested operations.