### PR TITLE
perf: tune HTTP connection pool for load testing scenarios

### DIFF
--- a/http.go
+++ b/http.go
@@ -46,7 +46,7 @@ const (
 // maxIdleConns is the maximum number of idle connections across all hosts.
 // Set to 0 (unlimited) because the default value of 100 (from http.DefaultTransport)
 // caps the effective idle pool even when MaxIdleConnsPerHost is set higher.
-// Idle connections that are not actually used impose no meaningful cost.
+// Idle connections are cleaned up by IdleConnTimeout and operator.Close().
 const maxIdleConns = 0
 
 // maxIdleConnsPerHost is the maximum number of idle connections per host.


### PR DESCRIPTION
## Summary
- Increase `MaxIdleConnsPerHost` from 2 (default) to 500 to prevent connection pool exhaustion under concurrent load
- Set `MaxIdleConns` to 0 (unlimited) to remove the global idle connection cap (default 100) that would otherwise limit the per-host pool
- Idle connections not actually used impose no meaningful cost, so this has no impact on normal `runn run` usage

Ref #1410