### PR TITLE
fix: keep track of the step index and display the corresponding rows.

### DIFF
--- a/result.go
+++ b/result.go
@@ -42,6 +42,7 @@ type RunResult struct {
 // StepResult is the result of a step run.
 type StepResult struct {
 	ID                 string        // Runbook ID
+	Index              int           // Index of step
 	Key                string        // Key of step
 	Desc               string        // Description of step
 	Skipped            bool          // Whether step run was skipped or not
@@ -228,14 +229,14 @@ func failedRunbookPathsAndErrors(rr *RunResult) ([][]string, []int, []error) {
 	if rr.Err == nil {
 		return paths, indexes, errs
 	}
-	for i, sr := range rr.StepResults {
+	for _, sr := range rr.StepResults {
 		if sr.Err == nil {
 			continue
 		}
 		if len(sr.IncludedRunResults) == 0 {
 			paths = append(paths, []string{rr.Path})
 			errs = append(errs, sr.Err)
-			indexes = append(indexes, i)
+			indexes = append(indexes, sr.Index)
 			continue
 		}
 		for _, ir := range sr.IncludedRunResults {

--- a/step.go
+++ b/step.go
@@ -139,10 +139,10 @@ func (s *step) setResult(err error) {
 		runResults = s.includeRunner.runResults
 	}
 	if errors.Is(errStepSkipped, err) {
-		s.result = &StepResult{ID: s.runbookID(), Key: s.key, Desc: s.desc, Skipped: true, Err: nil, IncludedRunResults: runResults}
+		s.result = &StepResult{ID: s.runbookID(), Index: s.idx, Key: s.key, Desc: s.desc, Skipped: true, Err: nil, IncludedRunResults: runResults}
 		return
 	}
-	s.result = &StepResult{ID: s.runbookID(), Key: s.key, Desc: s.desc, Skipped: false, Err: err, IncludedRunResults: runResults}
+	s.result = &StepResult{ID: s.runbookID(), Index: s.idx, Key: s.key, Desc: s.desc, Skipped: false, Err: err, IncludedRunResults: runResults}
 }
 
 func (s *step) clearResult() {


### PR DESCRIPTION
Fix: https://github.com/k1LoW/runn/issues/1325

This pull request updates the way step indices are tracked and referenced in runbook execution results. The main change is to explicitly include the step index in the `StepResult` struct and to use this index when reporting failed steps, improving the accuracy and clarity of error reporting.

**Step result struct and error reporting improvements:**

* Added a new `Index` field to the `StepResult` struct in `result.go` to explicitly track the index of each step.
* Updated the `setResult` method in `step.go` to set the `Index` field when creating `StepResult` instances, ensuring step indices are always recorded.
* Modified the `failedRunbookPathsAndErrors` function in `result.go` to use the new `Index` field from `StepResult` instead of relying on the loop index, making error reporting more robust and accurate.