### PR TITLE
fix: drop the trailing partial line when truncating failure diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           fail_level: warning
           go_version_file: go.mod
           golangci_lint_version: v2.12.2
-          golangci_lint_flags: --timeout=5m --verbose
+          golangci_lint_flags: --timeout=10m --verbose
           cache: false
 
       - name: Run gostyle

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  timeout: 2m
+  timeout: 10m
 linters:
   enable:
     - errorlint

--- a/failure_debugger.go
+++ b/failure_debugger.go
@@ -40,17 +40,30 @@ func newLimitedBuffer(maxBytes int) *limitedBuffer {
 
 func (b *limitedBuffer) Write(p []byte) (int, error) {
 	n := len(p)
+	if b.truncated {
+		// WHY: once truncated the buffer is sealed. Re-opening it would let a
+		// later chunk append a fresh partial line past the trimmed boundary.
+		return n, nil
+	}
 	remaining := b.max - b.buf.Len()
-	if remaining <= 0 {
-		b.truncated = b.truncated || n > 0
+	if len(p) <= remaining {
+		_, _ = b.buf.Write(p)
 		return n, nil
 	}
-	if len(p) > remaining {
+	if remaining > 0 {
 		_, _ = b.buf.Write(p[:remaining])
-		b.truncated = true
-		return n, nil
 	}
-	_, _ = b.buf.Write(p)
+	b.truncated = true
+	// WHY: masking runs on the assembled block, and maskedio substitutes whole
+	// literals. A secrets: value split by the cut would survive as a prefix that
+	// matches nothing, so drop the trailing partial line. The trim has to apply
+	// to the buffer rather than to p, because the first half of the value may
+	// have arrived in an earlier Write.
+	if i := bytes.LastIndexByte(b.buf.Bytes(), '\n'); i >= 0 {
+		b.buf.Truncate(i + 1)
+	} else {
+		b.buf.Reset()
+	}
 	return n, nil
 }
 
@@ -88,7 +101,7 @@ func (d *failureDebugger) CaptureResultByStep(_ Trails, result *RunResult) {
 	defer d.buf.Reset()
 
 	sr := latestStepResult(result.StepResults)
-	if sr == nil || sr.Err == nil || d.buf.Len() == 0 {
+	if sr == nil || sr.Err == nil || (d.buf.Len() == 0 && !d.buf.truncated) {
 		return
 	}
 

--- a/failure_debugger_test.go
+++ b/failure_debugger_test.go
@@ -192,7 +192,42 @@ func TestDebugOnFailureTruncatesDiagnostics(t *testing.T) {
 	got := stderr.String()
 	want := "... diagnostics truncated at 1048576 bytes ..."
 	if !strings.Contains(got, want) {
-		t.Errorf("truncation marker not found:\n%s", got[len(got)-256:])
+		t.Errorf("truncation marker not found:\n%s", got)
+	}
+}
+
+func TestLimitedBufferTruncatesOnLineBoundary(t *testing.T) {
+	tests := []struct {
+		name          string
+		writes        []string
+		want          string
+		wantTruncated bool
+	}{
+		{"under the cap", []string{"ab\n"}, "ab\n", false},
+		{"cut inside a line drops the line", []string{"ab\nSUPERSECRET\n"}, "ab\n", true},
+		{"cut with the head of the line already buffered", []string{"ab\nSUPER", "SECRET\nxx"}, "ab\n", true},
+		{"no newline drops everything", []string{"0123456789ABCDEF"}, "", true},
+		{"sealed once truncated", []string{"ab\nSUPER", "SECRET\nxx", "cd\n"}, "ab\n", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newLimitedBuffer(10)
+			for _, w := range tt.writes {
+				n, err := b.Write([]byte(w))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if n != len(w) {
+					t.Errorf("Write returned %d, want %d", n, len(w))
+				}
+			}
+			if got := string(b.Bytes()); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+			if b.truncated != tt.wantTruncated {
+				t.Errorf("truncated = %v, want %v", b.truncated, tt.wantTruncated)
+			}
+		})
 	}
 }
 

--- a/failure_debugger_test.go
+++ b/failure_debugger_test.go
@@ -192,7 +192,11 @@ func TestDebugOnFailureTruncatesDiagnostics(t *testing.T) {
 	got := stderr.String()
 	want := "... diagnostics truncated at 1048576 bytes ..."
 	if !strings.Contains(got, want) {
-		t.Errorf("truncation marker not found:\n%s", got)
+		tail := got
+		if len(tail) > 256 {
+			tail = tail[len(tail)-256:]
+		}
+		t.Errorf("truncation marker not found:\n%s", tail)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/k1LoW/grpcstub v0.26.5
 	github.com/k1LoW/grpcurlreq v0.2.9
 	github.com/k1LoW/httpstub v0.28.4
-	github.com/k1LoW/maskedio v0.4.4
+	github.com/k1LoW/maskedio v0.4.5
 	github.com/k1LoW/protoresolv v0.1.8
 	github.com/k1LoW/repin v0.4.1
 	github.com/k1LoW/sshc/v4 v4.3.3

--- a/go.sum
+++ b/go.sum
@@ -324,8 +324,8 @@ github.com/k1LoW/grpcurlreq v0.2.9 h1:Gjl887DkOM5tTOwI1EEZ5wJtl79TmSiZBSsTZ5aqCl
 github.com/k1LoW/grpcurlreq v0.2.9/go.mod h1:0illzZPYYq2zOAKrdI4z761FyMUz+l1XIgniF7/I1Jc=
 github.com/k1LoW/httpstub v0.28.4 h1:nKrTIt4o/ouVasV4dipFkIXOvRJUsL3haSoPJQTd5yE=
 github.com/k1LoW/httpstub v0.28.4/go.mod h1:eyPXSflY1mUvsmIF4DCpS6CZI7129+pJpWHuL8tWqBg=
-github.com/k1LoW/maskedio v0.4.4 h1:U3JNg1jVNfO+4ZEVy6cloFwgBIvvYbODmiFLIFEgjpo=
-github.com/k1LoW/maskedio v0.4.4/go.mod h1:ugf3OzV7imakceGtmkOY13oJsDynL2YVXRcn9VUZEiE=
+github.com/k1LoW/maskedio v0.4.5 h1:QBSqAVaZ64R73WWeBRlnkYJC1GPHYGGWALlAOP6424U=
+github.com/k1LoW/maskedio v0.4.5/go.mod h1:ccP0DWn89nzQpMBlQKkV5PWLrt/H+/lEFvtlGu1WuD0=
 github.com/k1LoW/protoresolv v0.1.8 h1:9XXxLRzJPPuq+Hrr7opwLSKQb+IVhUd/WaT/zrp0urM=
 github.com/k1LoW/protoresolv v0.1.8/go.mod h1:dO3kmLTwfhbcjjNmgZpg6Swti1i0KMjYqXxY/Fv8lU0=
 github.com/k1LoW/repin v0.4.1 h1:Dibm3e2A+f2HEwdES6afO1TI5+Wj0wxD3Hq9vNycQFM=


### PR DESCRIPTION
## Summary

Closes the two halves of the same problem: `secrets:` values reaching stderr unmasked from failure diagnostics.

### runn side: truncation split the value

- `limitedBuffer.Write` cut the byte stream at an arbitrary offset, but masking only runs later, when `CaptureResultByStep` writes the assembled block through `op.stderr` (`*maskedio.Writer`). maskedio substitutes whole literals, so a value straddling the 1 MiB cap survived as an unmasked prefix
- Trim back to the last newline on truncation. The trim applies to the buffer rather than to the incoming chunk: `"ab\nSUPER"` followed by `"SECRET\nxx"` used to leave `"ab\nSUPERSE"`, which trimming only `p[:remaining]` would not have caught
- Seal the buffer once truncated. The trim re-opens room under the cap, so without the seal the next chunk appends a fresh partial line
- `CaptureResultByStep` emits the block when the buffer was truncated even if the trim emptied it, so the truncation notice is not silently lost

The cut also no longer splits a UTF-8 rune, since `\n` cannot appear inside a multi-byte sequence.

`TestLimitedBufferTruncatesOnLineBoundary` covers the policy directly. Against the previous implementation four of its five cases fail, each leaving `"ab\nSUPERSE"` or `"0123456789"` in the buffer.

### maskedio side: Flush wrote its buffer unmasked

Bumped to v0.4.5. Before it, a chunk whose tail looked like the start of a keyword was held whole and then written verbatim on flush, so a complete value earlier in that same chunk reached the writer in the clear (k1LoW/maskedio#27). The release also fixes the lock inversion between `Write` and `Flush` that the masking change first introduced.

## Also here: the lint timeout

The first CI run on this branch failed the Lint job with `0 issues.` and `Timeout exceeded`, at 5m0.03s against the `--timeout=5m` budget, with Go package loading alone accounting for 4m56s of it. Raised to 10m, and `.golangci.yml` raised to match, since `make lint` passes no flag and was therefore running against an even tighter 2m.

Not a theoretical margin: the Lint job on this branch took 6m3s after the change, which the old budget would have failed.

## Worth a look

Diagnostics that are a single line longer than the cap now come out empty rather than truncated mid-line, leaving only the truncation notice. Reachable when one capture writes over 1 MiB with no newline at all.

Follow-up to #1514.