### PR TITLE
feat: add structured JSON output for run, list, and loadt commands

### DIFF
--- a/cmd/loadt.go
+++ b/cmd/loadt.go
@@ -52,6 +52,10 @@ var loadtCmd = &cobra.Command{
 			err = errors.Join(err, donegroup.Wait(ctx))
 		}()
 		pathp := strings.Join(args, string(filepath.ListSeparator))
+		outputFormat, err := cmd.Flags().GetString("format")
+		if err != nil {
+			return err
+		}
 		flgs.Format = "none" // Disable runn output
 		opts, err := flgs.ToOpts()
 		if err != nil {
@@ -116,8 +120,15 @@ var loadtCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := lr.Report(os.Stdout); err != nil {
-			return err
+		switch outputFormat {
+		case "json":
+			if err := lr.ReportJSON(os.Stdout); err != nil {
+				return err
+			}
+		default:
+			if err := lr.Report(os.Stdout); err != nil {
+				return err
+			}
 		}
 		if err := lr.CheckThreshold(flgs.LoadTThreshold); err != nil {
 			return err
@@ -163,6 +174,7 @@ func init() {
 		panic(err)
 	}
 
+	loadtCmd.Flags().StringVarP(&flgs.Format, "format", "", "", flgs.Usage("Format"))
 	loadtCmd.Flags().IntVarP(&flgs.LoadTConcurrent, "load-concurrent", "", 1, flgs.Usage("LoadTConcurrent"))
 	loadtCmd.Flags().StringVarP(&flgs.LoadTDuration, "duration", "", "10sec", flgs.Usage("LoadTDuration"))
 	loadtCmd.Flags().StringVarP(&flgs.LoadTWarmUp, "warm-up", "", "5sec", flgs.Usage("LoadTWarmUp"))

--- a/kv_test.go
+++ b/kv_test.go
@@ -42,8 +42,8 @@ func TestRunNWithKV(t *testing.T) {
 	}
 	got := ops.Result()
 	opts := []cmp.Option{
-		cmpopts.IgnoreFields(runResultSimplified{}, "Elapsed"),
-		cmpopts.IgnoreFields(stepResultSimplified{}, "Elapsed"),
+		cmpopts.IgnoreFields(runResultSimplified{}, "Elapsed", "Desc", "Labels"),
+		cmpopts.IgnoreFields(stepResultSimplified{}, "Elapsed", "Index", "Desc", "RunnerType", "RunnerKey", "Error"),
 	}
 	if diff := cmp.Diff(got.simplify(), want.simplify(), opts...); diff != "" {
 		t.Error(diff)

--- a/operator.go
+++ b/operator.go
@@ -125,6 +125,11 @@ func (op *operator) Desc() string {
 	return op.desc
 }
 
+// Labels returns the labels of the runbook.
+func (op *operator) Labels() []string {
+	return op.labels
+}
+
 // If returns `if:` of runbook.
 func (op *operator) If() string {
 	return op.ifCond

--- a/operator_test.go
+++ b/operator_test.go
@@ -605,8 +605,8 @@ func TestRunN(t *testing.T) {
 			got := ops.Result().simplify()
 			want := tt.want.simplify()
 			opts := []cmp.Option{
-				cmpopts.IgnoreFields(runResultSimplified{}, "Elapsed", "ID"),
-				cmpopts.IgnoreFields(stepResultSimplified{}, "Elapsed", "ID"),
+				cmpopts.IgnoreFields(runResultSimplified{}, "Elapsed", "ID", "Desc", "Labels"),
+				cmpopts.IgnoreFields(stepResultSimplified{}, "Elapsed", "ID", "Index", "Desc", "RunnerType", "RunnerKey", "Error"),
 			}
 			if diff := cmp.Diff(got, want, opts...); diff != "" {
 				t.Error(diff)
@@ -685,8 +685,8 @@ func TestNeeds(t *testing.T) {
 			got := ops.Result().simplify()
 			want := tt.want.simplify()
 			opts := []cmp.Option{
-				cmpopts.IgnoreFields(runResultSimplified{}, "Elapsed"),
-				cmpopts.IgnoreFields(stepResultSimplified{}, "Elapsed"),
+				cmpopts.IgnoreFields(runResultSimplified{}, "Elapsed", "Desc", "Labels"),
+				cmpopts.IgnoreFields(stepResultSimplified{}, "Elapsed", "Index", "Desc", "RunnerType", "RunnerKey", "Error"),
 			}
 			if diff := cmp.Diff(got, want, opts...); diff != "" {
 				t.Error(diff)

--- a/result_test.go
+++ b/result_test.go
@@ -115,15 +115,17 @@ func TestResultOutJSON(t *testing.T) {
 		{newRunNResult(t, 4, []*RunResult{
 			{
 				ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
+				Desc:        "success runbook",
 				Path:        "testdata/book/runn_0_success.yml",
 				Err:         nil,
-				StepResults: []*StepResult{{ID: "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0", Key: "0", Err: nil}},
+				StepResults: []*StepResult{{ID: "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0", Key: "0", Desc: "step 0", RunnerType: RunnerTypeTest, RunnerKey: "test", Err: nil}},
 			},
 			{
 				ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
+				Desc:        "fail runbook",
 				Path:        "testdata/book/runn_1_fail.yml",
 				Err:         errDummy,
-				StepResults: []*StepResult{{ID: "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0", Key: "0", Err: errDummy}},
+				StepResults: []*StepResult{{ID: "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0", Key: "0", RunnerType: RunnerTypeHTTP, RunnerKey: "req", Err: errDummy}},
 			},
 			{
 				ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
@@ -141,15 +143,17 @@ func TestResultOutJSON(t *testing.T) {
 		{newRunNResult(t, 5, []*RunResult{
 			{
 				ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
+				Desc:        "success runbook",
 				Path:        "testdata/book/runn_0_success.yml",
 				Err:         nil,
-				StepResults: []*StepResult{{ID: "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0", Key: "0", Err: nil}},
+				StepResults: []*StepResult{{ID: "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0", Key: "0", Desc: "step 0", RunnerType: RunnerTypeTest, RunnerKey: "test", Err: nil}},
 			},
 			{
 				ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",
+				Desc:        "fail runbook",
 				Path:        "testdata/book/runn_1_fail.yml",
 				Err:         errDummy,
-				StepResults: []*StepResult{{ID: "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0", Key: "0", Err: errDummy}},
+				StepResults: []*StepResult{{ID: "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0", Key: "0", RunnerType: RunnerTypeHTTP, RunnerKey: "req", Err: errDummy}},
 			},
 			{
 				ID:          "ab13ba1e546838ceafa17f91ab3220102f397b2e",

--- a/testdata/result_out_json_0.golden
+++ b/testdata/result_out_json_0.golden
@@ -6,25 +6,35 @@
   "results": [
     {
       "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e",
+      "desc": "success runbook",
       "path": "testdata/book/runn_0_success.yml",
       "result": "success",
       "steps": [
         {
           "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
+          "index": 0,
           "key": "0",
+          "desc": "step 0",
+          "runner_type": "test",
+          "runner_key": "test",
           "result": "success"
         }
       ]
     },
     {
       "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e",
+      "desc": "fail runbook",
       "path": "testdata/book/runn_1_fail.yml",
       "result": "failure",
       "steps": [
         {
           "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
+          "index": 0,
           "key": "0",
-          "result": "failure"
+          "runner_type": "http",
+          "runner_key": "req",
+          "result": "failure",
+          "error": "dummy"
         }
       ]
     },
@@ -35,6 +45,7 @@
       "steps": [
         {
           "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
+          "index": 0,
           "key": "0",
           "result": "success"
         }
@@ -47,6 +58,7 @@
       "steps": [
         {
           "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
+          "index": 0,
           "key": "0",
           "result": "skipped"
         }

--- a/testdata/result_out_json_1.golden
+++ b/testdata/result_out_json_1.golden
@@ -6,25 +6,35 @@
   "results": [
     {
       "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e",
+      "desc": "success runbook",
       "path": "testdata/book/runn_0_success.yml",
       "result": "success",
       "steps": [
         {
           "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
+          "index": 0,
           "key": "0",
+          "desc": "step 0",
+          "runner_type": "test",
+          "runner_key": "test",
           "result": "success"
         }
       ]
     },
     {
       "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e",
+      "desc": "fail runbook",
       "path": "testdata/book/runn_1_fail.yml",
       "result": "failure",
       "steps": [
         {
           "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
+          "index": 0,
           "key": "0",
-          "result": "failure"
+          "runner_type": "http",
+          "runner_key": "req",
+          "result": "failure",
+          "error": "dummy"
         }
       ]
     },
@@ -35,6 +45,7 @@
       "steps": [
         {
           "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
+          "index": 0,
           "key": "0",
           "result": "success"
         }
@@ -47,6 +58,7 @@
       "steps": [
         {
           "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
+          "index": 0,
           "key": "0",
           "result": "skipped"
         }
@@ -59,8 +71,10 @@
       "steps": [
         {
           "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
+          "index": 0,
           "key": "0",
-          "result": "failure"
+          "result": "failure",
+          "error": "dummy"
         }
       ]
     }

--- a/testdata/result_out_json_2.golden
+++ b/testdata/result_out_json_2.golden
@@ -11,6 +11,7 @@
       "steps": [
         {
           "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
+          "index": 0,
           "key": "0",
           "result": "success"
         }
@@ -23,8 +24,10 @@
       "steps": [
         {
           "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
+          "index": 0,
           "key": "0",
-          "result": "failure"
+          "result": "failure",
+          "error": "dummy"
         }
       ]
     }

--- a/testdata/result_out_json_3.golden
+++ b/testdata/result_out_json_3.golden
@@ -11,6 +11,7 @@
       "steps": [
         {
           "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
+          "index": 0,
           "key": "0",
           "result": "success"
         }
@@ -23,8 +24,10 @@
       "steps": [
         {
           "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
+          "index": 0,
           "key": "0",
           "result": "failure",
+          "error": "dummy",
           "included_run_result": [
             {
               "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
@@ -33,8 +36,10 @@
               "steps": [
                 {
                   "id": "",
+                  "index": 0,
                   "key": "0",
-                  "result": "failure"
+                  "result": "failure",
+                  "error": "dummy"
                 }
               ]
             }

--- a/trail.go
+++ b/trail.go
@@ -28,6 +28,7 @@ const (
 	RunnerTypeDump    RunnerType = "dump"
 	RunnerTypeInclude RunnerType = "include"
 	RunnerTypeBind    RunnerType = "bind"
+	RunnerTypeRunner  RunnerType = "runner"
 )
 
 // Trail - The trail of elements in the runbook at runtime.


### PR DESCRIPTION
This pull request introduces enhancements to the output formats and result reporting for both the `list` and `loadt` commands, and extends the details included in result summaries for runbooks and steps. The main improvements are the addition of JSON output options, richer result metadata in both code and tests, and internal refactoring to support these features.

**Enhancements to output formats:**

* Added a `--format` flag to both `list` and `loadt` commands, allowing users to output results in JSON format in addition to the existing table or text formats. The `list` command outputs a structured array of runbook metadata, and the `loadt` command outputs detailed load test results as JSON. [[1]](diffhunk://#diff-2cb6b39b26188bd68fce779dd82957aa4b969400c8a1554746a19f388924d9e5R57-R109) [[2]](diffhunk://#diff-2cb6b39b26188bd68fce779dd82957aa4b969400c8a1554746a19f388924d9e5R193) [[3]](diffhunk://#diff-249ca2b9988d0fb09e9bf266ee8a3574312032409255e19a15d37f5777ca7845R55-R58) [[4]](diffhunk://#diff-249ca2b9988d0fb09e9bf266ee8a3574312032409255e19a15d37f5777ca7845R123-R132) [[5]](diffhunk://#diff-249ca2b9988d0fb09e9bf266ee8a3574312032409255e19a15d37f5777ca7845R177) [[6]](diffhunk://#diff-cc3335422a8b48b780c753483c9fd77c9a9220c63f7dfa71b36567822470bbd9R15-R33) [[7]](diffhunk://#diff-cc3335422a8b48b780c753483c9fd77c9a9220c63f7dfa71b36567822470bbd9R156-R186)

**Richer result metadata:**

* Extended the `runResultSimplified` and `stepResultSimplified` structures to include additional fields such as `desc`, `labels`, `index`, `runner_type`, `runner_key`, and `error`, providing more context in JSON outputs and tests. [[1]](diffhunk://#diff-b67a0c563bd29e3d46d4cba43d67e8405b2d4a75f59b45d2a5eacaee606c6d44R73) [[2]](diffhunk://#diff-b67a0c563bd29e3d46d4cba43d67e8405b2d4a75f59b45d2a5eacaee606c6d44R83-R89) [[3]](diffhunk://#diff-b67a0c563bd29e3d46d4cba43d67e8405b2d4a75f59b45d2a5eacaee606c6d44L264-R320) [[4]](diffhunk://#diff-8919a54203ded41bed26a73090f6b77ac2a5993e0724bb217cda4e0de44c893aR118-R128) [[5]](diffhunk://#diff-8919a54203ded41bed26a73090f6b77ac2a5993e0724bb217cda4e0de44c893aR146-R156) [[6]](diffhunk://#diff-cc05996e1b2b4935a16f95e1d9436b11b2ab092d2083cf887094e0cb61ef2f29R9-R37)
* Added the `Labels()` method to the operator, exposing runbook labels for use in summaries and outputs.

**Internal refactoring and support:**

* Refactored the `step` struct to provide a `runnerType()` method and ensure that `StepResult` includes runner type and key, which are now set in `setResult` and used in result reporting. [[1]](diffhunk://#diff-02f8cadbcbdf5890db53dd9045479ed573d367d5760f66b6accecfa63b5cacd3L76-R111) [[2]](diffhunk://#diff-02f8cadbcbdf5890db53dd9045479ed573d367d5760f66b6accecfa63b5cacd3L142-R149)
* Updated tests and test helpers to account for the new metadata fields, and adjusted comparison options to ignore new fields where appropriate. [[1]](diffhunk://#diff-ce891ad9aa825e17241b2345086f2eb837d50c7d1c196ec65ca00ecec1570eabL45-R46) [[2]](diffhunk://#diff-f14dfc4d064382aab6debd000f42737a6b7f9f49b4c58e0e552640e4c70c4714L608-R609) [[3]](diffhunk://#diff-f14dfc4d064382aab6debd000f42737a6b7f9f49b4c58e0e552640e4c70c4714L688-R689)

These changes improve the usability of the CLI by offering machine-readable outputs and provide more detailed context for both users and automated systems consuming runbook and load test results.