### PR TITLE
fix: use context.WithoutCancel instead of context.Background for CDP allocator

### DIFF
--- a/cdp.go
+++ b/cdp.go
@@ -129,7 +129,9 @@ func (rnr *cdpRunner) Run(ctx context.Context, s *step) error {
 func (rnr *cdpRunner) run(ctx context.Context, cas CDPActions, s *step) error {
 	o := s.parent
 	if rnr.ctx == nil {
-		allocCtx, cancel := chromedp.NewExecAllocator(context.Background(), rnr.opts...)
+		// Use WithoutCancel to prevent Chrome process from being killed by step-level cancellation,
+		// as the browser instance is reused across multiple steps.
+		allocCtx, cancel := chromedp.NewExecAllocator(context.WithoutCancel(ctx), rnr.opts...)
 		ctxx, _ := chromedp.NewContext(allocCtx)
 		rnr.ctx = ctxx
 		rnr.cancel = cancel


### PR DESCRIPTION
This pull request makes a targeted improvement to the way browser context cancellation is handled in the `cdpRunner` implementation. The change ensures that the Chrome browser process is not prematurely terminated when individual steps are canceled, allowing the browser instance to be reused across multiple steps.

Resource management improvement:

* Updated the creation of the Chrome Exec Allocator in `cdp.go` to use `context.WithoutCancel(ctx)` instead of `context.Background()`, preventing the Chrome process from being killed by step-level cancellation and supporting browser reuse across steps.