### PR TITLE
feat: add RUNN_DEBUG_ON_FAILURE environment variable

### DIFF
--- a/failure_debugger_test.go
+++ b/failure_debugger_test.go
@@ -358,3 +358,38 @@ func failureDiagnosticBlocks(out string) []string {
 		out = out[j+len(end):]
 	}
 }
+
+func TestDebugOnFailureFromEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{"unset", "", false},
+		{"set", "1", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// RUNN_DEBUG takes precedence over RUNN_DEBUG_ON_FAILURE, so pin it.
+			t.Setenv("RUNN_DEBUG", "")
+			t.Setenv("RUNN_DEBUG_ON_FAILURE", tt.env)
+			opn, err := Load("testdata/book/if.yml")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(opn.ops) == 0 {
+				t.Fatal("no operator loaded")
+			}
+			var got bool
+			for _, c := range opn.ops[0].capturers {
+				if _, ok := c.(*failureDebugger); ok {
+					got = true
+					break
+				}
+			}
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/failure_debugger_test.go
+++ b/failure_debugger_test.go
@@ -370,8 +370,11 @@ func TestDebugOnFailureFromEnv(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// RUNN_DEBUG takes precedence over RUNN_DEBUG_ON_FAILURE, so pin it.
-			t.Setenv("RUNN_DEBUG", "")
+			// Pin every RUNN_* variable Load() reads: RUNN_RUN/ID/LABEL narrow the
+			// set of runbooks, and RUNN_DEBUG takes precedence over RUNN_DEBUG_ON_FAILURE.
+			for _, k := range []string{"RUNN_RUN", "RUNN_ID", "RUNN_LABEL", "RUNN_SCOPES", "RUNN_DEBUG"} {
+				t.Setenv(k, "")
+			}
 			t.Setenv("RUNN_DEBUG_ON_FAILURE", tt.env)
 			opn, err := Load("testdata/book/if.yml")
 			if err != nil {

--- a/operator.go
+++ b/operator.go
@@ -1550,6 +1550,9 @@ func Load(pathp string, opts ...Option) (*operatorN, error) {
 	if os.Getenv("RUNN_DEBUG") != "" {
 		envOpts = append(envOpts, Debug(true))
 	}
+	if os.Getenv("RUNN_DEBUG_ON_FAILURE") != "" {
+		envOpts = append(envOpts, DebugOnFailure(true))
+	}
 	opts = append(envOpts, opts...)
 	if err := bk.applyOptions(opts...); err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- Add `RUNN_DEBUG_ON_FAILURE` so `runn.DebugOnFailure` can be turned on from the environment, mirroring the existing `RUNN_DEBUG` / `Debug` pair
- `Load()` is the only entry point that reads environment variables, so this covers the Go test helper path (`runn.Load(..., runn.T(t))`), which is where the `--debug-on-failure` CLI flag is not available
- `--debug` / `RUNN_DEBUG` keeps precedence when both are set: the capturer selection in `New()` is an `else if`, so the plain debugger still wins

`RUNN_DEBUG` is not documented in README today, so this leaves the docs untouched rather than documenting one of the pair. Happy to add a section covering both if that is preferred.

Follow-up to #1514.