### PR TITLE
fix: propagate scanner errors from SSH session goroutines instead of panicking

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -282,6 +282,13 @@ L:
 		}
 	}
 
+	// Check for scanner errors that may have raced with channel close.
+	select {
+	case err := <-rnr.scanErr:
+		return err
+	default:
+	}
+
 	o.capturers.captureSSHStdout(stdout)
 	o.capturers.captureSSHStderr(stderr)
 


### PR DESCRIPTION
This pull request improves error handling in the `sshRunner` by replacing panics with structured error propagation for scanner errors on SSH session output streams. The main changes introduce a new error channel to capture and return errors from goroutines reading from stdout and stderr, ensuring the calling code can handle these errors gracefully.

**Error handling improvements:**

* Added a new `scanErr` channel to the `sshRunner` struct to capture errors from scanning SSH session output streams (`stdout` and `stderr`).
* Replaced `panic` calls in the goroutines scanning `stdout` and `stderr` with sending the error to the `scanErr` channel, allowing for proper error propagation. [[1]](diffhunk://#diff-2705f40b61c6c903a22ce3c907292f8a75812055a41e0d22c292026d909a4465R106-R114) [[2]](diffhunk://#diff-2705f40b61c6c903a22ce3c907292f8a75812055a41e0d22c292026d909a4465L124-R126)
* Updated the main session read loop to listen for errors on the `scanErr` channel and return them immediately, improving robustness.
* Ensured the `scanErr` channel is reset to `nil` in `closeSession()` for proper cleanup.