### PR TITLE
Add Close() to httpRunner to clean up idle connections

### DIFF
--- a/http.go
+++ b/http.go
@@ -108,6 +108,13 @@ func newHTTPRunnerWithHandler(name string, h http.Handler) (*httpRunner, error) 
 	}, nil
 }
 
+func (rnr *httpRunner) Close() error {
+	if rnr.client != nil {
+		rnr.client.CloseIdleConnections()
+	}
+	return nil
+}
+
 func (r *httpRequest) validate() error {
 	switch r.method {
 	case http.MethodPost, http.MethodPatch:

--- a/operator.go
+++ b/operator.go
@@ -173,6 +173,9 @@ func (op *operator) Close(force bool) {
 		}
 		_ = r.Close()
 	}
+	for _, r := range op.httpRunners {
+		_ = r.Close()
+	}
 }
 
 func (op *operator) runStep(ctx context.Context, s *step) error {


### PR DESCRIPTION
## Summary

- Add `httpRunner.Close()` which calls `client.CloseIdleConnections()` to release idle HTTP connections
- Add HTTP runner cleanup to `operator.Close()` for consistency with other runners (gRPC, DB, SSH, CDP)

Previously, `httpRunner` was the only runner type without a `Close()` method, causing idle HTTP connections to never be explicitly released. This could lead to resource leaks, particularly in load testing scenarios (`runn loadt`) where `runN()` is called repeatedly.

ref #1410