### PR TITLE
fix: adapt to copilot-sdk/go v0.2.2 breaking change

### DIFF
--- a/agent_copilot.go
+++ b/agent_copilot.go
@@ -122,8 +122,10 @@ func (p *copilotProvider) Run(ctx context.Context, req *agentRunRequest) (*Agent
 	}
 
 	var content string
-	if event != nil && event.Data.Content != nil {
-		content = *event.Data.Content
+	if event != nil {
+		if d, ok := event.Data.(*copilot.AssistantMessageData); ok {
+			content = d.Content
+		}
 	}
 
 	return &AgentResponse{Content: content}, nil

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/elk-language/go-prompt v1.3.1
 	github.com/expr-lang/expr v1.17.8
 	github.com/fatih/color v1.19.0
-	github.com/github/copilot-sdk/go v0.2.0
+	github.com/github/copilot-sdk/go v0.2.2
 	github.com/gliderlabs/ssh v0.3.8
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/goccy/go-json v0.10.6

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,8 @@ github.com/fullstorydev/grpcurl v1.9.3 h1:PC1Xi3w+JAvEE2Tg2Gf2RfVgPbf9+tbuQr1Zky
 github.com/fullstorydev/grpcurl v1.9.3/go.mod h1:/b4Wxe8bG6ndAjlfSUjwseQReUDUvBJiFEB7UllOlUE=
 github.com/github/copilot-sdk/go v0.2.0 h1:RnrIIirmtp4wGgqSQFJ2k9phbeveIxOtYZqDogoNEa0=
 github.com/github/copilot-sdk/go v0.2.0/go.mod h1:uGWkjVYcp2DV9DgtqYihh5tEoJjNqxIFaUNnrwY4FxM=
+github.com/github/copilot-sdk/go v0.2.2 h1:QPgh0kGu4WYZUVBXjnKr3atR1rMTet7xuPUXkdZQumI=
+github.com/github/copilot-sdk/go v0.2.2/go.mod h1:uGWkjVYcp2DV9DgtqYihh5tEoJjNqxIFaUNnrwY4FxM=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=


### PR DESCRIPTION
## Summary
- Fix build failure caused by `copilot-sdk/go` v0.2.2 breaking change where `SessionEvent.Data` changed from a concrete `Data` struct to a `SessionEventData` interface
- Use type assertion (`*copilot.AssistantMessageData`) to access the assistant response content
- Bump `copilot-sdk/go` from v0.2.0 to v0.2.2

Fixes CI failure: https://github.com/k1LoW/runn/actions/runs/24268124563/job/70867423992
