### PR TITLE
fix: remove unnecessary done channel in handleConns to prevent potential deadlock

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -330,12 +330,7 @@ func (rnr *sshRunner) runOnce(ctx context.Context, c *sshCommand, s *step) error
 
 func handleConns(ctx context.Context, lc, rc net.Conn) (err error) {
 	defer func() {
-		if errr := rc.Close(); errr != nil {
-			err = errr
-		}
-		if errr := lc.Close(); errr != nil {
-			err = errr
-		}
+		err = errors.Join(err, rc.Close(), lc.Close())
 	}()
 
 	eg, _ := errgroup.WithContext(ctx) // FIXME: context handling


### PR DESCRIPTION
This pull request refactors the connection handling logic in the `handleConns` function in `ssh.go` to simplify the code and improve reliability. The main change is the removal of the manual synchronization channel and redundant error handling, with a shift to using the `errgroup`'s `Wait()` method for managing goroutine completion and error propagation.

Connection handling simplification:

* Removed the `done` channel and associated signaling code, relying solely on `errgroup.Wait()` for goroutine synchronization and error handling in `handleConns`.
* Eliminated redundant error checks and returns within the goroutines, streamlining the flow and reducing complexity.