### PR TITLE
refactor: reorder methods to satisfy funcorder lint rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - gosec
     - misspell
     - revive
+    - funcorder
     - modernize
   settings:
     errcheck:

--- a/http.go
+++ b/http.go
@@ -127,60 +127,6 @@ func newHTTPRunnerWithHandler(name string, h http.Handler) (*httpRunner, error) 
 	}, nil
 }
 
-// configureTLS configures TLS settings on the HTTP transport.
-// Uses sync.Once to ensure TLS is configured exactly once,
-// even when the runner is shared across goroutines.
-func (rnr *httpRunner) configureTLS() error {
-	rnr.tlsOnce.Do(func() {
-		if rnr.client == nil {
-			return
-		}
-		if rnr.client.Transport == nil {
-			tp, ok := http.DefaultTransport.(*http.Transport)
-			if !ok {
-				rnr.tlsErr = fmt.Errorf("failed to cast: %v", http.DefaultTransport)
-				return
-			}
-			rnr.client.Transport = tp.Clone()
-		}
-		ts, ok := rnr.client.Transport.(*http.Transport)
-		if !ok {
-			if len(rnr.cacert) != 0 || len(rnr.cert) != 0 || len(rnr.key) != 0 {
-				rnr.tlsErr = fmt.Errorf("cannot configure TLS: client transport is %T, want *http.Transport", rnr.client.Transport)
-			}
-			return
-		}
-		if ts.TLSClientConfig != nil {
-			ts.TLSClientConfig = ts.TLSClientConfig.Clone()
-		} else {
-			ts.TLSClientConfig = new(tls.Config)
-		}
-		ts.TLSClientConfig.InsecureSkipVerify = rnr.skipVerify
-		if len(rnr.cacert) != 0 {
-			certpool, err := x509.SystemCertPool()
-			if err != nil {
-				// FIXME for Windows
-				// ref: https://github.com/golang/go/issues/18609
-				certpool = x509.NewCertPool()
-			}
-			if !certpool.AppendCertsFromPEM(rnr.cacert) {
-				rnr.tlsErr = fmt.Errorf("failed to append cacert")
-				return
-			}
-			ts.TLSClientConfig.RootCAs = certpool
-		}
-		if len(rnr.cert) != 0 && len(rnr.key) != 0 {
-			cert, err := tls.X509KeyPair(rnr.cert, rnr.key)
-			if err != nil {
-				rnr.tlsErr = err
-				return
-			}
-			ts.TLSClientConfig.Certificates = []tls.Certificate{cert}
-		}
-	})
-	return rnr.tlsErr
-}
-
 func (rnr *httpRunner) Close() error {
 	if rnr.client != nil {
 		rnr.client.CloseIdleConnections()
@@ -462,6 +408,60 @@ func (rnr *httpRunner) Run(ctx context.Context, s *step) error {
 		return err
 	}
 	return nil
+}
+
+// configureTLS configures TLS settings on the HTTP transport.
+// Uses sync.Once to ensure TLS is configured exactly once,
+// even when the runner is shared across goroutines.
+func (rnr *httpRunner) configureTLS() error {
+	rnr.tlsOnce.Do(func() {
+		if rnr.client == nil {
+			return
+		}
+		if rnr.client.Transport == nil {
+			tp, ok := http.DefaultTransport.(*http.Transport)
+			if !ok {
+				rnr.tlsErr = fmt.Errorf("failed to cast: %v", http.DefaultTransport)
+				return
+			}
+			rnr.client.Transport = tp.Clone()
+		}
+		ts, ok := rnr.client.Transport.(*http.Transport)
+		if !ok {
+			if len(rnr.cacert) != 0 || len(rnr.cert) != 0 || len(rnr.key) != 0 {
+				rnr.tlsErr = fmt.Errorf("cannot configure TLS: client transport is %T, want *http.Transport", rnr.client.Transport)
+			}
+			return
+		}
+		if ts.TLSClientConfig != nil {
+			ts.TLSClientConfig = ts.TLSClientConfig.Clone()
+		} else {
+			ts.TLSClientConfig = new(tls.Config)
+		}
+		ts.TLSClientConfig.InsecureSkipVerify = rnr.skipVerify
+		if len(rnr.cacert) != 0 {
+			certpool, err := x509.SystemCertPool()
+			if err != nil {
+				// FIXME for Windows
+				// ref: https://github.com/golang/go/issues/18609
+				certpool = x509.NewCertPool()
+			}
+			if !certpool.AppendCertsFromPEM(rnr.cacert) {
+				rnr.tlsErr = fmt.Errorf("failed to append cacert")
+				return
+			}
+			ts.TLSClientConfig.RootCAs = certpool
+		}
+		if len(rnr.cert) != 0 && len(rnr.key) != 0 {
+			cert, err := tls.X509KeyPair(rnr.cert, rnr.key)
+			if err != nil {
+				rnr.tlsErr = err
+				return
+			}
+			ts.TLSClientConfig.Certificates = []tls.Certificate{cert}
+		}
+	})
+	return rnr.tlsErr
 }
 
 func (rnr *httpRunner) run(ctx context.Context, r *httpRequest, s *step) error {

--- a/internal/exprtrace/tracer.go
+++ b/internal/exprtrace/tracer.go
@@ -80,6 +80,38 @@ var (
 	identifierTracerFuncPairValue         = ast.IdentifierNode{Value: keyTracerFuncPairValue}
 )
 
+func NewTracer(trace *EvalTraceStore, store EvalEnv) *Tracer {
+	builtinFunctionsMap := map[string]*exprbuiltin.Function{}
+
+	for _, function := range exprbuiltin.Builtins {
+		builtinFunctionsMap[function.Name] = function
+	}
+	mapper := &TagMapper{ptrMap: map[uintptr]int{}, counter: 0}
+	structFieldBaseNodes := map[uintptr]bool{}
+
+	return &Tracer{
+		trace:          trace,
+		store:          store,
+		contextType:    reflect.TypeFor[context.Context](),
+		traceTagType:   reflect.TypeFor[EvalTraceTag](),
+		funcAttrsCache: map[string]int{},
+		builtinsMap:    builtinFunctionsMap,
+		eval: patcherEvaluationPhaseFields{
+			closureEvalCount: map[TraceStoreKey]int{},
+		},
+		firstPhasePatcher: firstPhasePatcher{
+			trace:                trace,
+			mapper:               mapper,
+			structFieldBaseNodes: structFieldBaseNodes,
+		},
+		secondPhasePatcher: secondPhasePatcher{
+			patching:             patcherPatchingPhaseFields{},
+			mapper:               mapper,
+			structFieldBaseNodes: &structFieldBaseNodes,
+		},
+	}
+}
+
 func (t *Tracer) InstallTracerFunctions(store any) any {
 	var env map[string]any
 
@@ -112,292 +144,11 @@ func (t *Tracer) InstallTracerFunctions(store any) any {
 	return env
 }
 
-type NodeEvalResult interface { //nostyle:ifacenames
-	Output() any
-}
-
-type TraceEntry interface { //nostyle:ifacenames
-	EvalResultByCallCount(callCount int) NodeEvalResult
-}
-
-type traceEntry[T NodeEvalResult] struct {
-	tag         EvalTraceTag
-	evalResults []T
-}
-
-func (t *traceEntry[T]) EvalResultByCallCount(callCount int) NodeEvalResult {
-	return t.evalResults[callCount]
-}
-
-type callEvalResult struct {
-	output any
-}
-
-func (c *callEvalResult) Output() any {
-	return c.output
-}
-
-type closureEvalResult struct {
-	output any
-}
-
-func (c *closureEvalResult) Output() any {
-	return c.output
-}
-
-type builtinEvalResult struct {
-	output           any
-	closureEvalCount int
-}
-
-func (b *builtinEvalResult) Output() any {
-	return b.output
-}
-
-type binaryEvalResult struct {
-	output any
-}
-
-func (b *binaryEvalResult) Output() any {
-	return b.output
-}
-
-type conditionalEvalResult struct {
-	output any
-}
-
-func (c *conditionalEvalResult) Output() any {
-	return c.output
-}
-
-type identifierEvalResult struct {
-	value any
-}
-
-func (i *identifierEvalResult) Output() any {
-	return i.value
-}
-
-type pointerEvalResult struct {
-	value            any
-	closureCallCount int
-}
-
-func (p *pointerEvalResult) Output() any {
-	return p.value
-}
-
-type variableDeclaratorEvalResult struct {
-	value any
-}
-
-func (v *variableDeclaratorEvalResult) Output() any {
-	return v.value
-}
-
-type memberEvalResult struct {
-	value    any
-	optional bool
-	method   bool
-}
-
-func (m *memberEvalResult) Output() any {
-	return m.value
-}
-
-type mapEvalResult struct {
-	value map[string]any
-}
-
-func (m *mapEvalResult) Output() any {
-	return m.value
-}
-
-type boolEvalResult struct {
-	value any
-}
-
-func (b *boolEvalResult) Output() any {
-	return b.value
-}
-
-type integerEvalResult struct {
-	value any
-}
-
-func (i *integerEvalResult) Output() any {
-	return i.value
-}
-
-type floatEvalResult struct {
-	value any
-}
-
-func (f *floatEvalResult) Output() any {
-	return f.value
-}
-
-type pairEvalResult struct {
-	value any
-}
-
-func (p *pairEvalResult) Output() any {
-	return p.value
-}
-
-type arrayEvalResult struct {
-	values any
-}
-
-func (a *arrayEvalResult) Output() any {
-	return a.values
-}
-
-type sliceEvalResult struct {
-	values any
-}
-
-func (a *sliceEvalResult) Output() any {
-	return a.values
-}
-
-type baseTraceInfo struct {
-	tag EvalTraceTag
-}
-
-type IntegerNodeTraceInfo struct {
-	baseTraceInfo
-	integerNode *ast.IntegerNode
-}
-
-type FloatNodeTraceInfo struct {
-	baseTraceInfo
-	floatNode *ast.FloatNode
-}
-
-type CallNodeTraceInfo struct {
-	baseTraceInfo
-	callNode *ast.CallNode
-}
-
-type PredicateNodeTraceInfo struct {
-	baseTraceInfo
-	predicateNode *ast.PredicateNode
-	builtinTag    EvalTraceTag
-}
-
-type BuiltinNodeTraceInfo struct {
-	baseTraceInfo
-	builtinNode *ast.BuiltinNode
-}
-
-type BinaryNodeTraceInfo struct {
-	baseTraceInfo
-	binaryNode *ast.BinaryNode
-}
-
-type ArrayNodeTraceInfo struct {
-	baseTraceInfo
-	arrayNode *ast.ArrayNode
-}
-
-type SliceNodeTraceInfo struct {
-	baseTraceInfo
-	sliceNode *ast.SliceNode
-}
-
-type MapNodeTraceInfo struct {
-	baseTraceInfo
-	mapNode *ast.MapNode
-}
-
-type PairNodeTraceInfo struct {
-	baseTraceInfo
-	pairNode *ast.PairNode
-}
-
-type ConditionalNodeTraceInfo struct {
-	baseTraceInfo
-	conditionalNode *ast.ConditionalNode
-}
-
-type IdentifierNodeTraceInfo struct {
-	baseTraceInfo
-	identifierNode *ast.IdentifierNode
-}
-
-type PointerNodeTraceInfo struct {
-	baseTraceInfo
-	pointerNode *ast.PointerNode
-	closureTag  EvalTraceTag
-}
-
-type VariableDeclaratorNodeTraceInfo struct {
-	baseTraceInfo
-	variableDeclaratorNode *ast.VariableDeclaratorNode
-}
-
-type MemberNodeTraceInfo struct {
-	baseTraceInfo
-	memberNode *ast.MemberNode
-}
-
-type TagMapper struct {
-	ptrMap  map[uintptr]int
-	counter int
-}
-
-func (m *TagMapper) build(node ast.Node) {
-	ast.Walk(&node, m)
-}
-
-func (m *TagMapper) Visit(node *ast.Node) {
-	cnt := m.counter
-	cnt += 1
-	m.counter = cnt
-
-	ptr := reflect.ValueOf(*node).Pointer()
-	m.ptrMap[ptr] = cnt
-}
-
-func (m *TagMapper) indexByNode(node ast.Node) int {
-	ptr := reflect.ValueOf(node).Pointer()
-	if idx, ok := m.ptrMap[ptr]; ok {
-		return idx
-	} else {
-		return -1
-	}
-}
-
-func NewTracer(trace *EvalTraceStore, store EvalEnv) *Tracer {
-	builtinFunctionsMap := map[string]*exprbuiltin.Function{}
-
-	for _, function := range exprbuiltin.Builtins {
-		builtinFunctionsMap[function.Name] = function
-	}
-	mapper := &TagMapper{ptrMap: map[uintptr]int{}, counter: 0}
-	structFieldBaseNodes := map[uintptr]bool{}
-
-	return &Tracer{
-		trace:          trace,
-		store:          store,
-		contextType:    reflect.TypeFor[context.Context](),
-		traceTagType:   reflect.TypeFor[EvalTraceTag](),
-		funcAttrsCache: map[string]int{},
-		builtinsMap:    builtinFunctionsMap,
-		eval: patcherEvaluationPhaseFields{
-			closureEvalCount: map[TraceStoreKey]int{},
-		},
-		firstPhasePatcher: firstPhasePatcher{
-			trace:                trace,
-			mapper:               mapper,
-			structFieldBaseNodes: structFieldBaseNodes,
-		},
-		secondPhasePatcher: secondPhasePatcher{
-			patching:             patcherPatchingPhaseFields{},
-			mapper:               mapper,
-			structFieldBaseNodes: &structFieldBaseNodes,
-		},
+func (t *Tracer) Patches() []expr.Option {
+	return []expr.Option{
+		expr.Patch(&t.firstPhasePatcher),
+		expr.Patch(&t.secondPhasePatcher),
+		expr.AllowUndefinedVariables(), // Add this option to allow undefined variables like Bar in $env?.[Bar]
 	}
 }
 
@@ -690,6 +441,7 @@ func (t *Tracer) traceSlice(values any, info *SliceNodeTraceInfo) any {
 
 	return values
 }
+
 func (t *Tracer) traceMap(value map[string]any, info *MapNodeTraceInfo) map[string]any {
 	entry, ok := traceEntryByTag[*mapEvalResult](t.trace, info.tag)
 	if !ok {
@@ -730,11 +482,260 @@ func (t *Tracer) tracePairValue(value any, info *PairNodeTraceInfo) any {
 	return value
 }
 
-func (t *Tracer) Patches() []expr.Option {
-	return []expr.Option{
-		expr.Patch(&t.firstPhasePatcher),
-		expr.Patch(&t.secondPhasePatcher),
-		expr.AllowUndefinedVariables(), // Add this option to allow undefined variables like Bar in $env?.[Bar]
+type NodeEvalResult interface { //nostyle:ifacenames
+	Output() any
+}
+
+type TraceEntry interface { //nostyle:ifacenames
+	EvalResultByCallCount(callCount int) NodeEvalResult
+}
+
+type traceEntry[T NodeEvalResult] struct {
+	tag         EvalTraceTag
+	evalResults []T
+}
+
+func (t *traceEntry[T]) EvalResultByCallCount(callCount int) NodeEvalResult {
+	return t.evalResults[callCount]
+}
+
+type callEvalResult struct {
+	output any
+}
+
+func (c *callEvalResult) Output() any {
+	return c.output
+}
+
+type closureEvalResult struct {
+	output any
+}
+
+func (c *closureEvalResult) Output() any {
+	return c.output
+}
+
+type builtinEvalResult struct {
+	output           any
+	closureEvalCount int
+}
+
+func (b *builtinEvalResult) Output() any {
+	return b.output
+}
+
+type binaryEvalResult struct {
+	output any
+}
+
+func (b *binaryEvalResult) Output() any {
+	return b.output
+}
+
+type conditionalEvalResult struct {
+	output any
+}
+
+func (c *conditionalEvalResult) Output() any {
+	return c.output
+}
+
+type identifierEvalResult struct {
+	value any
+}
+
+func (i *identifierEvalResult) Output() any {
+	return i.value
+}
+
+type pointerEvalResult struct {
+	value            any
+	closureCallCount int
+}
+
+func (p *pointerEvalResult) Output() any {
+	return p.value
+}
+
+type variableDeclaratorEvalResult struct {
+	value any
+}
+
+func (v *variableDeclaratorEvalResult) Output() any {
+	return v.value
+}
+
+type memberEvalResult struct {
+	value    any
+	optional bool
+	method   bool
+}
+
+func (m *memberEvalResult) Output() any {
+	return m.value
+}
+
+type mapEvalResult struct {
+	value map[string]any
+}
+
+func (m *mapEvalResult) Output() any {
+	return m.value
+}
+
+type boolEvalResult struct {
+	value any
+}
+
+func (b *boolEvalResult) Output() any {
+	return b.value
+}
+
+type integerEvalResult struct {
+	value any
+}
+
+func (i *integerEvalResult) Output() any {
+	return i.value
+}
+
+type floatEvalResult struct {
+	value any
+}
+
+func (f *floatEvalResult) Output() any {
+	return f.value
+}
+
+type pairEvalResult struct {
+	value any
+}
+
+func (p *pairEvalResult) Output() any {
+	return p.value
+}
+
+type arrayEvalResult struct {
+	values any
+}
+
+func (a *arrayEvalResult) Output() any {
+	return a.values
+}
+
+type sliceEvalResult struct {
+	values any
+}
+
+func (a *sliceEvalResult) Output() any {
+	return a.values
+}
+
+type baseTraceInfo struct {
+	tag EvalTraceTag
+}
+
+type IntegerNodeTraceInfo struct {
+	baseTraceInfo
+	integerNode *ast.IntegerNode
+}
+
+type FloatNodeTraceInfo struct {
+	baseTraceInfo
+	floatNode *ast.FloatNode
+}
+
+type CallNodeTraceInfo struct {
+	baseTraceInfo
+	callNode *ast.CallNode
+}
+
+type PredicateNodeTraceInfo struct {
+	baseTraceInfo
+	predicateNode *ast.PredicateNode
+	builtinTag    EvalTraceTag
+}
+
+type BuiltinNodeTraceInfo struct {
+	baseTraceInfo
+	builtinNode *ast.BuiltinNode
+}
+
+type BinaryNodeTraceInfo struct {
+	baseTraceInfo
+	binaryNode *ast.BinaryNode
+}
+
+type ArrayNodeTraceInfo struct {
+	baseTraceInfo
+	arrayNode *ast.ArrayNode
+}
+
+type SliceNodeTraceInfo struct {
+	baseTraceInfo
+	sliceNode *ast.SliceNode
+}
+
+type MapNodeTraceInfo struct {
+	baseTraceInfo
+	mapNode *ast.MapNode
+}
+
+type PairNodeTraceInfo struct {
+	baseTraceInfo
+	pairNode *ast.PairNode
+}
+
+type ConditionalNodeTraceInfo struct {
+	baseTraceInfo
+	conditionalNode *ast.ConditionalNode
+}
+
+type IdentifierNodeTraceInfo struct {
+	baseTraceInfo
+	identifierNode *ast.IdentifierNode
+}
+
+type PointerNodeTraceInfo struct {
+	baseTraceInfo
+	pointerNode *ast.PointerNode
+	closureTag  EvalTraceTag
+}
+
+type VariableDeclaratorNodeTraceInfo struct {
+	baseTraceInfo
+	variableDeclaratorNode *ast.VariableDeclaratorNode
+}
+
+type MemberNodeTraceInfo struct {
+	baseTraceInfo
+	memberNode *ast.MemberNode
+}
+
+type TagMapper struct {
+	ptrMap  map[uintptr]int
+	counter int
+}
+
+func (m *TagMapper) Visit(node *ast.Node) {
+	cnt := m.counter
+	cnt += 1
+	m.counter = cnt
+
+	ptr := reflect.ValueOf(*node).Pointer()
+	m.ptrMap[ptr] = cnt
+}
+
+func (m *TagMapper) build(node ast.Node) {
+	ast.Walk(&node, m)
+}
+
+func (m *TagMapper) indexByNode(node ast.Node) int {
+	ptr := reflect.ValueOf(node).Pointer()
+	if idx, ok := m.ptrMap[ptr]; ok {
+		return idx
+	} else {
+		return -1
 	}
 }
 

--- a/internal/exprtrace/tree_printer.go
+++ b/internal/exprtrace/tree_printer.go
@@ -77,6 +77,33 @@ type treePrinter struct {
 	config        *treePrinterConfig
 }
 
+func (tp *treePrinter) EvalEnv() EvalEnv {
+	return tp.env
+}
+
+func (tp *treePrinter) PeekNodeEvalResultOutput(node ast.Node) any {
+	tag := buildTag(tp.mapper, node)
+	cnt := tp.callCounterByTag(tag) + 1
+	t, _ := tp.trace.TraceEntryByTag(tag)
+
+	switch typedNode := node.(type) {
+	case *ast.NilNode:
+		return nil
+	case *ast.BoolNode:
+		return typedNode.Value
+	case *ast.IntegerNode:
+		return typedNode.Value
+	case *ast.FloatNode:
+		return typedNode.Value
+	case *ast.ConstantNode:
+		return typedNode.Value
+	case *ast.StringNode:
+		return typedNode.Value
+	default:
+		return t.EvalResultByCallCount(cnt).Output()
+	}
+}
+
 func (tp *treePrinter) formatLabel(prefix string, label fmt.Stringer, output any) string {
 	sb := tp.stringBuilder
 	sb.Reset()
@@ -401,33 +428,6 @@ func (tp *treePrinter) walkPredicateNode(node ast.Node, print treeprint.Tree, la
 	} else {
 		label := tp.formatLabel(labelPrefix, node, labelNotEvaluated)
 		tp.addBranch(print, -1, label)
-	}
-}
-
-func (tp *treePrinter) EvalEnv() EvalEnv {
-	return tp.env
-}
-
-func (tp *treePrinter) PeekNodeEvalResultOutput(node ast.Node) any {
-	tag := buildTag(tp.mapper, node)
-	cnt := tp.callCounterByTag(tag) + 1
-	t, _ := tp.trace.TraceEntryByTag(tag)
-
-	switch typedNode := node.(type) {
-	case *ast.NilNode:
-		return nil
-	case *ast.BoolNode:
-		return typedNode.Value
-	case *ast.IntegerNode:
-		return typedNode.Value
-	case *ast.FloatNode:
-		return typedNode.Value
-	case *ast.ConstantNode:
-		return typedNode.Value
-	case *ast.StringNode:
-		return typedNode.Value
-	default:
-		return t.EvalResultByCallCount(cnt).Output()
 	}
 }
 

--- a/operator.go
+++ b/operator.go
@@ -110,14 +110,256 @@ type operator struct {
 	mu sync.Mutex
 }
 
+// New returns *operator.
+func New(opts ...Option) (*operator, error) {
+	bk := newBook()
+	if err := bk.applyOptions(opts...); err != nil {
+		return nil, err
+	}
+	id, err := generateRandomID()
+	if err != nil {
+		return nil, err
+	}
+	st := store.New(bk.vars, bk.funcs, bk.secrets, bk.stepKeys)
+	op := &operator{
+		id:             id,
+		httpRunners:    map[string]*httpRunner{},
+		dbRunners:      map[string]*dbRunner{},
+		grpcRunners:    map[string]*grpcRunner{},
+		cdpRunners:     map[string]*cdpRunner{},
+		sshRunners:     map[string]*sshRunner{},
+		includeRunners: map[string]*includeRunner{},
+		deferred:       &deferredOpAndSteps{},
+		store:          st,
+		useMap:         bk.useMap,
+		desc:           bk.desc,
+		labels:         bk.labels,
+		debug:          bk.debug,
+		nm:             waitmap.New[string, *store.Store](),
+		profile:        bk.profile,
+		interval:       bk.interval,
+		loop:           bk.loop,
+		concurrency:    bk.concurrency,
+		t:              bk.t,
+		thisT:          bk.t,
+		force:          bk.force,
+		trace:          bk.trace,
+		waitTimeout:    bk.waitTimeout,
+		included:       bk.included,
+		ifCond:         bk.ifCond,
+		skipTest:       bk.skipTest,
+		stdout:         st.MaskRule().NewWriter(bk.stdout),
+		stderr:         st.MaskRule().NewWriter(bk.stderr),
+		newOnly:        bk.loadOnly,
+		bookPath:       bk.path,
+		beforeFuncs:    bk.beforeFuncs,
+		afterFuncs:     bk.afterFuncs,
+		sw:             stopw.New(),
+		capturers:      bk.capturers,
+		runResult:      newRunResult(bk.desc, bk.labels, bk.path, bk.included, st),
+		dbg:            newDBG(bk.attach),
+		maskRule:       st.MaskRule(),
+	}
+
+	if op.debug {
+		op.capturers = append(op.capturers, NewDebugger(op.stderr))
+	}
+
+	root, err := bk.generateOperatorRoot()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate root path (%s): %w", bk.path, err)
+	}
+	op.root = root
+
+	var loErr error
+	op.needs = lo.MapEntries(bk.needs, func(key string, path string) (string, *need) {
+		p, err := fs.Path(path, op.root)
+		if err != nil {
+			loErr = errors.Join(loErr, err)
+		}
+		return key, &need{
+			path: p,
+		}
+	})
+	if loErr != nil {
+		return nil, loErr
+	}
+
+	// The host rules specified by the option take precedence.
+	hostRules := append(bk.hostRulesFromOpts, bk.hostRules...)
+
+	for k, v := range bk.httpRunners {
+		if _, ok := v.validator.(*nopValidator); ok {
+			for _, l := range bk.openAPI3DocLocations {
+				key, p := fs.SplitKeyAndPath(l)
+				if key != "" && key != k {
+					continue
+				}
+				c := &httpRunnerConfig{
+					OpenAPI3DocLocation: p,
+				}
+
+				runner, ok := bk.runners[k].(map[string]any)
+				if ok {
+					c.SkipValidateRequest, _ = runner["skipValidateRequest"].(bool)
+					c.SkipValidateResponse, _ = runner["skipValidateResponse"].(bool)
+				}
+
+				val, err := newHttpValidator(c)
+				if err != nil {
+					return nil, err
+				}
+				v.validator = val
+				break
+			}
+		}
+		if len(hostRules) > 0 {
+			tp, ok := v.client.Transport.(*http.Transport)
+			if !ok {
+				return nil, fmt.Errorf("failed to cast: %v", v.client.Transport)
+			}
+			tp.DialContext = hostRules.dialContextFunc()
+		}
+		if err := v.configureTLS(); err != nil {
+			return nil, err
+		}
+		op.httpRunners[k] = v
+	}
+	for k, v := range bk.dbRunners {
+		if len(hostRules) > 0 {
+			v.hostRules = hostRules
+			if err := v.Renew(); err != nil {
+				return nil, err
+			}
+		}
+		if v.operatorID == "" {
+			v.operatorID = op.id
+		}
+		op.dbRunners[k] = v
+	}
+	for k, v := range bk.grpcRunners {
+		if bk.grpcNoTLS {
+			useTLS := false
+			v.tls = &useTLS
+		}
+		for _, proto := range bk.grpcProtos {
+			key, p := fs.SplitKeyAndPath(proto)
+			if key != "" && key != k {
+				continue
+			}
+			v.protos = append(v.protos, p)
+		}
+		for _, ip := range bk.grpcImportPaths {
+			key, p := fs.SplitKeyAndPath(ip)
+			if key != "" && key != k {
+				continue
+			}
+			v.importPaths = append(v.importPaths, p)
+		}
+		v.bufDirs = sliceutil.Unique(append(v.bufDirs, bk.grpcBufDirs...))
+		v.bufLocks = sliceutil.Unique(append(v.bufLocks, bk.grpcBufLocks...))
+		v.bufConfigs = sliceutil.Unique(append(v.bufConfigs, bk.grpcBufConfigs...))
+		v.bufModules = sliceutil.Unique(append(v.bufModules, bk.grpcBufModules...))
+		if len(hostRules) > 0 {
+			v.hostRules = hostRules
+			if err := v.Renew(); err != nil {
+				return nil, err
+			}
+		}
+		if v.operatorID == "" {
+			v.operatorID = op.id
+		}
+		op.grpcRunners[k] = v
+	}
+	for k, v := range bk.cdpRunners {
+		if len(hostRules) > 0 {
+			v.opts = append(v.opts, hostRules.chromedpOpt())
+		}
+		if err := v.Renew(); err != nil {
+			return nil, err
+		}
+		if v.operatorID == "" {
+			v.operatorID = op.id
+		}
+		op.cdpRunners[k] = v
+	}
+	for k, v := range bk.sshRunners {
+		if len(hostRules) > 0 {
+			v.hostRules = hostRules
+			if err := v.Renew(); err != nil {
+				return nil, err
+			}
+		}
+		if v.operatorID == "" {
+			v.operatorID = op.id
+		}
+		op.sshRunners[k] = v
+	}
+	maps.Copy(op.includeRunners, bk.includeRunners)
+
+	keys := map[string]struct{}{}
+	for k := range op.httpRunners {
+		keys[k] = struct{}{}
+	}
+	for k := range op.dbRunners {
+		if _, ok := keys[k]; ok {
+			return nil, fmt.Errorf("duplicate runner names (%s): %s", op.bookPath, k)
+		}
+		keys[k] = struct{}{}
+	}
+	for k := range op.grpcRunners {
+		if _, ok := keys[k]; ok {
+			return nil, fmt.Errorf("duplicate runner names (%s): %s", op.bookPath, k)
+		}
+		keys[k] = struct{}{}
+	}
+	for k := range op.cdpRunners {
+		if _, ok := keys[k]; ok {
+			return nil, fmt.Errorf("duplicate runner names (%s): %s", op.bookPath, k)
+		}
+		keys[k] = struct{}{}
+	}
+	for k := range op.sshRunners {
+		if _, ok := keys[k]; ok {
+			return nil, fmt.Errorf("duplicate runner names (%s): %s", op.bookPath, k)
+		}
+		keys[k] = struct{}{}
+	}
+	for k := range op.includeRunners {
+		if _, ok := keys[k]; ok {
+			return nil, fmt.Errorf("duplicate runner names (%s): %s", op.bookPath, k)
+		}
+		keys[k] = struct{}{}
+	}
+	var errs error
+	for k, err := range bk.runnerErrs {
+		errs = errors.Join(errs, fmt.Errorf("runner %s error: %w", k, err))
+	}
+	if errs != nil && !op.newOnly {
+		return nil, fmt.Errorf("failed to add runners (%s): %w", op.bookPath, errs)
+	}
+
+	op.numberOfSteps = len(bk.rawSteps)
+
+	for i, s := range bk.rawSteps {
+		key := fmt.Sprintf("%d", i)
+		if op.useMap {
+			key = bk.stepKeys[i]
+		}
+		if err := op.appendStep(i, key, s); err != nil {
+			if op.newOnly {
+				continue
+			}
+			return nil, fmt.Errorf("failed to append step (%s): %w", op.bookPath, err)
+		}
+	}
+
+	return op, nil
+}
+
 // ID returns the unique identifier of the current runbook.
 func (op *operator) ID() string {
 	return op.id
-}
-
-// runbookID returns id of the root runbook.
-func (op *operator) runbookID() string { //nolint:unused
-	return op.trails().runbookID()
 }
 
 // Desc returns the description of the runbook.
@@ -181,6 +423,125 @@ func (op *operator) Close(force bool) {
 	for _, r := range op.httpRunners {
 		_ = r.Close()
 	}
+}
+
+// Run executes the runbook with the given context.
+// It handles context cancellation, waits for sub-processes to complete,
+// and returns any errors encountered during execution.
+func (op *operator) Run(ctx context.Context) (err error) {
+	defer deprecation.PrintWarnings()
+	cctx, cancel := donegroup.WithCancel(ctx)
+	defer func() {
+		cancel()
+		var errr error
+		if op.waitTimeout > 0 {
+			errr = donegroup.WaitWithTimeout(cctx, op.waitTimeout)
+		} else {
+			errr = donegroup.Wait(cctx)
+		}
+		err = errors.Join(err, errr)
+		op.nm.Close()
+	}()
+	if op.t != nil {
+		op.t.Helper()
+	}
+	if !op.profile {
+		op.sw.Disable()
+	}
+	opn := op.toOperatorN()
+	result, err := opn.runN(cctx)
+	opn.mu.Lock()
+	opn.results = append(opn.results, result)
+	opn.mu.Unlock()
+	if err != nil {
+		if !errors.Is(err, ErrFailFast) {
+			return err
+		}
+	}
+	return result.RunResults[len(result.RunResults)-1].Err
+}
+
+// DumpProfile writes the execution profile data to the provided writer.
+// It returns an error if profiling was not enabled or if writing fails.
+func (op *operator) DumpProfile(w io.Writer) error {
+	r := op.sw.Result()
+	if r == nil {
+		return errors.New("no profile")
+	}
+	// Use encoding/json because goccy/go-json got a SIGSEGV error due to the increase in Trail fields.
+	enc := ejson.NewEncoder(w)
+	if err := enc.Encode(r); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Result returns the execution result of the runbook.
+// It includes information about the execution status, errors, and captured data.
+func (op *operator) Result() *RunResult {
+	op.runResult.ID = op.runbookID()
+	r := op.sw.Result()
+	if r != nil {
+		if err := setElasped(op.runResult, r); err != nil {
+			panic(err)
+		}
+	}
+	return op.runResult
+}
+
+// Debugln prints a debug message followed by a newline when debug mode is enabled.
+func (op *operator) Debugln(a any) {
+	if !op.debug {
+		return
+	}
+	_, _ = fmt.Fprintln(op.stderr, a)
+}
+
+// Debugf prints a formatted debug message when debug mode is enabled.
+func (op *operator) Debugf(format string, a ...any) {
+	if !op.debug {
+		return
+	}
+	_, _ = fmt.Fprintf(op.stderr, format, a...) //nolint:gosec
+}
+
+// Warnln prints a warning message followed by a newline to stderr.
+func (op *operator) Warnln(a any) {
+	_, _ = fmt.Fprintln(op.stderr, a)
+}
+
+// Warnf prints a formatted warning message to stderr.
+func (op *operator) Warnf(format string, a ...any) {
+	_, _ = fmt.Fprintf(op.stderr, format, a...)
+}
+
+// Skipped returns whether the runbook execution was skipped.
+func (op *operator) Skipped() bool {
+	return op.skipped
+}
+
+// StepResults returns the execution results of all steps in the runbook.
+func (op *operator) StepResults() []*StepResult {
+	var results []*StepResult
+	for _, s := range op.steps {
+		if lo.ContainsBy(op.deferred.steps, func(op *deferredOpAndStep) bool {
+			return s.runbookID() == op.step.runbookID()
+		}) {
+			continue
+		}
+		results = append(results, s.result)
+	}
+	for _, os := range op.deferred.steps {
+		if op.id == os.op.id {
+			results = append(results, os.step.result)
+		}
+	}
+	return results
+}
+
+// runbookID returns id of the root runbook.
+func (op *operator) runbookID() string { //nolint:unused
+	return op.trails().runbookID()
 }
 
 func (op *operator) runStep(ctx context.Context, s *step) error {
@@ -484,253 +845,6 @@ func (op *operator) trails() Trails {
 	return trs
 }
 
-// New returns *operator.
-func New(opts ...Option) (*operator, error) {
-	bk := newBook()
-	if err := bk.applyOptions(opts...); err != nil {
-		return nil, err
-	}
-	id, err := generateRandomID()
-	if err != nil {
-		return nil, err
-	}
-	st := store.New(bk.vars, bk.funcs, bk.secrets, bk.stepKeys)
-	op := &operator{
-		id:             id,
-		httpRunners:    map[string]*httpRunner{},
-		dbRunners:      map[string]*dbRunner{},
-		grpcRunners:    map[string]*grpcRunner{},
-		cdpRunners:     map[string]*cdpRunner{},
-		sshRunners:     map[string]*sshRunner{},
-		includeRunners: map[string]*includeRunner{},
-		deferred:       &deferredOpAndSteps{},
-		store:          st,
-		useMap:         bk.useMap,
-		desc:           bk.desc,
-		labels:         bk.labels,
-		debug:          bk.debug,
-		nm:             waitmap.New[string, *store.Store](),
-		profile:        bk.profile,
-		interval:       bk.interval,
-		loop:           bk.loop,
-		concurrency:    bk.concurrency,
-		t:              bk.t,
-		thisT:          bk.t,
-		force:          bk.force,
-		trace:          bk.trace,
-		waitTimeout:    bk.waitTimeout,
-		included:       bk.included,
-		ifCond:         bk.ifCond,
-		skipTest:       bk.skipTest,
-		stdout:         st.MaskRule().NewWriter(bk.stdout),
-		stderr:         st.MaskRule().NewWriter(bk.stderr),
-		newOnly:        bk.loadOnly,
-		bookPath:       bk.path,
-		beforeFuncs:    bk.beforeFuncs,
-		afterFuncs:     bk.afterFuncs,
-		sw:             stopw.New(),
-		capturers:      bk.capturers,
-		runResult:      newRunResult(bk.desc, bk.labels, bk.path, bk.included, st),
-		dbg:            newDBG(bk.attach),
-		maskRule:       st.MaskRule(),
-	}
-
-	if op.debug {
-		op.capturers = append(op.capturers, NewDebugger(op.stderr))
-	}
-
-	root, err := bk.generateOperatorRoot()
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate root path (%s): %w", bk.path, err)
-	}
-	op.root = root
-
-	var loErr error
-	op.needs = lo.MapEntries(bk.needs, func(key string, path string) (string, *need) {
-		p, err := fs.Path(path, op.root)
-		if err != nil {
-			loErr = errors.Join(loErr, err)
-		}
-		return key, &need{
-			path: p,
-		}
-	})
-	if loErr != nil {
-		return nil, loErr
-	}
-
-	// The host rules specified by the option take precedence.
-	hostRules := append(bk.hostRulesFromOpts, bk.hostRules...)
-
-	for k, v := range bk.httpRunners {
-		if _, ok := v.validator.(*nopValidator); ok {
-			for _, l := range bk.openAPI3DocLocations {
-				key, p := fs.SplitKeyAndPath(l)
-				if key != "" && key != k {
-					continue
-				}
-				c := &httpRunnerConfig{
-					OpenAPI3DocLocation: p,
-				}
-
-				runner, ok := bk.runners[k].(map[string]any)
-				if ok {
-					c.SkipValidateRequest, _ = runner["skipValidateRequest"].(bool)
-					c.SkipValidateResponse, _ = runner["skipValidateResponse"].(bool)
-				}
-
-				val, err := newHttpValidator(c)
-				if err != nil {
-					return nil, err
-				}
-				v.validator = val
-				break
-			}
-		}
-		if len(hostRules) > 0 {
-			tp, ok := v.client.Transport.(*http.Transport)
-			if !ok {
-				return nil, fmt.Errorf("failed to cast: %v", v.client.Transport)
-			}
-			tp.DialContext = hostRules.dialContextFunc()
-		}
-		if err := v.configureTLS(); err != nil {
-			return nil, err
-		}
-		op.httpRunners[k] = v
-	}
-	for k, v := range bk.dbRunners {
-		if len(hostRules) > 0 {
-			v.hostRules = hostRules
-			if err := v.Renew(); err != nil {
-				return nil, err
-			}
-		}
-		if v.operatorID == "" {
-			v.operatorID = op.id
-		}
-		op.dbRunners[k] = v
-	}
-	for k, v := range bk.grpcRunners {
-		if bk.grpcNoTLS {
-			useTLS := false
-			v.tls = &useTLS
-		}
-		for _, proto := range bk.grpcProtos {
-			key, p := fs.SplitKeyAndPath(proto)
-			if key != "" && key != k {
-				continue
-			}
-			v.protos = append(v.protos, p)
-		}
-		for _, ip := range bk.grpcImportPaths {
-			key, p := fs.SplitKeyAndPath(ip)
-			if key != "" && key != k {
-				continue
-			}
-			v.importPaths = append(v.importPaths, p)
-		}
-		v.bufDirs = sliceutil.Unique(append(v.bufDirs, bk.grpcBufDirs...))
-		v.bufLocks = sliceutil.Unique(append(v.bufLocks, bk.grpcBufLocks...))
-		v.bufConfigs = sliceutil.Unique(append(v.bufConfigs, bk.grpcBufConfigs...))
-		v.bufModules = sliceutil.Unique(append(v.bufModules, bk.grpcBufModules...))
-		if len(hostRules) > 0 {
-			v.hostRules = hostRules
-			if err := v.Renew(); err != nil {
-				return nil, err
-			}
-		}
-		if v.operatorID == "" {
-			v.operatorID = op.id
-		}
-		op.grpcRunners[k] = v
-	}
-	for k, v := range bk.cdpRunners {
-		if len(hostRules) > 0 {
-			v.opts = append(v.opts, hostRules.chromedpOpt())
-		}
-		if err := v.Renew(); err != nil {
-			return nil, err
-		}
-		if v.operatorID == "" {
-			v.operatorID = op.id
-		}
-		op.cdpRunners[k] = v
-	}
-	for k, v := range bk.sshRunners {
-		if len(hostRules) > 0 {
-			v.hostRules = hostRules
-			if err := v.Renew(); err != nil {
-				return nil, err
-			}
-		}
-		if v.operatorID == "" {
-			v.operatorID = op.id
-		}
-		op.sshRunners[k] = v
-	}
-	maps.Copy(op.includeRunners, bk.includeRunners)
-
-	keys := map[string]struct{}{}
-	for k := range op.httpRunners {
-		keys[k] = struct{}{}
-	}
-	for k := range op.dbRunners {
-		if _, ok := keys[k]; ok {
-			return nil, fmt.Errorf("duplicate runner names (%s): %s", op.bookPath, k)
-		}
-		keys[k] = struct{}{}
-	}
-	for k := range op.grpcRunners {
-		if _, ok := keys[k]; ok {
-			return nil, fmt.Errorf("duplicate runner names (%s): %s", op.bookPath, k)
-		}
-		keys[k] = struct{}{}
-	}
-	for k := range op.cdpRunners {
-		if _, ok := keys[k]; ok {
-			return nil, fmt.Errorf("duplicate runner names (%s): %s", op.bookPath, k)
-		}
-		keys[k] = struct{}{}
-	}
-	for k := range op.sshRunners {
-		if _, ok := keys[k]; ok {
-			return nil, fmt.Errorf("duplicate runner names (%s): %s", op.bookPath, k)
-		}
-		keys[k] = struct{}{}
-	}
-	for k := range op.includeRunners {
-		if _, ok := keys[k]; ok {
-			return nil, fmt.Errorf("duplicate runner names (%s): %s", op.bookPath, k)
-		}
-		keys[k] = struct{}{}
-	}
-	var errs error
-	for k, err := range bk.runnerErrs {
-		errs = errors.Join(errs, fmt.Errorf("runner %s error: %w", k, err))
-	}
-	if errs != nil && !op.newOnly {
-		return nil, fmt.Errorf("failed to add runners (%s): %w", op.bookPath, errs)
-	}
-
-	op.numberOfSteps = len(bk.rawSteps)
-
-	for i, s := range bk.rawSteps {
-		key := fmt.Sprintf("%d", i)
-		if op.useMap {
-			key = bk.stepKeys[i]
-		}
-		if err := op.appendStep(i, key, s); err != nil {
-			if op.newOnly {
-				continue
-			}
-			return nil, fmt.Errorf("failed to append step (%s): %w", op.bookPath, err)
-		}
-	}
-
-	return op, nil
-}
-
 // appendStep appends step.
 func (op *operator) appendStep(idx int, key string, s map[string]any) error {
 	if op.t != nil {
@@ -950,70 +1064,6 @@ func (op *operator) appendStep(idx int, key string, s map[string]any) error {
 
 	op.steps = append(op.steps, st)
 	return nil
-}
-
-// Run executes the runbook with the given context.
-// It handles context cancellation, waits for sub-processes to complete,
-// and returns any errors encountered during execution.
-func (op *operator) Run(ctx context.Context) (err error) {
-	defer deprecation.PrintWarnings()
-	cctx, cancel := donegroup.WithCancel(ctx)
-	defer func() {
-		cancel()
-		var errr error
-		if op.waitTimeout > 0 {
-			errr = donegroup.WaitWithTimeout(cctx, op.waitTimeout)
-		} else {
-			errr = donegroup.Wait(cctx)
-		}
-		err = errors.Join(err, errr)
-		op.nm.Close()
-	}()
-	if op.t != nil {
-		op.t.Helper()
-	}
-	if !op.profile {
-		op.sw.Disable()
-	}
-	opn := op.toOperatorN()
-	result, err := opn.runN(cctx)
-	opn.mu.Lock()
-	opn.results = append(opn.results, result)
-	opn.mu.Unlock()
-	if err != nil {
-		if !errors.Is(err, ErrFailFast) {
-			return err
-		}
-	}
-	return result.RunResults[len(result.RunResults)-1].Err
-}
-
-// DumpProfile writes the execution profile data to the provided writer.
-// It returns an error if profiling was not enabled or if writing fails.
-func (op *operator) DumpProfile(w io.Writer) error {
-	r := op.sw.Result()
-	if r == nil {
-		return errors.New("no profile")
-	}
-	// Use encoding/json because goccy/go-json got a SIGSEGV error due to the increase in Trail fields.
-	enc := ejson.NewEncoder(w)
-	if err := enc.Encode(r); err != nil {
-		return err
-	}
-	return nil
-}
-
-// Result returns the execution result of the runbook.
-// It includes information about the execution status, errors, and captured data.
-func (op *operator) Result() *RunResult {
-	op.runResult.ID = op.runbookID()
-	r := op.sw.Result()
-	if r != nil {
-		if err := setElasped(op.runResult, r); err != nil {
-			panic(err)
-		}
-	}
-	return op.runResult
 }
 
 func (op *operator) clearResult() {
@@ -1382,37 +1432,6 @@ func (op *operator) expandCondBeforeRecord(ifCond string, s *step) (bool, error)
 	return expr.EvalCond(ifCond, sm)
 }
 
-// Debugln prints a debug message followed by a newline when debug mode is enabled.
-func (op *operator) Debugln(a any) {
-	if !op.debug {
-		return
-	}
-	_, _ = fmt.Fprintln(op.stderr, a)
-}
-
-// Debugf prints a formatted debug message when debug mode is enabled.
-func (op *operator) Debugf(format string, a ...any) {
-	if !op.debug {
-		return
-	}
-	_, _ = fmt.Fprintf(op.stderr, format, a...) //nolint:gosec
-}
-
-// Warnln prints a warning message followed by a newline to stderr.
-func (op *operator) Warnln(a any) {
-	_, _ = fmt.Fprintln(op.stderr, a)
-}
-
-// Warnf prints a formatted warning message to stderr.
-func (op *operator) Warnf(format string, a ...any) {
-	_, _ = fmt.Fprintf(op.stderr, format, a...)
-}
-
-// Skipped returns whether the runbook execution was skipped.
-func (op *operator) Skipped() bool {
-	return op.skipped
-}
-
 func (op *operator) skip() error {
 	op.Debugf(yellow("Skip %s\n"), op.desc)
 	op.skipped = true
@@ -1448,25 +1467,6 @@ func (op *operator) toOperatorN() *operatorN {
 	_ = opn.traverseOperators(op)
 
 	return opn
-}
-
-// StepResults returns the execution results of all steps in the runbook.
-func (op *operator) StepResults() []*StepResult {
-	var results []*StepResult
-	for _, s := range op.steps {
-		if lo.ContainsBy(op.deferred.steps, func(op *deferredOpAndStep) bool {
-			return s.runbookID() == op.step.runbookID()
-		}) {
-			continue
-		}
-		results = append(results, s.result)
-	}
-	for _, os := range op.deferred.steps {
-		if op.id == os.op.id {
-			results = append(results, os.step.result)
-		}
-	}
-	return results
 }
 
 type operatorN struct {

--- a/ssh.go
+++ b/ssh.go
@@ -76,6 +76,41 @@ func newSSHRunner(name, addr string) (*sshRunner, error) {
 	return rnr, nil
 }
 
+func (rnr *sshRunner) Close() error {
+	if rnr.client != nil {
+		if err := rnr.client.Close(); err != nil {
+			return err
+		}
+	}
+	if err := rnr.closeSession(); err != nil {
+		return err
+	}
+	rnr.client = nil
+	return nil
+}
+
+func (rnr *sshRunner) Run(ctx context.Context, s *step) error {
+	o := s.parent
+	cmd, err := parseSSHCommand(s.sshCommand, s, o.expandBeforeRecord)
+	if err != nil {
+		return fmt.Errorf("invalid ssh command: %w", err)
+	}
+	if err := rnr.run(ctx, cmd, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (rnr *sshRunner) Renew() error {
+	if rnr.client != nil && rnr.addr == "" {
+		return errors.New("SSH runners created with the runn.SshRunner option cannot be renewed") //nostyle:errorstrings
+	}
+	if err := rnr.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (rnr *sshRunner) startSession() error {
 	if !rnr.keepSession {
 		return errors.New("could not use startSession() when keepSession = false")
@@ -179,41 +214,6 @@ func (rnr *sshRunner) closeSession() error {
 	rnr.stderr = nil
 	rnr.scanErr = nil
 	rnr.sessCancel = nil
-	return nil
-}
-
-func (rnr *sshRunner) Close() error {
-	if rnr.client != nil {
-		if err := rnr.client.Close(); err != nil {
-			return err
-		}
-	}
-	if err := rnr.closeSession(); err != nil {
-		return err
-	}
-	rnr.client = nil
-	return nil
-}
-
-func (rnr *sshRunner) Run(ctx context.Context, s *step) error {
-	o := s.parent
-	cmd, err := parseSSHCommand(s.sshCommand, s, o.expandBeforeRecord)
-	if err != nil {
-		return fmt.Errorf("invalid ssh command: %w", err)
-	}
-	if err := rnr.run(ctx, cmd, s); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (rnr *sshRunner) Renew() error {
-	if rnr.client != nil && rnr.addr == "" {
-		return errors.New("SSH runners created with the runn.SshRunner option cannot be renewed") //nostyle:errorstrings
-	}
-	if err := rnr.Close(); err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
Enable funcorder linter and reorder struct methods so that constructors come first, exported methods second, and unexported methods last.