### PR TITLE
fix: forward step headers to reflection RPC

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -149,7 +149,7 @@ func (rnr *grpcRunner) Run(ctx context.Context, s *step) error {
 
 func (rnr *grpcRunner) run(ctx context.Context, r *grpcRequest, s *step) error {
 	o := s.parent
-	if err := rnr.connectAndResolve(ctx, o); err != nil {
+	if err := rnr.connectAndResolve(setHeaders(ctx, r.headers), o); err != nil {
 		return err
 	}
 	key := strings.Join([]string{r.service, r.method}, "/")

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -3,6 +3,7 @@ package runn
 import (
 	"context"
 	"fmt"
+	"net"
 	"path/filepath"
 	"testing"
 	"time"
@@ -13,7 +14,12 @@ import (
 	"github.com/k1LoW/runn/testutil"
 	"github.com/k1LoW/runn/version"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/reflection"
+	"google.golang.org/grpc/status"
 )
 
 func TestGrpcRunner(t *testing.T) {
@@ -596,6 +602,97 @@ func TestGrpcTraceHeader(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGrpcRunnerReflectionWithAuth(t *testing.T) {
+	t.Parallel()
+
+	const token = "Bearer runn-test"
+	authErr := status.Error(codes.Unauthenticated, "auth required")
+	checkAuth := func(ctx context.Context) bool {
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			return false
+		}
+		a := md.Get("authorization")
+		return len(a) > 0 && a[0] == token
+	}
+
+	srv := grpc.NewServer(
+		grpc.UnaryInterceptor(func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, h grpc.UnaryHandler) (any, error) {
+			if !checkAuth(ctx) {
+				return nil, authErr
+			}
+			return h(ctx, req)
+		}),
+		grpc.StreamInterceptor(func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, h grpc.StreamHandler) error {
+			if !checkAuth(ss.Context()) {
+				return authErr
+			}
+			return h(srv, ss)
+		}),
+	)
+	healthpb.RegisterHealthServer(srv, health.NewServer())
+	reflection.Register(srv)
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() { _ = srv.Serve(l) }()
+	t.Cleanup(srv.Stop)
+	addr := l.Addr().String()
+
+	t.Run("step headers are forwarded to reflection RPC", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := donegroup.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		o, err := New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		r, err := newGrpcRunner("greq", addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		useTLS := false
+		r.tls = &useTLS
+		req := &grpcRequest{
+			service:  "grpc.health.v1.Health",
+			method:   "Check",
+			headers:  metadata.MD{"authorization": {token}},
+			messages: []*grpcMessage{{op: GRPCOpMessage, params: map[string]any{}}},
+		}
+		s := newStep(0, "stepKey", o, nil)
+		if err := r.run(ctx, req, s); err != nil {
+			t.Errorf("run() with auth header failed: %v", err)
+		}
+	})
+
+	t.Run("reflection RPC fails without step headers", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := donegroup.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		o, err := New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		r, err := newGrpcRunner("greq", addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		useTLS := false
+		r.tls = &useTLS
+		req := &grpcRequest{
+			service:  "grpc.health.v1.Health",
+			method:   "Check",
+			messages: []*grpcMessage{{op: GRPCOpMessage, params: map[string]any{}}},
+		}
+		s := newStep(0, "stepKey", o, nil)
+		if err := r.run(ctx, req, s); err == nil {
+			t.Error("run() without auth header should fail")
+		}
+	})
 }
 
 func TestGrpcRunnerReusableLifecycle(t *testing.T) {


### PR DESCRIPTION
## Summary

- Step-level `headers:` were not forwarded to the reflection client context, so runn failed with `UNAUTHENTICATED` against servers whose auth interceptor covers every RPC including reflection
- Fixed by passing `setHeaders(ctx, r.headers)` to `connectAndResolve` in `run()`, mirroring the behaviour of `grpcurl -H`

Fixes #1484

## Test plan

- `TestGrpcRunnerReflectionWithAuth/step headers are forwarded to reflection RPC` — verifies the fix works against an auth-required server
- `TestGrpcRunnerReflectionWithAuth/reflection RPC fails without step headers` — documents that the server correctly rejects unauthenticated calls

<details>
<summary>Test results</summary>

**Before fix (FAIL):**
```
=== RUN   TestGrpcRunnerReflectionWithAuth/step_headers_are_forwarded_to_reflection_RPC
    grpc_test.go:668: run() with auth header failed: rpc error: code = Unauthenticated desc = auth required
--- FAIL: TestGrpcRunnerReflectionWithAuth (0.00s)
    --- FAIL: TestGrpcRunnerReflectionWithAuth/step_headers_are_forwarded_to_reflection_RPC (0.00s)
FAIL	github.com/k1LoW/runn	1.020s
```

**After fix (PASS):**
```
=== RUN   TestGrpcRunnerReflectionWithAuth/step_headers_are_forwarded_to_reflection_RPC
--- PASS: TestGrpcRunnerReflectionWithAuth (0.00s)
    --- PASS: TestGrpcRunnerReflectionWithAuth/step_headers_are_forwarded_to_reflection_RPC (0.00s)
PASS	github.com/k1LoW/runn	0.858s
```

</details>