### PR TITLE
fix: return nil instead of err variable in isLocalhost success path

### DIFF
--- a/http.go
+++ b/http.go
@@ -357,7 +357,7 @@ func isLocalhost(domain string) (bool, error) {
 	}
 	for _, ip := range ips {
 		if ip.IsLoopback() {
-			return true, err
+			return true, nil
 		}
 	}
 


### PR DESCRIPTION
This pull request makes a small fix to the `isLocalhost` function in `http.go`. The change ensures that when a loopback IP is detected, the function returns `nil` for the error instead of propagating a previous error value.