### PR TITLE
feat: structure error field in JSON output for programmatic error analysis

### DIFF
--- a/result_test.go
+++ b/result_test.go
@@ -207,6 +207,21 @@ func TestResultOutJSON(t *testing.T) {
 				}}}},
 			},
 		})},
+		{newRunNResult(t, 1, []*RunResult{
+			{
+				ID:   "ab13ba1e546838ceafa17f91ab3220102f397b2e",
+				Desc: "cond false runbook",
+				Path: "testdata/book/runn_cond_false.yml",
+				Err:  newCondFalseError("current.res.status == 200", "current.res.status == 200\n=> 404 == 200\n=> false"),
+				StepResults: []*StepResult{{
+					ID:         "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
+					Key:        "0",
+					RunnerType: RunnerTypeTest,
+					RunnerKey:  "test",
+					Err:        newCondFalseError("current.res.status == 200", "current.res.status == 200\n=> 404 == 200\n=> false"),
+				}},
+			},
+		})},
 	}
 	for i, tt := range tests {
 		key := fmt.Sprintf("result_out_json_%d", i)

--- a/testdata/result_out_json_0.golden
+++ b/testdata/result_out_json_0.golden
@@ -34,7 +34,9 @@
           "runner_type": "http",
           "runner_key": "req",
           "result": "failure",
-          "error": "dummy"
+          "error": {
+            "message": "dummy"
+          }
         }
       ]
     },

--- a/testdata/result_out_json_1.golden
+++ b/testdata/result_out_json_1.golden
@@ -34,7 +34,9 @@
           "runner_type": "http",
           "runner_key": "req",
           "result": "failure",
-          "error": "dummy"
+          "error": {
+            "message": "dummy"
+          }
         }
       ]
     },
@@ -74,7 +76,9 @@
           "index": 0,
           "key": "0",
           "result": "failure",
-          "error": "dummy"
+          "error": {
+            "message": "dummy"
+          }
         }
       ]
     }

--- a/testdata/result_out_json_2.golden
+++ b/testdata/result_out_json_2.golden
@@ -27,7 +27,9 @@
           "index": 0,
           "key": "0",
           "result": "failure",
-          "error": "dummy"
+          "error": {
+            "message": "dummy"
+          }
         }
       ]
     }

--- a/testdata/result_out_json_3.golden
+++ b/testdata/result_out_json_3.golden
@@ -27,7 +27,9 @@
           "index": 0,
           "key": "0",
           "result": "failure",
-          "error": "dummy",
+          "error": {
+            "message": "dummy"
+          },
           "included_run_result": [
             {
               "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
@@ -39,7 +41,9 @@
                   "index": 0,
                   "key": "0",
                   "result": "failure",
-                  "error": "dummy"
+                  "error": {
+                    "message": "dummy"
+                  }
                 }
               ]
             }

--- a/testdata/result_out_json_4.golden
+++ b/testdata/result_out_json_4.golden
@@ -1,0 +1,29 @@
+{
+  "total": 1,
+  "success": 0,
+  "failure": 1,
+  "skipped": 0,
+  "results": [
+    {
+      "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e",
+      "desc": "cond false runbook",
+      "path": "testdata/book/runn_cond_false.yml",
+      "result": "failure",
+      "steps": [
+        {
+          "id": "ab13ba1e546838ceafa17f91ab3220102f397b2e?step=0",
+          "index": 0,
+          "key": "0",
+          "runner_type": "test",
+          "runner_key": "test",
+          "result": "failure",
+          "error": {
+            "message": "condition is not true\n\nCondition:\n  current.res.status == 200\n  =\u003e 404 == 200\n  =\u003e false\n",
+            "condition": "current.res.status == 200",
+            "expr_trace": "current.res.status == 200\n=\u003e 404 == 200\n=\u003e false"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This pull request refactors error handling in step results to provide richer error information in the output JSON. Instead of returning a plain error string, errors are now represented as structured objects, allowing for more detailed reporting, especially for conditional failures.

Error handling improvements:

* Changed the `Error` field in `stepResultSimplified` from a string to a pointer to a new `stepErrorSimplified` struct, which includes `Message`, `Condition`, and `ExprTrace` fields for enhanced error detail.
* Updated the `simplifyStepResults` function to populate the new error structure, including condition and expression trace when the error is a conditional failure.

Testing and output updates:

* Added a new test case in `result_test.go` to cover conditional failure errors and ensure proper serialization.
* Updated all relevant golden files to reflect the new error format, replacing error strings with structured error objects. [[1]](diffhunk://#diff-cc05996e1b2b4935a16f95e1d9436b11b2ab092d2083cf887094e0cb61ef2f29L37-R39) [[2]](diffhunk://#diff-fd266467a4bdf13179d4d0a4b83001a0f9c7bf25ea59dd3a3f8bab12d82a4ca7L37-R39) [[3]](diffhunk://#diff-fd266467a4bdf13179d4d0a4b83001a0f9c7bf25ea59dd3a3f8bab12d82a4ca7L77-R81) [[4]](diffhunk://#diff-ef550bb999cf46777b08d24be3ada0747c52634925ccbb95617564e0790021caL30-R32) [[5]](diffhunk://#diff-332e298d08c93b9ce86a3bf3b0da0e61684ad9f20c65e29a887fb0e500b0c085L30-R32) [[6]](diffhunk://#diff-332e298d08c93b9ce86a3bf3b0da0e61684ad9f20c65e29a887fb0e500b0c085L42-R46)
* Added a new golden file demonstrating a conditional failure with detailed error information.