### PR TITLE
refactor: apply golangci-lint modernize fixes

### DIFF
--- a/cdp_test.go
+++ b/cdp_test.go
@@ -346,7 +346,6 @@ func TestCDP(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
 			t.Parallel()
 			ts := testutil.HTTPServer(t)

--- a/coverage_test.go
+++ b/coverage_test.go
@@ -28,7 +28,6 @@ func TestCoverage(t *testing.T) {
 	gs := testutil.GRPCServer(t, false, false)
 	t.Setenv("TEST_GRPC_ADDR", gs.Addr())
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
 			t.Parallel()
 			o, err := New(Book(tt.book), Scopes(scope.AllowReadParent))

--- a/db.go
+++ b/db.go
@@ -395,8 +395,7 @@ func isSELECTStmt(stmt string) bool {
 	if !strings.Contains(stmt, "SELECT") {
 		return false
 	}
-	lines := strings.Split(stmt, "\n")
-	for _, line := range lines {
+	for line := range strings.SplitSeq(stmt, "\n") {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "--") || strings.HasPrefix(line, "#") {
 			continue
@@ -511,8 +510,7 @@ func isIdentChar(b byte) bool {
 
 func isCommentOnlyStmt(stmt string) bool {
 	stmt = strings.ToUpper(stmt)
-	lines := strings.Split(stmt, "\n")
-	for _, line := range lines {
+	for line := range strings.SplitSeq(stmt, "\n") {
 		line = strings.TrimSpace(reInlineComment.ReplaceAllString(line, ""))
 		if line == "" {
 			continue

--- a/db_test.go
+++ b/db_test.go
@@ -474,7 +474,6 @@ SELECT 1
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.in, func(t *testing.T) {
 			t.Parallel()
 			got := isSELECTStmt(tt.in)
@@ -501,7 +500,6 @@ SELECT 1
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.in, func(t *testing.T) {
 			t.Parallel()
 			got := isCommentOnlyStmt(tt.in)
@@ -567,7 +565,6 @@ func TestHasReturningClause(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := hasReturningClause(tt.stmt); got != tt.want {

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -247,11 +247,8 @@ func TestGrpcRunner(t *testing.T) {
 	}
 
 	for _, useTLS := range []bool{true, false} {
-		useTLS := useTLS
 		for _, disableReflection := range []bool{true, false} {
-			disableReflection := disableReflection
 			for _, tt := range tests {
-				tt := tt
 				t.Run(fmt.Sprintf("%s (useTLS: %v, disableReflection: %v)", tt.name, useTLS, disableReflection), func(t *testing.T) {
 					t.Parallel()
 					ctx, cancel := donegroup.WithCancel(context.Background())
@@ -432,7 +429,6 @@ func TestGrpcRunnerWithTimeout(t *testing.T) {
 	useTLS := false
 	ts := testutil.GRPCServer(t, useTLS, false)
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := donegroup.WithCancel(context.Background())
 			t.Cleanup(cancel)
@@ -572,7 +568,6 @@ func TestGrpcTraceHeader(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := donegroup.WithCancel(context.Background())

--- a/hosts.go
+++ b/hosts.go
@@ -158,15 +158,15 @@ func (r hostRules) replaceDSN(dsn string) string { //nostyle:recvtype
 
 func parseDialTarget(target string) (string, string) {
 	net := "tcp"
-	m1 := strings.Index(target, ":")
-	m2 := strings.Index(target, ":/")
+	before, after, hasColon := strings.Cut(target, ":")
+	hasColonSlash := strings.Contains(target, ":/")
 	// handle unix:addr which will fail with url.Parse
-	if m1 >= 0 && m2 < 0 {
-		if n := target[0:m1]; n == "unix" {
-			return n, target[m1+1:]
+	if hasColon && !hasColonSlash {
+		if before == "unix" {
+			return before, after
 		}
 	}
-	if m2 >= 0 {
+	if hasColonSlash {
 		t, err := url.Parse(target)
 		if err != nil {
 			return net, target

--- a/internal/builtin/hash.go
+++ b/internal/builtin/hash.go
@@ -38,6 +38,6 @@ func (h *Hash) toBytes(v any) []byte {
 	case []byte:
 		return vv
 	default:
-		return []byte(fmt.Sprintf("%v", vv))
+		return fmt.Appendf(nil, "%v", vv)
 	}
 }

--- a/internal/expr/expr.go
+++ b/internal/expr/expr.go
@@ -217,7 +217,7 @@ func trimDeprecatedComment(cond string) string {
 	deprecation.AddWarning("Sharp comment", "`#` comment is deprecated. Use `//` instead.")
 
 	var trimed []string
-	for _, l := range strings.Split(cond, "\n") {
+	for l := range strings.SplitSeq(cond, "\n") {
 		if strings.HasPrefix(strings.Trim(l, " "), commentToken) {
 			continue
 		}

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -734,7 +734,6 @@ func TestEvalCount(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.count, func(t *testing.T) {
 			got, err := EvalCount(tt.count, tt.store)
 			if (err != nil) != tt.wantErr {

--- a/internal/exprtrace/tracer.go
+++ b/internal/exprtrace/tracer.go
@@ -381,8 +381,8 @@ func NewTracer(trace *EvalTraceStore, store EvalEnv) *Tracer {
 	return &Tracer{
 		trace:          trace,
 		store:          store,
-		contextType:    reflect.TypeOf((*context.Context)(nil)).Elem(),
-		traceTagType:   reflect.TypeOf((*EvalTraceTag)(nil)).Elem(),
+		contextType:    reflect.TypeFor[context.Context](),
+		traceTagType:   reflect.TypeFor[EvalTraceTag](),
 		funcAttrsCache: map[string]int{},
 		builtinsMap:    builtinFunctionsMap,
 		eval: patcherEvaluationPhaseFields{

--- a/internal/exprtrace/tracer_test.go
+++ b/internal/exprtrace/tracer_test.go
@@ -105,7 +105,7 @@ func Test_ExprOfficialGeneratedExamplesV1_17_1(t *testing.T) {
 
 	examples := strings.TrimSpace(string(examplesTxtBytes))
 
-	for _, line := range strings.Split(examples, "\n") {
+	for line := range strings.SplitSeq(examples, "\n") {
 		// Skip tests that use the reduce or map functions
 		// The implementation has changed in the newer version of expr
 		if strings.Contains(line, "reduce") || strings.Contains(line, "map(") {
@@ -209,7 +209,7 @@ func Test_ExprOfficialGeneratedExamples(t *testing.T) {
 		compileErrors []error
 		equalErrors   []error
 	)
-	for _, line := range strings.Split(examples, "\n") {
+	for line := range strings.SplitSeq(examples, "\n") {
 		// Skip tests that use the reduce or map functions
 		// The implementation has changed in the newer version of expr
 		if strings.Contains(line, "reduce") || strings.Contains(line, "map(") {

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -223,7 +223,7 @@ func (f *Flags) ToOpts() ([]runn.Option, error) {
 }
 
 func (f *Flags) Usage(name string) string {
-	field, ok := reflect.TypeOf(f).Elem().FieldByName(name)
+	field, ok := reflect.TypeFor[Flags]().FieldByName(name)
 	if !ok {
 		panic(fmt.Sprintf("invalid name: %s", name))
 	}

--- a/internal/scope/scope.go
+++ b/internal/scope/scope.go
@@ -44,8 +44,7 @@ func Set(scopes ...string) error {
 	Global.mu.Lock()
 	defer Global.mu.Unlock()
 	for _, s := range scopes {
-		splitted := strings.Split(strings.TrimSpace(s), ",")
-		for _, ss := range splitted {
+		for ss := range strings.SplitSeq(strings.TrimSpace(s), ",") {
 			switch ss {
 			case AllowReadParent:
 				Global.readParent = true

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -504,11 +504,10 @@ func evalBindKeyValue(bindVars map[string]any, k string, v any, store map[string
 	if err != nil {
 		return nil, err
 	}
-	if strings.HasSuffix(k, "[]") {
+	if kk, ok := strings.CutSuffix(k, "[]"); ok {
 		// Append to slice
 		// - foo[]
 		// - foo[bar][]
-		kk := strings.TrimSuffix(k, "[]")
 		return evalBindKeyValue(bindVars, kk, []any{v}, store)
 	}
 	// Merge to map

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -742,7 +742,6 @@ func TestMergeVars(t *testing.T) {
 		},
 	}
 	for i, tt := range tests {
-		tt := tt
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			t.Parallel()
 			got := mergeVars(tt.store, tt.vars)

--- a/operator.go
+++ b/operator.go
@@ -1211,7 +1211,6 @@ func (op *operator) runInternal(ctx context.Context) (rerr error) {
 
 		// afterFuncs
 		for i, fn := range op.afterFuncs {
-			i := i
 			trs := append(op.trails(), Trail{
 				Type:      TrailTypeAfterFunc,
 				FuncIndex: &i,
@@ -1255,7 +1254,6 @@ func (op *operator) runInternal(ctx context.Context) (rerr error) {
 
 	// beforeFuncs
 	for i, fn := range op.beforeFuncs {
-		i := i
 		trs := append(op.trails(), Trail{
 			Type:      TrailTypeBeforeFunc,
 			FuncIndex: &i,
@@ -2213,7 +2211,7 @@ func labelCond(labels []string) string {
 		label = strings.ReplaceAll(label, "!", "not ")
 
 		sb.WriteString("(")
-		for _, s := range strings.Split(label, " ") {
+		for s := range strings.SplitSeq(label, " ") {
 			switch s {
 			case "not":
 				sb.WriteString("not ")

--- a/operator_test.go
+++ b/operator_test.go
@@ -1039,7 +1039,6 @@ func TestHttp(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
 			ts := testutil.HTTPServer(t)
 			t.Setenv("TEST_HTTP_ENDPOINT", ts.URL)
@@ -1063,7 +1062,6 @@ func TestGrpc(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
 			t.Parallel()
 			ts := testutil.GRPCServer(t, false, false)
@@ -1111,7 +1109,6 @@ func TestDB(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
 			_, dsn := testutil.SQLite(t)
 			t.Setenv("TEST_DB_DSN", dsn)
@@ -1136,7 +1133,6 @@ func TestAfterFuncAlwaysCall(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
 			var rerr error
 			called := false
@@ -1176,7 +1172,6 @@ func TestBeforeFuncErr(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
 			o, err := New(Book(tt.book), BeforeFunc(func(*RunResult) error {
 				return errors.New("before func error")
@@ -1205,7 +1200,6 @@ func TestAfterFuncErr(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
 			o, err := New(Book(tt.book), AfterFunc(func(*RunResult) error {
 				return errors.New("after func error")
@@ -1238,7 +1232,6 @@ func TestAfterFuncIf(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
 			o, err := New(Book(tt.book), AfterFuncIf(func(*RunResult) error {
 				return errors.New("after func error")
@@ -1267,7 +1260,6 @@ func TestStoreKeys(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
 			ts := testutil.HTTPServer(t)
 			t.Setenv("TEST_HTTP_ENDPOINT", ts.URL)
@@ -1293,7 +1285,6 @@ func TestTrace(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv("DEBUG", "false")
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
 			buf := new(bytes.Buffer)
 			ts := testutil.HTTPServer(t)
@@ -1337,7 +1328,6 @@ func TestLoop(t *testing.T) {
 	}
 	ctx := context.Background()
 	for i, tt := range tests {
-		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
 			key := fmt.Sprintf("testloop_count%d", i)
 			got := new(bytes.Buffer)
@@ -1416,7 +1406,6 @@ func TestStepResult(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
 			o, err := New(Book(tt.book), Force(tt.force), Scopes(scope.AllowRunExec))
 			if err != nil {
@@ -1462,7 +1451,6 @@ func TestStepOutcome(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
 			o, err := New(Book(tt.book), Force(tt.force), Scopes(scope.AllowRunExec))
 			if err != nil {

--- a/option.go
+++ b/option.go
@@ -905,10 +905,8 @@ func GRPCBufDir(dirs ...string) Option {
 			return ErrNilBook
 		}
 		for _, dir := range dirs {
-			s := strings.Split(dir, ",")
-			for _, dirs := range s {
-				s := strings.Split(dirs, "\n")
-				for _, dir := range s {
+			for dirs := range strings.SplitSeq(dir, ",") {
+				for dir := range strings.SplitSeq(dirs, "\n") {
 					if dir == "" {
 						continue
 					}
@@ -927,10 +925,8 @@ func GRPCBufLock(locks ...string) Option {
 			return ErrNilBook
 		}
 		for _, lock := range locks {
-			s := strings.Split(lock, ",")
-			for _, locks := range s {
-				s := strings.Split(locks, "\n")
-				for _, lock := range s {
+			for locks := range strings.SplitSeq(lock, ",") {
+				for lock := range strings.SplitSeq(locks, "\n") {
 					if lock == "" {
 						continue
 					}
@@ -949,10 +945,8 @@ func GRPCBufConfig(configs ...string) Option {
 			return ErrNilBook
 		}
 		for _, config := range configs {
-			s := strings.Split(config, ",")
-			for _, configs := range s {
-				s := strings.Split(configs, "\n")
-				for _, config := range s {
+			for configs := range strings.SplitSeq(config, ",") {
+				for config := range strings.SplitSeq(configs, "\n") {
 					if config == "" {
 						continue
 					}
@@ -971,10 +965,8 @@ func GRPCBufModule(modules ...string) Option {
 			return ErrNilBook
 		}
 		for _, module := range modules {
-			s := strings.Split(module, ",")
-			for _, modules := range s {
-				s := strings.Split(modules, "\n")
-				for _, module := range s {
+			for modules := range strings.SplitSeq(module, ",") {
+				for module := range strings.SplitSeq(modules, "\n") {
 					if module == "" {
 						continue
 					}
@@ -1061,10 +1053,8 @@ func RunID(ids ...string) Option { //nostyle:repetition
 			return ErrNilBook
 		}
 		for _, id := range ids {
-			s := strings.Split(id, ",")
-			for _, ids := range s {
-				s := strings.Split(ids, "\n")
-				for _, id := range s {
+			for ids := range strings.SplitSeq(id, ",") {
+				for id := range strings.SplitSeq(ids, "\n") {
 					if id == "" {
 						continue
 					}
@@ -1083,10 +1073,8 @@ func RunLabel(labels ...string) Option { //nostyle:repetition
 			return ErrNilBook
 		}
 		for _, label := range labels {
-			s := strings.Split(label, ",")
-			for _, labels := range s {
-				s := strings.Split(labels, "\n")
-				for _, label := range s {
+			for labels := range strings.SplitSeq(label, ",") {
+				for label := range strings.SplitSeq(labels, "\n") {
 					if label == "" {
 						continue
 					}
@@ -1221,8 +1209,7 @@ func HostRules(rules ...string) Option {
 			return ErrNilBook
 		}
 		for _, rule := range rules {
-			s := strings.Split(rule, ",")
-			for _, ss := range s {
+			for ss := range strings.SplitSeq(rule, ",") {
 				hostrule := strings.Split(strings.TrimSpace(ss), " ")
 				if len(hostrule) != 2 {
 					return fmt.Errorf("invalid host rule: %s", rule)

--- a/option_test.go
+++ b/option_test.go
@@ -1017,7 +1017,6 @@ func TestBuiltinFunctionBooks(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
 			t.Parallel()
 			o, err := New(Book(tt.book))

--- a/parse_test.go
+++ b/parse_test.go
@@ -591,7 +591,6 @@ func TestParseDuration(t *testing.T) {
 		{"0.5", 500 * time.Millisecond, false},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.in, func(t *testing.T) {
 			t.Parallel()
 			got, err := parseDuration(tt.in)

--- a/result.go
+++ b/result.go
@@ -338,11 +338,11 @@ func simplifyStepResults(stepResults []*StepResult) []*stepResultSimplified {
 
 func sprintMultilinef(lineformat, format string, a ...any) string {
 	lines := strings.Split(fmt.Sprintf(format, a...), "\n")
-	var formatted string
+	var sb strings.Builder
 	for _, l := range lines {
-		formatted += fmt.Sprintf(lineformat, l)
+		fmt.Fprintf(&sb, lineformat, l)
 	}
-	return formatted
+	return sb.String()
 }
 
 var (

--- a/result_test.go
+++ b/result_test.go
@@ -251,7 +251,6 @@ func TestResultElasped(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
 			o, err := New(Book(tt.book), Profile(true))
 			if err != nil {

--- a/runbook_test.go
+++ b/runbook_test.go
@@ -282,7 +282,6 @@ func TestRunbookYamlAnchorAndAlias(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.book, func(t *testing.T) {
 			t.Parallel()
 			o, err := New(Book(tt.book))

--- a/test_test.go
+++ b/test_test.go
@@ -19,7 +19,6 @@ func TestTestRun(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.cond, func(t *testing.T) {
 			o, err := New(Var("foo", map[string]any{
 				"bar": "baz",

--- a/vars_test.go
+++ b/vars_test.go
@@ -90,7 +90,6 @@ func TestEvaluateSchema(t *testing.T) {
 		}
 	})
 	for i, tt := range tests {
-		tt := tt
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			// t.Parallel()
 			got, err := evaluateSchema(tt.value, wd, tt.store)


### PR DESCRIPTION
- Remove unnecessary loop variable copies (forvar, Go 1.22+)
- Use strings.SplitSeq for range-only iteration (stringsseq)
- Use strings.Cut/CutSuffix/Contains instead of Index-based patterns
- Use reflect.TypeFor instead of reflect.TypeOf pattern
- Use fmt.Appendf instead of []byte(fmt.Sprintf(...))
- Use strings.Builder instead of string concatenation in loop