### PR TITLE
Add --debug-on-failure option

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,17 +484,6 @@ The diagnostics are written to stderr and include command/stdout/stderr for Exec
 $ runn run path/to/**/*.yml --verbose --debug-on-failure
 ```
 
-- Secret values configured by `secrets:` are always masked.
-- Diagnostics are limited to 1 MiB per step. A truncation message is added when the limit is exceeded.
-- For a step with `loop:`, only the last iteration is shown.
-- For an included runbook, only the diagnostics of the failed inner step are shown.
-- When runbooks run concurrently, each runbook's diagnostics are written as a single block without mixing them together.
-- If both `--debug` and `--debug-on-failure` are specified, `--debug` takes precedence.
-- `liveOutput: true` still writes output while the command is running, including successful runs.
-
-The Exec runner records a non-zero exit code but does not treat it as a step failure by itself.
-Add a test such as `test: current.exit_code == 0` to show the command diagnostics on failure.
-
 ### `interval:`
 
 Interval between steps.

--- a/README.md
+++ b/README.md
@@ -475,6 +475,26 @@ Enable debug output for runn.
 debug: true
 ```
 
+#### Show debug output only for failed steps
+
+Use `--debug-on-failure` to keep the normal output for successful steps and print runner diagnostics only for failed steps.
+The diagnostics are written to stderr and include command/stdout/stderr for Exec and SSH runners, stdin for Exec runners, and the request and response details captured for other runners.
+
+``` console
+$ runn run path/to/**/*.yml --verbose --debug-on-failure
+```
+
+- Secret values configured by `secrets:` are always masked.
+- Diagnostics are limited to 1 MiB per step. A truncation message is added when the limit is exceeded.
+- For a step with `loop:`, only the last iteration is shown.
+- For an included runbook, only the diagnostics of the failed inner step are shown.
+- When runbooks run concurrently, each runbook's diagnostics are written as a single block without mixing them together.
+- If both `--debug` and `--debug-on-failure` are specified, `--debug` takes precedence.
+- `liveOutput: true` still writes output while the command is running, including successful runs.
+
+The Exec runner records a non-zero exit code but does not treat it as a step failure by itself.
+Add a test such as `test: current.exit_code == 0` to show the command diagnostics on failure.
+
 ### `interval:`
 
 Interval between steps.

--- a/book.go
+++ b/book.go
@@ -42,6 +42,7 @@ type book struct {
 	hostRules            hostRules
 	hostRulesFromOpts    hostRules
 	debug                bool
+	debugOnFailure       *failureDebugCoordinator
 	ifCond               string
 	skipTest             bool
 	funcs                map[string]any

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -133,6 +133,7 @@ var runCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(runCmd)
 	runCmd.Flags().BoolVarP(&flgs.Debug, "debug", "", false, flgs.Usage("Debug"))
+	runCmd.Flags().BoolVarP(&flgs.DebugOnFailure, "debug-on-failure", "", false, flgs.Usage("DebugOnFailure"))
 	runCmd.Flags().BoolVarP(&flgs.FailFast, "fail-fast", "", false, flgs.Usage("FailFast"))
 	runCmd.Flags().BoolVarP(&flgs.SkipTest, "skip-test", "", false, flgs.Usage("SkipTest"))
 	runCmd.Flags().BoolVarP(&flgs.SkipIncluded, "skip-included", "", false, flgs.Usage("SkipIncluded"))

--- a/failure_debugger.go
+++ b/failure_debugger.go
@@ -1,0 +1,129 @@
+package runn
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/k1LoW/maskedio"
+)
+
+const failureDebugMaxBytes = 1 << 20
+
+type failureDebugCoordinator struct {
+	mu sync.Mutex
+}
+
+func newFailureDebugCoordinator() *failureDebugCoordinator {
+	return &failureDebugCoordinator{}
+}
+
+func (c *failureDebugCoordinator) write(out *maskedio.Writer, b []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	_, err := out.Write(b)
+	return errors.Join(err, out.Flush())
+}
+
+type limitedBuffer struct {
+	buf       bytes.Buffer
+	max       int
+	truncated bool
+}
+
+func newLimitedBuffer(maxBytes int) *limitedBuffer {
+	return &limitedBuffer{max: maxBytes}
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	n := len(p)
+	remaining := b.max - b.buf.Len()
+	if remaining <= 0 {
+		b.truncated = b.truncated || n > 0
+		return n, nil
+	}
+	if len(p) > remaining {
+		_, _ = b.buf.Write(p[:remaining])
+		b.truncated = true
+		return n, nil
+	}
+	_, _ = b.buf.Write(p)
+	return n, nil
+}
+
+func (b *limitedBuffer) Bytes() []byte {
+	return b.buf.Bytes()
+}
+
+func (b *limitedBuffer) Len() int {
+	return b.buf.Len()
+}
+
+func (b *limitedBuffer) Reset() {
+	b.buf.Reset()
+	b.truncated = false
+}
+
+type failureDebugger struct {
+	*debugger
+	buf         *limitedBuffer
+	out         *maskedio.Writer
+	coordinator *failureDebugCoordinator
+}
+
+func newFailureDebugger(out *maskedio.Writer, coordinator *failureDebugCoordinator) *failureDebugger {
+	buf := newLimitedBuffer(failureDebugMaxBytes)
+	return &failureDebugger{
+		debugger:    NewDebugger(buf),
+		buf:         buf,
+		out:         out,
+		coordinator: coordinator,
+	}
+}
+
+func (d *failureDebugger) CaptureResultByStep(_ Trails, result *RunResult) {
+	defer d.buf.Reset()
+
+	sr := latestStepResult(result.StepResults)
+	if sr == nil || sr.Err == nil || d.buf.Len() == 0 {
+		return
+	}
+
+	var out bytes.Buffer
+	_, _ = fmt.Fprintln(&out, "-----START FAILURE DIAGNOSTICS-----")
+	_, _ = fmt.Fprintf(&out, "Runbook: %s\n", normalizePath(result.Path))
+	_, _ = fmt.Fprintf(&out, "Step: %s\n", sr.Key)
+	if sr.RunnerType != "" {
+		_, _ = fmt.Fprintf(&out, "Runner: %s", sr.RunnerType)
+		if sr.RunnerKey != "" {
+			_, _ = fmt.Fprintf(&out, " (%s)", sr.RunnerKey)
+		}
+		_, _ = fmt.Fprintln(&out)
+	}
+	_, _ = fmt.Fprintln(&out)
+	_, _ = out.Write(d.buf.Bytes())
+	if d.buf.truncated {
+		_, _ = fmt.Fprintf(&out, "\n... diagnostics truncated at %d bytes ...\n", failureDebugMaxBytes)
+	}
+	_, _ = fmt.Fprintln(&out, "-----END FAILURE DIAGNOSTICS-----")
+
+	if err := d.coordinator.write(d.out, out.Bytes()); err != nil {
+		d.errs = errors.Join(d.errs, err)
+	}
+}
+
+func (d *failureDebugger) SetCurrentTrails(trs Trails) {
+	d.buf.Reset()
+	d.debugger.SetCurrentTrails(trs)
+}
+
+func latestStepResult(results []*StepResult) *StepResult {
+	for i := len(results) - 1; i >= 0; i-- {
+		if results[i] != nil {
+			return results[i]
+		}
+	}
+	return nil
+}

--- a/failure_debugger.go
+++ b/failure_debugger.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/k1LoW/maskedio"
@@ -120,9 +121,9 @@ func (d *failureDebugger) SetCurrentTrails(trs Trails) {
 }
 
 func latestStepResult(results []*StepResult) *StepResult {
-	for i := len(results) - 1; i >= 0; i-- {
-		if results[i] != nil {
-			return results[i]
+	for _, result := range slices.Backward(results) {
+		if result != nil {
+			return result
 		}
 	}
 	return nil

--- a/failure_debugger_test.go
+++ b/failure_debugger_test.go
@@ -1,0 +1,360 @@
+package runn
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/k1LoW/maskedio"
+	"github.com/k1LoW/runn/internal/scope"
+)
+
+func TestDebugOnFailure(t *testing.T) {
+	tests := []struct {
+		name        string
+		runbook     string
+		wantErr     bool
+		contains    []string
+		notContains []string
+	}{
+		{
+			name: "success",
+			runbook: `desc: success
+steps:
+  command:
+    exec:
+      command: |
+        echo success-stdout
+        echo success-stderr >&2
+    test: current.exit_code == 0
+`,
+			notContains: []string{"success-stdout", "success-stderr", "FAILURE DIAGNOSTICS"},
+		},
+		{
+			name: "only failed step",
+			runbook: `desc: failure
+steps:
+  successful_command:
+    exec:
+      command: |
+        echo successful-step-stdout
+        echo successful-step-stderr >&2
+    test: current.exit_code == 0
+  failed_command:
+    exec:
+      command: |
+        echo failed-step-stdout
+        echo failed-step-stderr >&2
+        exit 7
+    test: current.exit_code == 0
+`,
+			wantErr: true,
+			contains: []string{
+				"-----START FAILURE DIAGNOSTICS-----",
+				"Step: failed_command",
+				"Runner: exec (exec)",
+				"failed-step-stdout",
+				"failed-step-stderr",
+				"-----END FAILURE DIAGNOSTICS-----",
+			},
+			notContains: []string{"successful-step-stdout", "successful-step-stderr"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeFailureDebugRunbook(t, "runbook.yml", tt.runbook)
+			var stderr bytes.Buffer
+			o, err := New(
+				Book(path),
+				DebugOnFailure(true),
+				Stderr(&stderr),
+				Scopes(scope.AllowRunExec, scope.AllowReadParent),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = o.Run(context.Background())
+			if tt.wantErr && err == nil {
+				t.Fatal("expected run error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatal(err)
+			}
+
+			got := stderr.String()
+			for _, want := range tt.contains {
+				if !strings.Contains(got, want) {
+					t.Errorf("output does not contain %q:\n%s", want, got)
+				}
+			}
+			for _, notWant := range tt.notContains {
+				if strings.Contains(got, notWant) {
+					t.Errorf("output unexpectedly contains %q:\n%s", notWant, got)
+				}
+			}
+		})
+	}
+}
+
+func TestDebugTakesPrecedenceOverDebugOnFailure(t *testing.T) {
+	path := writeFailureDebugRunbook(t, "runbook.yml", `desc: debug precedence
+steps:
+  failed_command:
+    exec:
+      command: |
+        echo precedence-stderr >&2
+        exit 1
+    test: current.exit_code == 0
+`)
+	var stderr bytes.Buffer
+	o, err := New(
+		Book(path),
+		Debug(true),
+		DebugOnFailure(true),
+		Stderr(&stderr),
+		Scopes(scope.AllowRunExec, scope.AllowReadParent),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Run(context.Background()); err == nil {
+		t.Fatal("expected run error")
+	}
+
+	got := stderr.String()
+	if strings.Contains(got, "FAILURE DIAGNOSTICS") {
+		t.Errorf("failure diagnostics should be disabled by debug:\n%s", got)
+	}
+	if c := strings.Count(got, "-----START STDERR-----"); c != 1 {
+		t.Errorf("stderr block count = %d, want 1:\n%s", c, got)
+	}
+}
+
+func TestDebugOnFailureMasksSecrets(t *testing.T) {
+	const secret = "failure-debug-secret"
+	path := writeFailureDebugRunbook(t, "runbook.yml", `desc: mask secrets
+vars:
+  secret: failure-debug-secret
+secrets:
+  - vars.secret
+steps:
+  failed_command:
+    exec:
+      command: |
+        echo '{{ vars.secret }}' >&2
+        exit 1
+    test: current.exit_code == 0
+`)
+	var stderr bytes.Buffer
+	o, err := New(
+		Book(path),
+		DebugOnFailure(true),
+		Stderr(&stderr),
+		Scopes(scope.AllowRunExec, scope.AllowReadParent),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Run(context.Background()); err == nil {
+		t.Fatal("expected run error")
+	}
+
+	got := stderr.String()
+	if strings.Contains(got, secret) {
+		t.Errorf("secret is not masked:\n%s", got)
+	}
+	if !strings.Contains(got, "*****") {
+		t.Errorf("masked value not found:\n%s", got)
+	}
+}
+
+func TestDebugOnFailureTruncatesDiagnostics(t *testing.T) {
+	var stderr bytes.Buffer
+	out := maskedio.NewWriter(&stderr)
+	d := newFailureDebugger(out, newFailureDebugCoordinator())
+	d.SetCurrentTrails(nil)
+	d.CaptureExecStdout(strings.Repeat("x", failureDebugMaxBytes+1))
+	d.CaptureResultByStep(nil, &RunResult{
+		Path: "runbook.yml",
+		StepResults: []*StepResult{{
+			Key:        "failed_command",
+			RunnerType: RunnerTypeExec,
+			RunnerKey:  execRunnerKey,
+			Err:        errors.New("failure"),
+		}},
+	})
+
+	got := stderr.String()
+	want := "... diagnostics truncated at 1048576 bytes ..."
+	if !strings.Contains(got, want) {
+		t.Errorf("truncation marker not found:\n%s", got[len(got)-256:])
+	}
+}
+
+func TestDebugOnFailureKeepsLastLoopIteration(t *testing.T) {
+	path := writeFailureDebugRunbook(t, "runbook.yml", `desc: loop failure
+steps:
+  retry:
+    loop:
+      count: 2
+      interval: 0
+    exec:
+      command: |
+        echo loop-stdout-{{ i }}
+        echo loop-stderr-{{ i }} >&2
+        exit 1
+      shell: bash
+    test: current.exit_code == 0
+`)
+	var stderr bytes.Buffer
+	o, err := New(
+		Book(path),
+		DebugOnFailure(true),
+		Stderr(&stderr),
+		Scopes(scope.AllowRunExec, scope.AllowReadParent),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Run(context.Background()); err == nil {
+		t.Fatal("expected run error")
+	}
+
+	got := stderr.String()
+	if !strings.Contains(got, "loop-stdout-1") || !strings.Contains(got, "loop-stderr-1") {
+		t.Errorf("last loop output not found:\n%s", got)
+	}
+	if strings.Contains(got, "loop-stdout-0") || strings.Contains(got, "loop-stderr-0") {
+		t.Errorf("earlier loop output found:\n%s", got)
+	}
+}
+
+func TestDebugOnFailureReportsIncludedLeafOnly(t *testing.T) {
+	dir := t.TempDir()
+	child := filepath.Join(dir, "child.yml")
+	parent := filepath.Join(dir, "parent.yml")
+	writeFile(t, child, `desc: child
+steps:
+  leaf_failure:
+    exec:
+      command: |
+        echo included-leaf-stderr >&2
+        exit 1
+    test: current.exit_code == 0
+`)
+	writeFile(t, parent, `desc: parent
+steps:
+  include_child:
+    include:
+      path: child.yml
+`)
+
+	var stderr bytes.Buffer
+	o, err := New(
+		Book(parent),
+		DebugOnFailure(true),
+		Stderr(&stderr),
+		Scopes(scope.AllowRunExec, scope.AllowReadParent),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := o.Run(context.Background()); err == nil {
+		t.Fatal("expected run error")
+	}
+
+	got := stderr.String()
+	if c := strings.Count(got, "-----START FAILURE DIAGNOSTICS-----"); c != 1 {
+		t.Errorf("diagnostic block count = %d, want 1:\n%s", c, got)
+	}
+	if !strings.Contains(got, "Runbook: "+normalizePath(child)) || !strings.Contains(got, "Step: leaf_failure") {
+		t.Errorf("included leaf not identified:\n%s", got)
+	}
+	if strings.Contains(got, "Step: include_child") {
+		t.Errorf("outer include diagnostics found:\n%s", got)
+	}
+}
+
+func TestDebugOnFailureDoesNotMixConcurrentRunbooks(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.yml"), failureDebugConcurrentRunbook("concurrent-token-a"))
+	writeFile(t, filepath.Join(dir, "b.yml"), failureDebugConcurrentRunbook("concurrent-token-b"))
+
+	var stderr bytes.Buffer
+	o, err := Load(
+		filepath.Join(dir, "*.yml"),
+		DebugOnFailure(true),
+		RunConcurrent(true, 2),
+		Stderr(&stderr),
+		Scopes(scope.AllowRunExec, scope.AllowReadParent),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := o.RunN(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	got := stderr.String()
+	if c := strings.Count(got, "-----START FAILURE DIAGNOSTICS-----"); c != 2 {
+		t.Fatalf("diagnostic block count = %d, want 2:\n%s", c, got)
+	}
+	for _, block := range failureDiagnosticBlocks(got) {
+		hasA := strings.Contains(block, "concurrent-token-a")
+		hasB := strings.Contains(block, "concurrent-token-b")
+		if hasA == hasB {
+			t.Errorf("diagnostic block is missing a token or contains mixed tokens:\n%s", block)
+		}
+	}
+}
+
+func writeFailureDebugRunbook(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	writeFile(t, path, content)
+	return path
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func failureDebugConcurrentRunbook(token string) string {
+	return `desc: concurrent failure
+steps:
+  failed_command:
+    exec:
+      command: |
+        echo ` + token + `
+        echo ` + token + ` >&2
+        exit 1
+    test: current.exit_code == 0
+`
+}
+
+func failureDiagnosticBlocks(out string) []string {
+	const start = "-----START FAILURE DIAGNOSTICS-----"
+	const end = "-----END FAILURE DIAGNOSTICS-----"
+	var blocks []string
+	for {
+		i := strings.Index(out, start)
+		if i < 0 {
+			return blocks
+		}
+		out = out[i+len(start):]
+		j := strings.Index(out, end)
+		if j < 0 {
+			return blocks
+		}
+		blocks = append(blocks, out[:j])
+		out = out[j+len(end):]
+	}
+}

--- a/failure_debugger_test.go
+++ b/failure_debugger_test.go
@@ -136,7 +136,7 @@ steps:
 }
 
 func TestDebugOnFailureMasksSecrets(t *testing.T) {
-	const secret = "failure-debug-secret"
+	const valueToMask = "failure-debug-secret"
 	path := writeFailureDebugRunbook(t, "runbook.yml", `desc: mask secrets
 vars:
   secret: failure-debug-secret
@@ -165,7 +165,7 @@ steps:
 	}
 
 	got := stderr.String()
-	if strings.Contains(got, secret) {
+	if strings.Contains(got, valueToMask) {
 		t.Errorf("secret is not masked:\n%s", got)
 	}
 	if !strings.Contains(got, "*****") {

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -24,6 +24,7 @@ var floatRe = regexp.MustCompile(`^\-?[0-9.]+$`)
 
 type Flags struct {
 	Debug           bool     `usage:"debug"`
+	DebugOnFailure  bool     `usage:"debug failed steps"`
 	Long            bool     `usage:"long format"`
 	FailFast        bool     `usage:"fail fast"`
 	SkipTest        bool     `usage:"skip \"test:\" section"`
@@ -89,6 +90,7 @@ func (f *Flags) ToOpts() ([]runn.Option, error) {
 	)
 	opts := []runn.Option{
 		runn.Debug(f.Debug),
+		runn.DebugOnFailure(f.DebugOnFailure),
 		runn.SkipTest(f.SkipTest),
 		runn.SkipIncluded(f.SkipIncluded),
 		runn.HTTPOpenApi3s(f.HTTPOpenApi3s),

--- a/operator.go
+++ b/operator.go
@@ -165,6 +165,8 @@ func New(opts ...Option) (*operator, error) {
 
 	if op.debug {
 		op.capturers = append(op.capturers, NewDebugger(op.stderr))
+	} else if bk.debugOnFailure != nil {
+		op.capturers = append(op.capturers, newFailureDebugger(op.stderr, bk.debugOnFailure))
 	}
 
 	root, err := bk.generateOperatorRoot()

--- a/option.go
+++ b/option.go
@@ -756,6 +756,20 @@ func Debug(debug bool) Option {
 	}
 }
 
+// DebugOnFailure enables debug output only for failed steps.
+func DebugOnFailure(enable bool) Option {
+	coordinator := newFailureDebugCoordinator()
+	return func(bk *book) error {
+		if bk == nil {
+			return ErrNilBook
+		}
+		if enable && bk.debugOnFailure == nil {
+			bk.debugOnFailure = coordinator
+		}
+		return nil
+	}
+}
+
 // Profile - Enable profile.
 func Profile(enable bool) Option {
 	return func(bk *book) error {


### PR DESCRIPTION
## Summary

Add `--debug-on-failure` to print runner diagnostics only for failed steps while preserving the normal output for successful steps.

The same behavior is also available to library users through `runn.DebugOnFailure`.

## Motivation

`--verbose` reports failed steps and assertions, but does not include captured runner output such as Exec stdout and stderr.

`--debug` includes those diagnostics, but prints them for every step, which can make successful CI output unnecessarily noisy.

`--debug-on-failure` provides the diagnostics needed to investigate failures without changing the normal successful output.

## Behavior

- Writes failure diagnostics to stderr.
- Includes the command, stdout, and stderr for Exec and SSH runners.
- Includes stdin for Exec runners and the captured request/response details for other runners.
- Always masks values configured through `secrets:`.
- Limits buffered diagnostics to 1 MiB per step and reports truncation.
  - This is an initial design choice, and the limit and truncation strategy are open to discussion.
- Shows only the last iteration of a failed loop step.
- Shows only the actual failed inner step for included runbooks.
- Serializes diagnostic blocks from concurrently running runbooks to avoid mixed output.
- Gives `--debug` precedence when both options are specified.
- Leaves `liveOutput: true` behavior unchanged.

Exec runners do not treat a non-zero exit code as a failure by itself. A test such as `test: current.exit_code == 0` is still required when the exit code should fail the step.

## Example

```console
runn run path/to/*/*.yml --verbose --debug-on-failure
```

Successful steps keep the normal output. When a step fails, diagnostics are written in a distinct block:

```
-----START FAILURE DIAGNOSTICS-----
Runbook: runbooks/verify.yml
Step: 0
Runner: exec (exec)

-----START COMMAND-----
ruby verify.rb basic
-----END COMMAND-----
-----START STDOUT-----
ok 1 - GET route
ok 2 - named route parameter
not ok 3 - POST form parameters
ok 4 - response status and header
ok 5 - not found
1..5

-----END STDOUT-----
-----START STDERR-----
  AssertionFailure: body: expected "420", got "42"
/Users/udzura/...

-----END STDERR-----
-----END FAILURE DIAGNOSTICS-----
```

## Testing

```
go test . -run 'TestDebugOnFailure|TestDebugTakesPrecedence' -count=1
go test -race . -run 'TestDebugOnFailure|TestDebugTakesPrecedence' -count=1
go vet ./...
```

Also, 

- Confirmed successful runs produce normal verbose output with no stderr diagnostics.
- Confirmed failed Exec steps produce only the relevant command, stdout, and stderr diagnostics on stderr.