### PR TITLE
feat: store prompt in agent runner step result

### DIFF
--- a/README.md
+++ b/README.md
@@ -2020,7 +2020,7 @@ steps:
     test: current.res.content != ''
 ```
 
-The response is stored in `steps[N].res.content`.
+The expanded prompt is stored in `steps[N].prompt` and the response in `steps[N].res.content`.
 
 #### Conversation context
 

--- a/agent.go
+++ b/agent.go
@@ -13,6 +13,7 @@ import (
 const (
 	agentStoreResponseKey = "res"
 	agentStoreContentKey  = "content"
+	agentStorePromptKey   = "prompt"
 )
 
 const (
@@ -196,6 +197,7 @@ func (rnr *agentRunner) Run(ctx context.Context, s *step) error {
 	o.capturers.captureAgentResponse(rnr.name, resp)
 
 	o.record(s.idx, map[string]any{
+		agentStorePromptKey: parsed.Prompt,
 		agentStoreResponseKey: map[string]any{
 			agentStoreContentKey: resp.Content,
 		},

--- a/agent_test.go
+++ b/agent_test.go
@@ -254,6 +254,13 @@ func TestAgentRunnerRun(t *testing.T) {
 
 	// Check store result
 	latest := o.store.Latest()
+	prompt, ok := latest["prompt"].(string)
+	if !ok {
+		t.Fatal("store does not contain prompt string")
+	}
+	if prompt != "Hello" {
+		t.Errorf("got prompt=%q, want %q", prompt, "Hello")
+	}
 	res, ok := latest["res"].(map[string]any)
 	if !ok {
 		t.Fatal("store does not contain res")


### PR DESCRIPTION
## Summary
- Store the expanded prompt in the agent runner's step result so it can be accessed via `steps[N].prompt`
- Add test assertion for the stored prompt value
