### PR TITLE
docs: Fix code block formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,6 +853,7 @@ steps:
         get:
           headers:
             X-Metadata: "'{{vars.metadata}}'"
+```
 
 ## Runner
 


### PR DESCRIPTION
Fixed an issue where a missing closing code block tag caused subsequent `##` sections to be incorrectly rendered.