### PR TITLE
fix: send cookies to http.Handler-based runners (httptest path)

### DIFF
--- a/http.go
+++ b/http.go
@@ -537,9 +537,7 @@ func (rnr *httpRunner) run(ctx context.Context, r *httpRequest, s *step) error {
 		defer res.Body.Close()
 	case rnr.handler != nil:
 		req = httptest.NewRequest(r.method, r.path, reqBody)
-		if r.mediaType != "" {
-			req.Header.Set("Content-Type", r.mediaType)
-		}
+		r.setContentTypeHeader(req)
 		r.setCookieHeader(req, o.store.Cookies())
 		for k, v := range r.headers {
 			req.Header.Del(k)

--- a/http.go
+++ b/http.go
@@ -324,6 +324,12 @@ func (r *httpRequest) setContentTypeHeader(req *http.Request) {
 func (r *httpRequest) setCookieHeader(req *http.Request, cookies map[string]map[string]*http.Cookie) {
 	if r.useCookie != nil && *r.useCookie {
 		domain := req.URL.Hostname()
+		if domain == "" {
+			domain, _, _ = net.SplitHostPort(req.Host)
+			if domain == "" {
+				domain = req.Host
+			}
+		}
 		path := req.URL.Path
 		for host, domainCookies := range cookies {
 			// Ignore port number
@@ -534,6 +540,7 @@ func (rnr *httpRunner) run(ctx context.Context, r *httpRequest, s *step) error {
 		if r.mediaType != "" {
 			req.Header.Set("Content-Type", r.mediaType)
 		}
+		r.setCookieHeader(req, o.store.Cookies())
 		for k, v := range r.headers {
 			req.Header.Del(k)
 			for _, vv := range v {

--- a/http_test.go
+++ b/http_test.go
@@ -647,6 +647,54 @@ func TestHTTPRunnerWithHandler(t *testing.T) {
 	}
 }
 
+func TestHTTPRunnerWithHandlerSendsCookies(t *testing.T) {
+	useCookie := true
+	s := http.NewServeMux()
+	var gotCookie string
+	s.HandleFunc("/cookies/check", func(w http.ResponseWriter, r *http.Request) {
+		c, err := r.Cookie("session")
+		if err != nil {
+			gotCookie = ""
+		} else {
+			gotCookie = c.Value
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	rnr, err := newHTTPRunnerWithHandler(t.Name(), s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	o, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Record a cookie in the store.
+	// httptest.NewRequest with a relative path defaults to host "example.com".
+	o.store.RecordCookie([]*http.Cookie{
+		{
+			Name:   "session",
+			Value:  "abc123",
+			Domain: "example.com",
+		},
+	})
+
+	req := &httpRequest{
+		path:      "/cookies/check",
+		method:    http.MethodGet,
+		mediaType: MediaTypeApplicationJSON,
+		useCookie: &useCookie,
+	}
+	step := newStep(0, "stepKey", o, nil)
+	if err := rnr.run(ctx, req, step); err != nil {
+		t.Fatal(err)
+	}
+	if gotCookie != "abc123" {
+		t.Errorf("got cookie %q, want %q", gotCookie, "abc123")
+	}
+}
+
 func TestNotFollowRedirect(t *testing.T) {
 	tests := []struct {
 		req               *httpRequest


### PR DESCRIPTION
## Summary

- Add missing `setCookieHeader` call in the `http.Handler`/httptest branch of `httpRunner.run()`, so stored cookies are attached to outgoing requests regardless of the transport
- Fix `setCookieHeader` to fall back to `req.Host` when `req.URL.Hostname()` returns empty (which happens with `httptest.NewRequest` for relative paths)
- Add `TestHTTPRunnerWithHandlerSendsCookies` regression test

Closes #1452