### PR TITLE
feat: enhance curl command handling with file uploads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/k0kubun/pp/v3 v3.5.0
 	github.com/k1LoW/bufresolv v0.7.9
 	github.com/k1LoW/concgroup v1.1.2
-	github.com/k1LoW/curlreq v0.3.3
+	github.com/k1LoW/curlreq v0.4.0
 	github.com/k1LoW/donegroup v1.10.2
 	github.com/k1LoW/duration v1.2.0
 	github.com/k1LoW/exec v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -1031,8 +1031,8 @@ github.com/k1LoW/bufresolv v0.7.9 h1:E1cd7z9xYtVa6Cg5VczA36Dica0/s1rBVtZfqR0brTU
 github.com/k1LoW/bufresolv v0.7.9/go.mod h1:m7HRk2zRXpWcDxyhDUKFQvtzFglku+XkrULZ36v2V4Q=
 github.com/k1LoW/concgroup v1.1.2 h1:h+rGuaRZnCYkMGCwFurawWIyaDNy6y0qm5RqhqlOHn8=
 github.com/k1LoW/concgroup v1.1.2/go.mod h1:Ac6DMp6S8ksaY54MwH5upf1CB6Q1iIhr3p6OLiOJB0o=
-github.com/k1LoW/curlreq v0.3.3 h1:ycHRTnphAq3vWZU49EdmXYYuF1AGkJBY5MQADvE7Ezo=
-github.com/k1LoW/curlreq v0.3.3/go.mod h1:kh0wTrg3kahGoGnAREXK5gYOcTXW7W/TnL8qbHe5Ppc=
+github.com/k1LoW/curlreq v0.4.0 h1:uLh39FPD5mBqfM7xwMRCq7/f0J9kLxbE1kSwJxlqWhk=
+github.com/k1LoW/curlreq v0.4.0/go.mod h1:Pkem8UZgh7cOghH7+9gUBkiXdMHWjSvuwfTbN0jvJKo=
 github.com/k1LoW/donegroup v1.10.2 h1:T3XWToJqsT9Gr+WBnxKV8FupE6x7LL0UsfMiYJrD8WA=
 github.com/k1LoW/donegroup v1.10.2/go.mod h1:I/s+pK8/noQoE7lY3ecYwhXOBvcKGYOBeKtSBlM6IXk=
 github.com/k1LoW/duration v1.2.0 h1:qq1gWtPh7YROFyerBufVP+ATR11mOOHDInrcC/Xe/6A=

--- a/runbook_test.go
+++ b/runbook_test.go
@@ -65,6 +65,7 @@ func TestAppendStep(t *testing.T) {
 		ins  [][]string
 	}{
 		{"curl_command", [][]string{{"curl", "https://example.com/path/to/index?foo=bar&baz=qux", "-XPOST", "-H", "Content-Type: application/json", "-d", `{"username": "alice"}`}}},
+		{"curl_command_with_file", [][]string{{"curl", "https://example.com/path/to/api", "-XPOST", "-H", "Content-Type: application/json", "-d", "@testdata/test.json"}}},
 		{"grpc_command", [][]string{{"grpcurl", "-d", `{"id": 1234, "tags": ["foo","bar"]}`, "grpc.server.com:443", "my.custom.server.Service/Method"}}},
 		{"exec_command", [][]string{{"echo", "hello", "world"}}},
 		{"multiple_http_runner", [][]string{
@@ -115,130 +116,6 @@ func TestAppendStep(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestExpandCurlDataFiles(t *testing.T) {
-	t.Parallel()
-
-	type testCase struct {
-		name  string
-		build func(path string) []string
-		want  func(content string) []string
-	}
-
-	cases := []testCase{
-		{
-			name: "short_parameter_d",
-			build: func(path string) []string {
-				return []string{"curl", "-d", "@" + path, "https://example.com"}
-			},
-			want: func(content string) []string {
-				return []string{"curl", "-d", content, "https://example.com"}
-			},
-		},
-		{
-			name: "short_parameter_d_inline",
-			build: func(path string) []string {
-				return []string{"curl", "-d@" + path, "https://example.com"}
-			},
-			want: func(content string) []string {
-				return []string{"curl", "-d", content, "https://example.com"}
-			},
-		},
-		{
-			name: "long_parameter_data_with_space",
-			build: func(path string) []string {
-				return []string{"curl", "--data", "@" + path, "https://example.com"}
-			},
-			want: func(content string) []string {
-				return []string{"curl", "--data", content, "https://example.com"}
-			},
-		},
-		{
-			name: "long_parameter_data_inline",
-			build: func(path string) []string {
-				return []string{"curl", "--data=@" + path, "https://example.com"}
-			},
-			want: func(content string) []string {
-				return []string{"curl", "--data", content, "https://example.com"}
-			},
-		},
-		{
-			name: "long_parameter_data_ascii_with_space",
-			build: func(path string) []string {
-				return []string{"curl", "--data-ascii", "@" + path, "https://example.com"}
-			},
-			want: func(content string) []string {
-				return []string{"curl", "--data-ascii", content, "https://example.com"}
-			},
-		},
-		{
-			name: "long_parameter_data_ascii_inline",
-			build: func(path string) []string {
-				return []string{"curl", "--data-ascii=@" + path, "https://example.com"}
-			},
-			want: func(content string) []string {
-				return []string{"curl", "--data-ascii", content, "https://example.com"}
-			},
-		},
-		{
-			name: "long_parameter_data_binary_with_space",
-			build: func(path string) []string {
-				return []string{"curl", "--data-binary", "@" + path, "https://example.com"}
-			},
-			want: func(content string) []string {
-				return []string{"curl", "--data-binary", content, "https://example.com"}
-			},
-		},
-		{
-			name: "long_parameter_data_binary_inline",
-			build: func(path string) []string {
-				return []string{"curl", "--data-binary=@" + path, "https://example.com"}
-			},
-			want: func(content string) []string {
-				return []string{"curl", "--data-binary", content, "https://example.com"}
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			dir := t.TempDir()
-			path := filepath.Join(dir, "payload.json")
-			content := `{"message":"hello"}`
-			if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-				t.Fatalf("failed to write temp file: %v", err)
-			}
-
-			in := tc.build(path)
-			before := append([]string(nil), in...)
-
-			out, err := expandCurlDataFiles(in)
-			if err != nil {
-				t.Fatalf("expandCurlDataFiles returned error: %v", err)
-			}
-
-			want := tc.want(content)
-			if diff := cmp.Diff(want, out); diff != "" {
-				t.Fatalf("unexpected args (-want +got):\n%s", diff)
-			}
-
-			if diff := cmp.Diff(before, in); diff != "" {
-				t.Fatalf("input slice must remain untouched (-want +got):\n%s", diff)
-			}
-		})
-	}
-
-	t.Run("missing_file_returns_error", func(t *testing.T) {
-		t.Parallel()
-
-		in := []string{"curl", "-d", "@does-not-exist", "https://example.com"}
-		if _, err := expandCurlDataFiles(in); err == nil {
-			t.Fatal("expected error for missing file, got nil")
-		}
-	})
 }
 
 func TestDetectRunbookAreas(t *testing.T) {

--- a/testdata/curl_command_with_file.append_step.golden
+++ b/testdata/curl_command_with_file.append_step.golden
@@ -1,0 +1,11 @@
+desc: curl_command_with_file
+runners:
+  req: https://example.com
+steps:
+- req:
+    /path/to/api:
+      post:
+        body:
+          application/json:
+            email: alice@example.com
+            username: alice

--- a/testdata/test.json
+++ b/testdata/test.json
@@ -1,0 +1,1 @@
+{"username": "alice", "email": "alice@example.com"}


### PR DESCRIPTION
This pull request updates how `curl` command parsing is handled in the `runbook` package, specifically improving support for file uploads in curl data arguments. The main change is the removal of custom logic for expanding curl data files in favor of a new approach provided by an updated dependency. Additionally, the code now supports specifying a working directory for curl file uploads, and related tests and test data have been updated accordingly.

**Curl command parsing and file upload improvements:**

* Replaced the custom `expandCurlDataFiles` function with the new `curlreq.Parser` (from the updated `github.com/k1LoW/curlreq` v0.4.0), which now handles file expansion for curl data arguments. This simplifies the code and leverages upstream improvements. (`runbook.go`, `go.mod`) [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L40-R40) [[2]](diffhunk://#diff-d415eb7fc8be6c9827fb8674a85e9f0623e5536bdd801f1afb4f4001cbb0d40aL262-R271) [[3]](diffhunk://#diff-d415eb7fc8be6c9827fb8674a85e9f0623e5536bdd801f1afb4f4001cbb0d40aL282-L348)
* Added a `wd` (working directory) field to the `runbook` struct and set its default to `"."` to support specifying the working directory for curl file uploads, which is now passed to the parser. (`runbook.go`) [[1]](diffhunk://#diff-d415eb7fc8be6c9827fb8674a85e9f0623e5536bdd801f1afb4f4001cbb0d40aR60) [[2]](diffhunk://#diff-d415eb7fc8be6c9827fb8674a85e9f0623e5536bdd801f1afb4f4001cbb0d40aR105)

**Testing updates:**

* Added a new test case for a curl command with a file upload and corresponding golden file and test data. (`runbook_test.go`, `testdata/curl_command_with_file.append_step.golden`, `testdata/test.json`) [[1]](diffhunk://#diff-be0d98098e62fe3a27ed809dde6f70f361419a01af8c21ae91379fa1d1e316a8R68) [[2]](diffhunk://#diff-a38e3070193890bd23d6bf5853dc2cd284fe46bea414ac49f75630de9ace4906R1-R11) [[3]](diffhunk://#diff-5432adb51a0903ae1adcaf4b28725c3e8a957d98a5b5804715d4408ec50d8d86R1)
* Removed the now-obsolete `TestExpandCurlDataFiles` and its supporting code, since file expansion is handled by the updated dependency. (`runbook_test.go`)

**Minor cleanup:**

* Removed the unused `slices` import from `runbook.go`.