### PR TITLE
Fix data race in httpRunner TLS configuration

### DIFF
--- a/book_test.go
+++ b/book_test.go
@@ -152,11 +152,11 @@ func TestParseRunnerForHttpRunner(t *testing.T) {
 	client := &http.Client{Timeout: time.Duration(30000000000)}
 	tests := []struct {
 		v    any
-		want any
+		want *httpRunner
 	}{
 		{
 			"https://example.com/",
-			httpRunner{
+			&httpRunner{
 				name:            "req",
 				endpoint:        secureUrl,
 				client:          client,
@@ -166,7 +166,7 @@ func TestParseRunnerForHttpRunner(t *testing.T) {
 		},
 		{
 			"http://example.com/",
-			httpRunner{
+			&httpRunner{
 				name:            "req",
 				endpoint:        url,
 				client:          client,
@@ -178,6 +178,7 @@ func TestParseRunnerForHttpRunner(t *testing.T) {
 	opts := []cmp.Option{
 		cmp.AllowUnexported(httpRunner{}),
 		cmpopts.IgnoreFields(http.Client{}, "Transport"),
+		cmpopts.IgnoreFields(httpRunner{}, "tlsOnce", "tlsErr"),
 	}
 
 	for _, tt := range tests {
@@ -187,7 +188,7 @@ func TestParseRunnerForHttpRunner(t *testing.T) {
 		}
 
 		got := bk.httpRunners["req"]
-		if diff := cmp.Diff(*got, tt.want, opts...); diff != "" {
+		if diff := cmp.Diff(got, tt.want, opts...); diff != "" {
 			t.Error(diff)
 		}
 	}

--- a/http.go
+++ b/http.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ajg/form"
@@ -60,6 +61,8 @@ type httpRunner struct {
 	useCookie         *bool
 	trace             *bool
 	traceHeaderName   string
+	tlsOnce           sync.Once
+	tlsErr            error
 }
 
 type httpRequest struct {
@@ -106,6 +109,60 @@ func newHTTPRunnerWithHandler(name string, h http.Handler) (*httpRunner, error) 
 		validator:       newNopValidator(),
 		traceHeaderName: DefaultTraceHeaderName,
 	}, nil
+}
+
+// configureTLS configures TLS settings on the HTTP transport.
+// Uses sync.Once to ensure TLS is configured exactly once,
+// even when the runner is shared across goroutines.
+func (rnr *httpRunner) configureTLS() error {
+	rnr.tlsOnce.Do(func() {
+		if rnr.client == nil {
+			return
+		}
+		if rnr.client.Transport == nil {
+			tp, ok := http.DefaultTransport.(*http.Transport)
+			if !ok {
+				rnr.tlsErr = fmt.Errorf("failed to cast: %v", http.DefaultTransport)
+				return
+			}
+			rnr.client.Transport = tp.Clone()
+		}
+		ts, ok := rnr.client.Transport.(*http.Transport)
+		if !ok {
+			if len(rnr.cacert) != 0 || len(rnr.cert) != 0 || len(rnr.key) != 0 {
+				rnr.tlsErr = fmt.Errorf("cannot configure TLS: client transport is %T, want *http.Transport", rnr.client.Transport)
+			}
+			return
+		}
+		if ts.TLSClientConfig != nil {
+			ts.TLSClientConfig = ts.TLSClientConfig.Clone()
+		} else {
+			ts.TLSClientConfig = new(tls.Config)
+		}
+		ts.TLSClientConfig.InsecureSkipVerify = rnr.skipVerify
+		if len(rnr.cacert) != 0 {
+			certpool, err := x509.SystemCertPool()
+			if err != nil {
+				// FIXME for Windows
+				// ref: https://github.com/golang/go/issues/18609
+				certpool = x509.NewCertPool()
+			}
+			if !certpool.AppendCertsFromPEM(rnr.cacert) {
+				rnr.tlsErr = fmt.Errorf("failed to append cacert")
+				return
+			}
+			ts.TLSClientConfig.RootCAs = certpool
+		}
+		if len(rnr.cert) != 0 && len(rnr.key) != 0 {
+			cert, err := tls.X509KeyPair(rnr.cert, rnr.key)
+			if err != nil {
+				rnr.tlsErr = err
+				return
+			}
+			ts.TLSClientConfig.Certificates = []tls.Certificate{cert}
+		}
+	})
+	return rnr.tlsErr
 }
 
 func (rnr *httpRunner) Close() error {
@@ -392,6 +449,9 @@ func (rnr *httpRunner) Run(ctx context.Context, s *step) error {
 }
 
 func (rnr *httpRunner) run(ctx context.Context, r *httpRequest, s *step) error {
+	if err := rnr.configureTLS(); err != nil {
+		return newErrUnrecoverable(err)
+	}
 	o := s.parent
 	r.multipartBoundary = rnr.multipartBoundary
 	r.root = o.root
@@ -422,50 +482,6 @@ func (rnr *httpRunner) run(ctx context.Context, r *httpRequest, s *step) error {
 	)
 	switch {
 	case rnr.client != nil:
-		if rnr.client.Transport == nil {
-			tp, ok := http.DefaultTransport.(*http.Transport)
-			if !ok {
-				return newErrUnrecoverable(fmt.Errorf("failed to cast: %v", http.DefaultTransport))
-			}
-			rnr.client.Transport = tp.Clone()
-		}
-		if ts, ok := rnr.client.Transport.(*http.Transport); ok {
-			existingConfig := ts.TLSClientConfig
-			if existingConfig != nil {
-				ts.TLSClientConfig = existingConfig.Clone()
-			} else {
-				ts.TLSClientConfig = new(tls.Config)
-			}
-			ts.TLSClientConfig.InsecureSkipVerify = rnr.skipVerify
-		}
-		if len(rnr.cacert) != 0 {
-			certpool, err := x509.SystemCertPool()
-			if err != nil {
-				// FIXME for Windows
-				// ref: https://github.com/golang/go/issues/18609
-				certpool = x509.NewCertPool()
-			}
-			if !certpool.AppendCertsFromPEM(rnr.cacert) {
-				return newErrUnrecoverable(err)
-			}
-			ts, ok := rnr.client.Transport.(*http.Transport)
-			if !ok {
-				return newErrUnrecoverable(fmt.Errorf("could not set cacert: interface conversion error: http.RoundTripper is %#v, not *http.Transport", rnr.client.Transport))
-			}
-			ts.TLSClientConfig.RootCAs = certpool
-		}
-		if len(rnr.cert) != 0 && len(rnr.key) != 0 {
-			cert, err := tls.X509KeyPair(rnr.cert, rnr.key)
-			if err != nil {
-				return newErrUnrecoverable(err)
-			}
-			ts, ok := rnr.client.Transport.(*http.Transport)
-			if !ok {
-				return newErrUnrecoverable(fmt.Errorf("could not set certificates: interface conversion error: http.RoundTripper is %#v, not *http.Transport", rnr.client.Transport))
-			}
-			ts.TLSClientConfig.Certificates = []tls.Certificate{cert}
-		}
-
 		u, err := mergeURL(rnr.endpoint, r.path)
 		if err != nil {
 			return newErrUnrecoverable(err)

--- a/operator.go
+++ b/operator.go
@@ -589,6 +589,9 @@ func New(opts ...Option) (*operator, error) {
 			}
 			tp.DialContext = hostRules.dialContextFunc()
 		}
+		if err := v.configureTLS(); err != nil {
+			return nil, err
+		}
 		op.httpRunners[k] = v
 	}
 	for k, v := range bk.dbRunners {

--- a/operator_test.go
+++ b/operator_test.go
@@ -975,6 +975,7 @@ func TestShard(t *testing.T) {
 				cmpopts.IgnoreFields(sshRunner{}, "client", "sess", "stdin", "stdout", "stderr", "operatorID"),
 				cmpopts.IgnoreFields(grpcRunner{}, "mu", "operatorID"),
 				cmpopts.IgnoreFields(dbRunner{}, "operatorID"),
+				cmpopts.IgnoreFields(httpRunner{}, "tlsOnce", "tlsErr"),
 				cmpopts.IgnoreFields(RunResult{}, "included", "store"),
 				cmpopts.IgnoreFields(http.Client{}, "Transport"),
 			}

--- a/option_test.go
+++ b/option_test.go
@@ -201,7 +201,7 @@ func TestOptionOverlay(t *testing.T) {
 			opts := []cmp.Option{
 				cmp.AllowUnexported(book{}, httpRunner{}, dbRunner{}),
 				cmpopts.IgnoreFields(book{}, "funcs", "stdout", "stderr"),
-				cmpopts.IgnoreFields(httpRunner{}, "endpoint", "client", "validator"),
+				cmpopts.IgnoreFields(httpRunner{}, "endpoint", "client", "validator", "tlsOnce", "tlsErr"),
 				cmpopts.IgnoreFields(dbRunner{}, "client"),
 			}
 			if diff := cmp.Diff(got, tt.want, opts...); diff != "" {
@@ -377,7 +377,7 @@ func TestOptionUnderlay(t *testing.T) {
 			opts := []cmp.Option{
 				cmp.AllowUnexported(book{}, httpRunner{}, dbRunner{}),
 				cmpopts.IgnoreFields(book{}, "funcs", "stdout", "stderr"),
-				cmpopts.IgnoreFields(httpRunner{}, "endpoint", "client", "validator"),
+				cmpopts.IgnoreFields(httpRunner{}, "endpoint", "client", "validator", "tlsOnce", "tlsErr"),
 				cmpopts.IgnoreFields(dbRunner{}, "client"),
 			}
 			if diff := cmp.Diff(got, tt.want, opts...); diff != "" {


### PR DESCRIPTION
## Summary

- Move TLS configuration from per-request (`httpRunner.run()`) to initialization time (`httpRunner.configureTLS()`) using `sync.Once`
- Call `configureTLS()` in `New()` for early error detection, and also in `run()` as a safety net (no-op after first call due to `sync.Once`)

Previously, every HTTP request cloned or recreated `TLSClientConfig` on the shared `Transport`. When the runner was shared across goroutines via `reuseHTTPRunner` (e.g., in `include` or `toOperatorN()` paths), this caused a data race on the `Transport.TLSClientConfig` field.

Since `skipVerify`, `cacert`, `cert`, and `key` are all set at initialization time and never change during execution, TLS configuration can safely be done once.

ref #1410